### PR TITLE
Refactors + Fix flattening logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ For each type you can access following properties:
 - `variables` <- list of instance variables
 - `computedVariables` <- list of computed instance variables
 - `storedVariables` <- list of computed stored variables
-- `inheritedTypes` <- list of type names that this type implements / inherits in the declaration order
 - `inherits.BaseClass` => info whether type inherits from known base class
 - `implements.Protocol` => info whether type implements known protocol
 - `based.BaseClassOrProtocol` => info whether type implements or inherits from `BaseClassOrProtocol` (all type names encountered, even those that Sourcery didn't scan)

--- a/Sourcery.podspec
+++ b/Sourcery.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Sourcery"
-  s.version      = "0.4.1"
+  s.version      = "0.4.2"
   s.summary      = "A tool that brings meta-programming to Swift, allowing you to code generate Swift code."
 
   s.description  = <<-DESC

--- a/Sourcery/CodeGenerated/Description.generated.swift
+++ b/Sourcery/CodeGenerated/Description.generated.swift
@@ -26,7 +26,7 @@ extension Enum.Case.AssociatedValue {
     override var description: String {
         var string = "\(type(of: self)): "
         string += "name = \(name), "
-        string += "type = \(type), "
+        string += "type = \(typeName), "
         return string
     }
 }

--- a/Sourcery/CodeGenerated/Description.generated.swift
+++ b/Sourcery/CodeGenerated/Description.generated.swift
@@ -26,7 +26,7 @@ extension Enum.Case.AssociatedValue {
     override var description: String {
         var string = "\(type(of: self)): "
         string += "name = \(name), "
-        string += "type = \(typeName), "
+        string += "typeName = \(typeName), "
         return string
     }
 }

--- a/Sourcery/CodeGenerated/Equality.generated.swift
+++ b/Sourcery/CodeGenerated/Equality.generated.swift
@@ -26,7 +26,7 @@ extension Enum.Case.AssociatedValue {
     override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Enum.Case.AssociatedValue else { return false }
         if self.name != rhs.name { return false }
-        if self.type != rhs.type { return false }
+        if self.typeName != rhs.typeName { return false }
 
         return true
     }

--- a/Sourcery/Generating/Generator.swift
+++ b/Sourcery/Generating/Generator.swift
@@ -106,15 +106,14 @@ enum Generator {
             }
 
             baseType.based.keys.forEach {  type.based[$0] = $0 }
+            baseType.inherits.keys.forEach {  type.inherits[$0] = $0 }
+            baseType.implements.keys.forEach {  type.implements[$0] = $0 }
 
             if baseType.isClass {
                 type.inherits[name] = name
-                baseType.inherits.keys.forEach {  type.inherits[$0] = $0 }
             } else if baseType is Protocol {
                 type.implements[name] = name
-                baseType.implements.keys.forEach {  type.implements[$0] = $0 }
             }
-
         }
     }
 

--- a/Sourcery/Models/Enum.swift
+++ b/Sourcery/Models/Enum.swift
@@ -9,11 +9,11 @@ class Enum: Type {
     class Case: NSObject {
         class AssociatedValue: NSObject {
             let name: String?
-            let type: String
+            let typeName: String
 
-            init(name: String?, type: String) {
+            init(name: String?, typeName: String) {
                 self.name = name
-                self.type = type
+                self.typeName = typeName
             }
         }
 

--- a/Sourcery/Models/Enum.swift
+++ b/Sourcery/Models/Enum.swift
@@ -8,8 +8,8 @@ import Foundation
 class Enum: Type {
     class Case: NSObject {
         class AssociatedValue: NSObject {
-            var name: String?
-            var type: String
+            let name: String?
+            let type: String
 
             init(name: String?, type: String) {
                 self.name = name
@@ -17,9 +17,9 @@ class Enum: Type {
             }
         }
 
-        var name: String
-        var rawValue: String?
-        var associatedValues: [AssociatedValue]
+        let name: String
+        let rawValue: String?
+        let associatedValues: [AssociatedValue]
 
         var hasAssociatedValue: Bool {
             return !associatedValues.isEmpty

--- a/Sourcery/Models/Type.swift
+++ b/Sourcery/Models/Type.swift
@@ -10,7 +10,9 @@ class Type: NSObject {
     internal var isExtension: Bool
 
     var kind: String { return isExtension ? "extension" : "class" }
-    var accessLevel: AccessLevel
+
+    /// What is the type access level?
+    let accessLevel: AccessLevel
 
     /// Name in global scope 
     var name: String {
@@ -24,7 +26,7 @@ class Type: NSObject {
     /// Name in parent scope
     var localName: String
 
-    /// All instance variables
+    /// All variables associated with this type
     var variables: [Variable]
 
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
@@ -32,7 +34,7 @@ class Type: NSObject {
 
     /// All type static variables
     var staticVariables: [Variable] {
-        return variables.filter({ $0.isStatic })
+        return variables.filter { $0.isStatic }
     }
 
     /// Only computed instance variables
@@ -46,7 +48,6 @@ class Type: NSObject {
     }
 
     /// Types / Protocols names we inherit from, in order of definition
-    var inheritedTypes: [String]
     var inheritedTypes: [String] {
         didSet {
             based.removeAll()
@@ -79,7 +80,7 @@ class Type: NSObject {
     }
 
     /// Parent name
-    var parentName: String?
+    private(set) var parentName: String?
 
     /// Parent type
     /// sourcery: skipEquality
@@ -95,7 +96,16 @@ class Type: NSObject {
     /// sourcery: skipDescription
     internal var __parserData: Any?
 
-    init(name: String = "", parent: Type? = nil, accessLevel: AccessLevel = .internal, isExtension: Bool = false, variables: [Variable] = [], inheritedTypes: [String] = [], containedTypes: [Type] = [], annotations: [String: NSObject] = [:], isGeneric: Bool = false) {
+    init(name: String = "",
+         parent: Type? = nil,
+         accessLevel: AccessLevel = .internal,
+         isExtension: Bool = false,
+         variables: [Variable] = [],
+         inheritedTypes: [String] = [],
+         containedTypes: [Type] = [],
+         annotations: [String: NSObject] = [:],
+         isGeneric: Bool = false) {
+
         self.localName = name
         self.accessLevel = accessLevel
         self.isExtension = isExtension

--- a/Sourcery/Models/Type.swift
+++ b/Sourcery/Models/Type.swift
@@ -47,6 +47,14 @@ class Type: NSObject {
 
     /// Types / Protocols names we inherit from, in order of definition
     var inheritedTypes: [String]
+    var inheritedTypes: [String] {
+        didSet {
+            based.removeAll()
+            inheritedTypes.forEach { name in
+                self.based[name] = name
+            }
+        }
+    }
 
     /// contains all base types inheriting from given BaseClass or implementing given Protocol, even not known by Sourcery
     /// sourcery: skipEquality
@@ -113,7 +121,6 @@ class Type: NSObject {
         self.variables += type.variables
 
         type.annotations.forEach { self.annotations[$0.key] = $0.value }
-        type.based.keys.forEach { self.based[$0] = $0 }
         type.inherits.keys.forEach { self.inherits[$0] = $0 }
         type.implements.keys.forEach { self.implements[$0] = $0 }
         self.inheritedTypes = Array(Set(self.inheritedTypes + type.inheritedTypes))

--- a/Sourcery/Models/Variable.swift
+++ b/Sourcery/Models/Variable.swift
@@ -57,13 +57,13 @@ class Variable: NSObject {
     internal var __parserData: Any?
 
     init(name: String,
-         type: String,
+         typeName: String,
          accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
          isComputed: Bool = false,
          isStatic: Bool = false) {
 
         self.name = name
-        self.typeName = type
+        self.typeName = typeName
         self.isComputed = isComputed
         self.isStatic = isStatic
         self.readAccess = accessLevel.read

--- a/Sourcery/Models/Variable.swift
+++ b/Sourcery/Models/Variable.swift
@@ -6,9 +6,10 @@
 import Foundation
 
 /// Defines a variable
+
 class Variable: NSObject {
     /// Variable name
-    var name: String
+    let name: String
 
     /// Variable type
     var typeName: String
@@ -19,8 +20,9 @@ class Variable: NSObject {
 
     /// Is the variable optional?
     var isOptional: Bool {
-        if typeName.hasSuffix("?") { return true }
-        if typeName.hasPrefix("Optional<") { return true }
+        if typeName.hasSuffix("?") || typeName.hasPrefix("Optional<") {
+            return true
+        }
         return false
     }
 
@@ -36,16 +38,16 @@ class Variable: NSObject {
     }
 
     /// Whether is computed
-    var isComputed: Bool
+    let isComputed: Bool
 
     /// Whether this is static variable
-    var isStatic: Bool
+    let isStatic: Bool
 
     /// Read access
-    var readAccess: AccessLevel
+    let readAccess: AccessLevel
 
     /// Write access
-    var writeAccess: AccessLevel
+    let writeAccess: AccessLevel
 
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
     var annotations: [String: NSObject] = [:]
@@ -54,7 +56,12 @@ class Variable: NSObject {
     /// sourcery: skipEquality, skipDescription
     internal var __parserData: Any?
 
-    init(name: String, type: String, accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal), isComputed: Bool = false, isStatic: Bool = false) {
+    init(name: String,
+         type: String,
+         accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
+         isComputed: Bool = false,
+         isStatic: Bool = false) {
+
         self.name = name
         self.typeName = type
         self.isComputed = isComputed

--- a/Sourcery/Parsing/Parser.swift
+++ b/Sourcery/Parsing/Parser.swift
@@ -322,7 +322,7 @@ extension Parser {
             computed = false
         }
 
-        let variable = Variable(name: name, type: type, accessLevel: (read: accesibility, write: writeAccessibility), isComputed: computed, isStatic: isStatic)
+        let variable = Variable(name: name, typeName: type, accessLevel: (read: accesibility, write: writeAccessibility), isComputed: computed, isStatic: isStatic)
         variable.annotations = parseAnnotations(source)
         variable.__parserData = source
 
@@ -367,9 +367,9 @@ extension Parser {
 
             switch nameType.count {
             case 1:
-                return Enum.Case.AssociatedValue(name: nil, type: nameType.first ?? "")
+                return Enum.Case.AssociatedValue(name: nil, typeName: nameType.first ?? "")
             case 2:
-                return Enum.Case.AssociatedValue(name: nameType.first, type: nameType.last ?? "")
+                return Enum.Case.AssociatedValue(name: nameType.first, typeName: nameType.last ?? "")
             default:
                 print("\(logPrefix)parseEnumAssociatedValues: Unknown enum case body format \(body)")
                 return nil

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -20,7 +20,7 @@ internal class SourceryTemplate: Template {
 /// If you specify templatePath as a folder, it will create a Generated[TemplateName].swift file
 /// If you specify templatePath as specific file, it will put all generated results into that single file
 public class Sourcery {
-    public static let version: String = inUnitTests ? "Major.Minor.Patch" : "0.4.1"
+    public static let version: String = inUnitTests ? "Major.Minor.Patch" : "0.4.2"
     public static let generationMarker: String = "// Generated using Sourcery"
 
     let verbose: Bool

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -8,8 +8,8 @@ class GeneratorSpec: QuickSpec {
 
         describe("Generator") {
 
-            let fooType = Type(name: "Foo", variables: [Variable(name: "intValue", typeName: "Int")], inheritedTypes: ["Decodable"])
-            let fooSubclassType = Type(name: "FooSubclass", inheritedTypes: ["Foo", "KnownProtocol"])
+            let fooType = Type(name: "Foo", variables: [Variable(name: "intValue", typeName: "Int")], inheritedTypes: ["Decodable", "AlternativeProtocol"])
+            let fooSubclassType = Type(name: "FooSubclass", inheritedTypes: ["Foo", "ProtocolBasedOnKnownProtocol"])
             let barType = Struct(name: "Bar", inheritedTypes: ["NSObject", "ProjectClass", "KnownProtocol", "Decodable"])
 
             let complexType = Struct(name: "Complex", accessLevel: .public, isExtension: false, variables: [])
@@ -37,7 +37,9 @@ class GeneratorSpec: QuickSpec {
                     Type(name: "NSObject", accessLevel: .none, isExtension: true, inheritedTypes: ["KnownProtocol"]),
                     Type(name: "ProjectClass", accessLevel: .none),
                     Type(name: "ProjectFooSubclass", inheritedTypes: ["FooSubclass"]),
-                    Protocol(name: "KnownProtocol")
+                    Protocol(name: "KnownProtocol"),
+                    Protocol(name: "AlternativeProtocol"),
+                    Protocol(name: "ProtocolBasedOnKnownProtocol", inheritedTypes: ["KnownProtocol"])
             ]
 
             func generate(_ template: String) -> String {
@@ -50,7 +52,7 @@ class GeneratorSpec: QuickSpec {
             }
 
             it("generates types.protocols") {
-                expect(generate("Found {{ types.protocols.count }} protocols")).to(equal("Found 1 protocols"))
+                expect(generate("Found {{ types.protocols.count }} protocols")).to(equal("Found 3 protocols"))
             }
 
             it("generates types.classes") {
@@ -115,6 +117,7 @@ class GeneratorSpec: QuickSpec {
                     expect(generate("{% if type.Bar.inherits.ProjectClass %} TRUE {% endif %}")).to(equal(" TRUE "))
                     expect(generate("{% if type.Bar.inherits.Decodable %} TRUE {% endif %}")).toNot(equal(" TRUE "))
                     expect(generate("{% if type.Bar.inherits.KnownProtocol %} TRUE {% endif %}")).toNot(equal(" TRUE "))
+                    expect(generate("{% if type.Bar.inherits.AlternativeProtocol %} TRUE {% endif %}")).toNot(equal(" TRUE "))
 
                     expect(generate("{% if type.ProjectFooSubclass.inherits.Foo %} TRUE {% endif %}")).to(equal(" TRUE "))
                 }
@@ -125,6 +128,7 @@ class GeneratorSpec: QuickSpec {
                     expect(generate("{% if type.Bar.implements.KnownProtocol %} TRUE {% endif %}")).to(equal(" TRUE "))
 
                     expect(generate("{% if type.ProjectFooSubclass.implements.KnownProtocol %} TRUE {% endif %}")).to(equal(" TRUE "))
+                    expect(generate("{% if type.ProjectFooSubclass.implements.AlternativeProtocol %} TRUE {% endif %}")).to(equal(" TRUE "))
                 }
 
                 it("generates proper response for type.based") {
@@ -135,6 +139,7 @@ class GeneratorSpec: QuickSpec {
                     expect(generate("{% if type.ProjectFooSubclass.based.KnownProtocol %} TRUE {% endif %}")).to(equal(" TRUE "))
                     expect(generate("{% if type.ProjectFooSubclass.based.Foo %} TRUE {% endif %}")).to(equal(" TRUE "))
                     expect(generate("{% if type.ProjectFooSubclass.based.Decodable %} TRUE {% endif %}")).to(equal(" TRUE "))
+                    expect(generate("{% if type.ProjectFooSubclass.based.AlternativeProtocol %} TRUE {% endif %}")).to(equal(" TRUE "))
                 }
             }
         }

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -8,20 +8,20 @@ class GeneratorSpec: QuickSpec {
 
         describe("Generator") {
 
-            let fooType = Type(name: "Foo", accessLevel: .public, variables: [Variable(name: "intValue", type: "Int", accessLevel: (read: .public, write: .public), isComputed: false)], inheritedTypes: ["Decodable"])
-            let fooSubclassType = Type(name: "FooSubclass", accessLevel: .public, inheritedTypes: ["Foo", "KnownProtocol"])
-            let barType = Struct(name: "Bar", accessLevel: .public, inheritedTypes: ["NSObject", "ProjectClass", "KnownProtocol", "Decodable"])
+            let fooType = Type(name: "Foo", variables: [Variable(name: "intValue", typeName: "Int")], inheritedTypes: ["Decodable"])
+            let fooSubclassType = Type(name: "FooSubclass", inheritedTypes: ["Foo", "KnownProtocol"])
+            let barType = Struct(name: "Bar", inheritedTypes: ["NSObject", "ProjectClass", "KnownProtocol", "Decodable"])
 
             let complexType = Struct(name: "Complex", accessLevel: .public, isExtension: false, variables: [])
-            let fooVar = Variable(name: "foo", type: "Foo", accessLevel: (read: .public, write: .public), isComputed: false)
+            let fooVar = Variable(name: "foo", typeName: "Foo", accessLevel: (read: .public, write: .public), isComputed: false)
             fooVar.type = fooType
-            let barVar = Variable(name: "bar", type: "Bar", accessLevel: (read: .public, write: .public), isComputed: false)
+            let barVar = Variable(name: "bar", typeName: "Bar", accessLevel: (read: .public, write: .public), isComputed: false)
             barVar.type = barType
 
             complexType.variables = [
                 fooVar,
                 barVar,
-                Variable(name: "fooBar", type: "Int", accessLevel: (read: .public, write: .public), isComputed: true)
+                Variable(name: "fooBar", typeName: "Int", isComputed: true)
             ]
 
             let types = [
@@ -31,7 +31,7 @@ class GeneratorSpec: QuickSpec {
                     barType,
                     Enum(name: "Options", accessLevel: .public, inheritedTypes: ["KnownProtocol"], cases: [Enum.Case(name: "optionA"), Enum.Case(name: "optionB")], containedTypes: [
                         Type(name: "InnerOptions", accessLevel: .public, variables: [
-                            Variable(name: "foo", type: "Int", accessLevel: (read: .public, write: .public), isComputed: false)
+                            Variable(name: "foo", typeName: "Int", accessLevel: (read: .public, write: .public), isComputed: false)
                             ])
                         ]),
                     Type(name: "NSObject", accessLevel: .none, isExtension: true, inheritedTypes: ["KnownProtocol"]),

--- a/SourceryTests/Models/EnumSpec.swift
+++ b/SourceryTests/Models/EnumSpec.swift
@@ -6,7 +6,7 @@ class EnumSpec: QuickSpec {
     override func spec() {
         describe ("Enum") {
             var sut: Enum?
-            let variable = Variable(name: "variable", type: "Int", accessLevel: (read: .public, write: .internal), isComputed: false)
+            let variable = Variable(name: "variable", typeName: "Int", accessLevel: (read: .public, write: .internal), isComputed: false)
 
             beforeEach {
                 sut = Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["String"], cases: [Enum.Case(name: "CaseA"), Enum.Case(name: "CaseB")])
@@ -25,7 +25,7 @@ class EnumSpec: QuickSpec {
             }
 
             context("given associated values") {
-                let sut = Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["String"], cases: [Enum.Case(name: "CaseA", associatedValues: [Enum.Case.AssociatedValue(name: nil, type: "Int")]), Enum.Case(name: "CaseB")])
+                let sut = Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["String"], cases: [Enum.Case(name: "CaseA", associatedValues: [Enum.Case.AssociatedValue(name: nil, typeName: "Int")]), Enum.Case(name: "CaseB")])
 
                 it("hasAssociatedValues") {
                     expect(sut.hasAssociatedValues).to(beTrue())
@@ -47,7 +47,7 @@ class EnumSpec: QuickSpec {
                         expect(sut).toNot(equal(Enum(name: "Foo", accessLevel: .internal, isExtension: true, inheritedTypes: ["String"], cases: [Enum.Case(name: "CaseA"), Enum.Case(name: "CaseB")])))
                         expect(sut).toNot(equal(Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [Enum.Case(name: "CaseA"), Enum.Case(name: "CaseB")])))
                         expect(sut).toNot(equal(Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["String"], cases: [Enum.Case(name: "CaseB")])))
-                        expect(sut).toNot(equal(Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["String"], cases: [Enum.Case(name: "CaseB", associatedValues: [Enum.Case.AssociatedValue(name: nil, type: "Int")])])))
+                        expect(sut).toNot(equal(Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["String"], cases: [Enum.Case(name: "CaseB", associatedValues: [Enum.Case.AssociatedValue(name: nil, typeName: "Int")])])))
                         expect(sut).toNot(equal(Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["String"], cases: [Enum.Case(name: "CaseB")])))
                     }
                 }

--- a/SourceryTests/Models/TypeSpec.swift
+++ b/SourceryTests/Models/TypeSpec.swift
@@ -95,6 +95,15 @@ class TypeSpec: QuickSpec {
                     guard let annotations = sut?.annotations else { return fail() }
                     expect(annotations == expected).to(beTrue())
                 }
+
+                it("adds inherited types") {
+                    let type = Type(name: "Foo", isExtension: true, inheritedTypes: ["Something", "New"])
+
+                    sut?.extend(type)
+
+                    expect(sut?.inheritedTypes).to(equal(["NSObject", "New", "Something"]))
+                    expect(sut?.based).to(equal(["NSObject": "NSObject", "Something": "Something", "New": "New"]))
+                }
             }
 
             describe("When testing equality") {

--- a/SourceryTests/Models/TypeSpec.swift
+++ b/SourceryTests/Models/TypeSpec.swift
@@ -6,9 +6,9 @@ class TypeSpec: QuickSpec {
     override func spec() {
         describe ("Type") {
             var sut: Type?
-            let staticVariable = Variable(name: "staticVar", type: "Int", isStatic: true)
-            let computedVariable = Variable(name: "variable", type: "Int", isComputed: true)
-            let storedVariable = Variable(name: "otherVariable", type: "Int", isComputed: false)
+            let staticVariable = Variable(name: "staticVar", typeName: "Int", isStatic: true)
+            let computedVariable = Variable(name: "variable", typeName: "Int", isComputed: true)
+            let storedVariable = Variable(name: "otherVariable", typeName: "Int", isComputed: false)
             let parentType = Type(name: "Parent")
 
             beforeEach {
@@ -77,7 +77,7 @@ class TypeSpec: QuickSpec {
 
             describe("when extending with Type extension") {
                 it("adds variables") {
-                    let extraVariable = Variable(name: "variable", type: "Int")
+                    let extraVariable = Variable(name: "variable", typeName: "Int")
                     let type = Type(name: "Foo", isExtension: true, variables: [extraVariable])
 
                     sut?.extend(type)
@@ -87,8 +87,7 @@ class TypeSpec: QuickSpec {
 
                 it("adds annotations") {
                     let expected: [String: NSObject] = ["something": NSNumber(value: 161), "ExtraAnnotation": "ExtraValue" as NSString]
-                    let type = Type(name: "Foo", isExtension: true)
-                    type.annotations["ExtraAnnotation"] = "ExtraValue" as NSString
+                    let type = Type(name: "Foo", isExtension: true, annotations: ["ExtraAnnotation": "ExtraValue" as NSString])
 
                     sut?.extend(type)
 

--- a/SourceryTests/Models/VariableSpec.swift
+++ b/SourceryTests/Models/VariableSpec.swift
@@ -38,8 +38,6 @@ class VariableSpec: QuickSpec {
             }
 
             context("given optional type with long generic syntax") {
-                sut?.typeName = "Optional<Int>"
-
                 it("reports optional true") {
                     expect(Variable(name: "Foo", type: "Optional<Int>").isOptional).to(beTrue())
                 }

--- a/SourceryTests/Models/VariableSpec.swift
+++ b/SourceryTests/Models/VariableSpec.swift
@@ -8,7 +8,7 @@ class VariableSpec: QuickSpec {
             var sut: Variable?
 
             beforeEach {
-                sut = Variable(name: "variable", type: "Int", accessLevel: (read: .public, write: .internal), isComputed: true)
+                sut = Variable(name: "variable", typeName: "Int", accessLevel: (read: .public, write: .internal), isComputed: true)
             }
 
             afterEach {
@@ -29,38 +29,38 @@ class VariableSpec: QuickSpec {
 
             context("given optional type with short syntax") {
                 it("reports optional true") {
-                    expect(Variable(name: "Foo", type: "Int?").isOptional).to(beTrue())
+                    expect(Variable(name: "Foo", typeName: "Int?").isOptional).to(beTrue())
                 }
 
                 it("reports non-optional type for unwrappedTypeName") {
-                    expect(Variable(name: "Foo", type: "Int?").unwrappedTypeName).to(equal("Int"))
+                    expect(Variable(name: "Foo", typeName: "Int?").unwrappedTypeName).to(equal("Int"))
                 }
             }
 
             context("given optional type with long generic syntax") {
                 it("reports optional true") {
-                    expect(Variable(name: "Foo", type: "Optional<Int>").isOptional).to(beTrue())
+                    expect(Variable(name: "Foo", typeName: "Optional<Int>").isOptional).to(beTrue())
                 }
 
                 it("reports non-optional type for unwrappedTypeName") {
-                    expect(Variable(name: "Foo", type: "Optional<Int>").unwrappedTypeName).to(equal("Int"))
+                    expect(Variable(name: "Foo", typeName: "Optional<Int>").unwrappedTypeName).to(equal("Int"))
                 }
             }
 
             describe("When testing equality") {
                 context("given same items") {
                     it("is equal") {
-                        expect(sut).to(equal(Variable(name: "variable", type: "Int", accessLevel: (read: .public, write: .internal), isComputed: true)))
+                        expect(sut).to(equal(Variable(name: "variable", typeName: "Int", accessLevel: (read: .public, write: .internal), isComputed: true)))
                     }
                 }
 
                 context("given different items") {
                     it("is not equal") {
-                        expect(sut).toNot(equal(Variable(name: "other", type: "Int", accessLevel: (read: .public, write: .internal), isComputed: true)))
-                        expect(sut).toNot(equal(Variable(name: "variable", type: "Float", accessLevel: (read: .public, write: .internal), isComputed: true)))
-                        expect(sut).toNot(equal(Variable(name: "other", type: "Int", accessLevel: (read: .internal, write: .internal), isComputed: true)))
-                        expect(sut).toNot(equal(Variable(name: "other", type: "Int", accessLevel: (read: .public, write: .public), isComputed: true)))
-                        expect(sut).toNot(equal(Variable(name: "other", type: "Int", accessLevel: (read: .public, write: .internal), isComputed: false)))
+                        expect(sut).toNot(equal(Variable(name: "other", typeName: "Int", accessLevel: (read: .public, write: .internal), isComputed: true)))
+                        expect(sut).toNot(equal(Variable(name: "variable", typeName: "Float", accessLevel: (read: .public, write: .internal), isComputed: true)))
+                        expect(sut).toNot(equal(Variable(name: "other", typeName: "Int", accessLevel: (read: .internal, write: .internal), isComputed: true)))
+                        expect(sut).toNot(equal(Variable(name: "other", typeName: "Int", accessLevel: (read: .public, write: .public), isComputed: true)))
+                        expect(sut).toNot(equal(Variable(name: "other", typeName: "Int", accessLevel: (read: .public, write: .internal), isComputed: false)))
                     }
                 }
             }

--- a/SourceryTests/ParserSpec.swift
+++ b/SourceryTests/ParserSpec.swift
@@ -39,20 +39,20 @@ class ParserSpec: QuickSpec {
                 }
 
                 it("extracts standard property correctly") {
-                    expect(parse("var name: String")).to(equal(Variable(name: "name", type: "String", accessLevel: (read: .internal, write: .internal), isComputed: false)))
+                    expect(parse("var name: String")).to(equal(Variable(name: "name", typeName: "String", accessLevel: (read: .internal, write: .internal), isComputed: false)))
                 }
 
                 it("extracts standard let property correctly") {
                     let r = parse("let name: String")
-                    expect(r).to(equal(Variable(name: "name", type: "String", accessLevel: (read: .internal, write: .none), isComputed: false)))
+                    expect(r).to(equal(Variable(name: "name", typeName: "String", accessLevel: (read: .internal, write: .none), isComputed: false)))
                 }
 
                 it("extracts computed property correctly") {
-                    expect(parse("var name: Int { return 2 }")).to(equal(Variable(name: "name", type: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)))
+                    expect(parse("var name: Int { return 2 }")).to(equal(Variable(name: "name", typeName: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)))
                 }
 
                 it("extracts generic property correctly") {
-                    expect(parse("let name: Observable<Int>")).to(equal(Variable(name: "name", type: "Observable<Int>", accessLevel: (read: .internal, write: .none), isComputed: false)))
+                    expect(parse("let name: Observable<Int>")).to(equal(Variable(name: "name", typeName: "Observable<Int>", accessLevel: (read: .internal, write: .none), isComputed: false)))
                 }
 
                 it("extracts property with didSet correctly") {
@@ -60,12 +60,12 @@ class ParserSpec: QuickSpec {
                             "var name: Int? {\n" +
                                     "didSet { _ = 2 }\n" +
                                     "willSet { _ = 4 }\n" +
-                                    "}")).to(equal(Variable(name: "name", type: "Int?", accessLevel: (read: .internal, write: .internal), isComputed: false)))
+                                    "}")).to(equal(Variable(name: "name", typeName: "Int?", accessLevel: (read: .internal, write: .internal), isComputed: false)))
                 }
 
                 context("given it has sourcery annotations") {
                     it("extracts single annotation") {
-                        let expectedVariable = Variable(name: "name", type: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["skipEquability"] = NSNumber(value: true)
 
                         expect(parse("// sourcery: skipEquability\n" +
@@ -73,7 +73,7 @@ class ParserSpec: QuickSpec {
                     }
 
                     it("extracts multiple annotations on the same line") {
-                        let expectedVariable = Variable(name: "name", type: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["skipEquability"] = NSNumber(value: true)
                         expectedVariable.annotations["jsonKey"] = "json_key" as NSString
 
@@ -82,7 +82,7 @@ class ParserSpec: QuickSpec {
                     }
 
                     it("extracts multi-line annotations, including numbers") {
-                        let expectedVariable = Variable(name: "name", type: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["skipEquability"] = NSNumber(value: true)
                         expectedVariable.annotations["jsonKey"] = "json_key" as NSString
                         expectedVariable.annotations["thirdProperty"] = NSNumber(value: -3)
@@ -94,7 +94,7 @@ class ParserSpec: QuickSpec {
                     }
 
                     it("extracts annotations interleaved with comments") {
-                        let expectedVariable = Variable(name: "name", type: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["isSet"] = NSNumber(value: true)
                         expectedVariable.annotations["numberOfIterations"] = NSNumber(value: 2)
 
@@ -106,7 +106,7 @@ class ParserSpec: QuickSpec {
                     }
 
                     it("stops extracting annotations if it encounters a non-comment line") {
-                        let expectedVariable = Variable(name: "name", type: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["numberOfIterations"] = NSNumber(value: 2)
 
                         let result = parse(        "// sourcery: isSet\n" +
@@ -146,7 +146,7 @@ class ParserSpec: QuickSpec {
                     it("extracts instance variables properly") {
                         expect(parse("struct Foo { var x: Int }"))
                                 .to(equal([
-                                                  Struct(name: "Foo", accessLevel: .internal, isExtension: false, variables: [Variable.init(name: "x", type: "Int", accessLevel: (read: .internal, write: .internal), isComputed: false)])
+                                                  Struct(name: "Foo", accessLevel: .internal, isExtension: false, variables: [Variable.init(name: "x", typeName: "Int", accessLevel: (read: .internal, write: .internal), isComputed: false)])
                                           ]))
                     }
 
@@ -154,8 +154,8 @@ class ParserSpec: QuickSpec {
                         expect(parse("struct Foo { static var x: Int { return 2 }; class var y: Int = 0 }"))
                                 .to(equal([
                                     Struct(name: "Foo", accessLevel: .internal, isExtension: false, variables: [
-                                        Variable.init(name: "x", type: "Int", accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: true),
-                                        Variable.init(name: "y", type: "Int", accessLevel: (read: .internal, write: .internal), isComputed: false, isStatic: true)
+                                        Variable.init(name: "x", typeName: "Int", accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: true),
+                                        Variable.init(name: "y", typeName: "Int", accessLevel: (read: .internal, write: .internal), isComputed: false, isStatic: true)
                                         ])
                                     ]))
                     }
@@ -181,7 +181,7 @@ class ParserSpec: QuickSpec {
                     it("extracts variables properly") {
                         expect(parse("class Foo { }; extension Foo { var x: Int }"))
                                 .to(equal([
-                                        Type(name: "Foo", accessLevel: .internal, isExtension: false, variables: [Variable.init(name: "x", type: "Int", accessLevel: (read: .internal, write: .internal), isComputed: false)])
+                                        Type(name: "Foo", accessLevel: .internal, isExtension: false, variables: [Variable.init(name: "x", typeName: "Int", accessLevel: (read: .internal, write: .internal), isComputed: false)])
                                 ]))
                     }
 
@@ -206,7 +206,7 @@ class ParserSpec: QuickSpec {
                     it("extracts extensions properly") {
                         expect(parse("protocol Foo { }; extension Bar: Foo { var x: Int { reutnr 0 } }"))
                             .to(equal([
-                                Type(name: "Bar", accessLevel: .none, isExtension: true, variables: [Variable.init(name: "x", type: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)], inheritedTypes: ["Foo"]),
+                                Type(name: "Bar", accessLevel: .none, isExtension: true, variables: [Variable.init(name: "x", typeName: "Int", accessLevel: (read: .internal, write: .none), isComputed: true)], inheritedTypes: ["Foo"]),
                                 Protocol(name: "Foo")
                                 ]))
                     }
@@ -221,7 +221,7 @@ class ParserSpec: QuickSpec {
                     }
 
                     it("replaces variable alias type with actual type") {
-                        let expectedVariable = Variable(name: "foo", type: "FooAlias")
+                        let expectedVariable = Variable(name: "foo", typeName: "FooAlias")
                         expectedVariable.type = Type(name: "Foo")
 
                         let type = parse("typealias FooAlias = Foo; internal class Foo {}; class Bar { internal var foo: FooAlias }").first
@@ -232,7 +232,7 @@ class ParserSpec: QuickSpec {
                     }
 
                     it("replaces variable optional alias type with actual type") {
-                        let expectedVariable = Variable(name: "foo", type: "FooAlias?")
+                        let expectedVariable = Variable(name: "foo", typeName: "FooAlias?")
                         expectedVariable.type = Type(name: "Foo")
 
                         let type = parse("typealias FooAlias = Foo; class Foo {}; class Bar { var foo: FooAlias? }").first
@@ -273,7 +273,7 @@ class ParserSpec: QuickSpec {
                     it("extracts variables properly") {
                         expect(parse("enum Foo { var x: Int { return 1 } }"))
                                 .to(equal([
-                                        Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [], variables: [Variable(name: "x", type: "Int", accessLevel: (.internal, .none), isComputed: true)])
+                                        Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [], variables: [Variable(name: "x", typeName: "Int", accessLevel: (.internal, .none), isComputed: true)])
                                 ]))
                     }
 
@@ -307,19 +307,19 @@ class ParserSpec: QuickSpec {
 
                         it("extracts enums with RawRepresentable by inferring from variable") {
                             expect(parse("enum Foo: RawRepresentable { case optionA; var rawValue: String { return \"\" }; init?(rawValue: String) { self = .optionA } }")).to(equal([
-                                Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["RawRepresentable"], rawType: "String", cases: [Enum.Case(name: "optionA")], variables: [Variable(name: "rawValue", type: "String", accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: false)])
+                                Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["RawRepresentable"], rawType: "String", cases: [Enum.Case(name: "optionA")], variables: [Variable(name: "rawValue", typeName: "String", accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: false)])
                                 ]))
                         }
 
                         it("extracts enums with RawRepresentable by inferring from variable with typealias") {
                             expect(parse("enum Foo: RawRepresentable { case optionA; typealias RawValue = String; var rawValue: RawValue { return \"\" }; init?(rawValue: RawValue) { self = .optionA } }")).to(equal([
-                                Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["RawRepresentable"], rawType: "String", cases: [Enum.Case(name: "optionA")], variables: [Variable(name: "rawValue", type: "RawValue", accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: false)])
+                                Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["RawRepresentable"], rawType: "String", cases: [Enum.Case(name: "optionA")], variables: [Variable(name: "rawValue", typeName: "RawValue", accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: false)])
                                 ]))
                         }
 
                         it("extracts enums with RawRepresentable by inferring from typealias") {
     						expect(parse("enum Foo: CustomStringConvertible, RawRepresentable { case optionA; typealias RawValue = String; var rawValue: RawValue { return \"\" }; init?(rawValue: RawValue) { self = .optionA } }")).to(equal([
-                                Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["CustomStringConvertible", "RawRepresentable"], rawType: "String", cases: [Enum.Case(name: "optionA")], variables: [Variable(name: "rawValue", type: "RawValue", accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: false)])
+                                Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["CustomStringConvertible", "RawRepresentable"], rawType: "String", cases: [Enum.Case(name: "optionA")], variables: [Variable(name: "rawValue", typeName: "RawValue", accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: false)])
                                 ]))
                         }
 
@@ -342,8 +342,8 @@ class ParserSpec: QuickSpec {
                                 .to(equal([
                                     Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases:
                                         [
-                                            Enum.Case(name: "optionA", associatedValues: [Enum.Case.AssociatedValue(name: nil, type: "Observable<Int>")]),
-                                            Enum.Case(name: "optionB", associatedValues: [Enum.Case.AssociatedValue(name: "named", type: "Float")])
+                                            Enum.Case(name: "optionA", associatedValues: [Enum.Case.AssociatedValue(name: nil, typeName: "Observable<Int>")]),
+                                            Enum.Case(name: "optionB", associatedValues: [Enum.Case.AssociatedValue(name: "named", typeName: "Float")])
                                         ])
                                 ]))
                     }

--- a/SourceryTests/ParserSpec.swift
+++ b/SourceryTests/ParserSpec.swift
@@ -37,7 +37,7 @@ class ParserSpec: QuickSpec {
                 it("ignores private variables") {
                     expect(parse("private var name: String")).to(beNil())
                 }
-                
+
                 it("extracts standard property correctly") {
                     expect(parse("var name: String")).to(equal(Variable(name: "name", type: "String", accessLevel: (read: .internal, write: .internal), isComputed: false)))
                 }
@@ -372,7 +372,7 @@ class ParserSpec: QuickSpec {
                                 ]))
                     }
                 }
-                
+
                 context("given extension") {
                     it("ignores extension for private type") {
                         expect(parse("private struct Foo {}; extension Foo { var x: Int { return 0 } }")).to(beEmpty())


### PR DESCRIPTION
Some refactorings but also fixing the implements / inherits flattening: since if an entity is a protocol then it can't inherit but can implement, when it's a class then it can do both, so we can join inherits and implements and only do check for manual assignment (because it's recursive)