### PR TITLE
Shell escape path names

### DIFF
--- a/bin/sourcery
+++ b/bin/sourcery
@@ -3,4 +3,4 @@
 
 parent_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
 
-${parent_path}/Sourcery.app/Contents/MacOS/Sourcery "$@"
+"${parent_path}"/Sourcery.app/Contents/MacOS/Sourcery "$@"


### PR DESCRIPTION
This was failing for me trying to build on my Jenkins machine, when the path has a space in it. This fixes that.