### PR TITLE
Add upperFirst Stencil filter to template rendering environment.

### DIFF
--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -12,8 +12,25 @@ import SwiftTryCatch
 internal class SourceryTemplate: Template {
     private(set) var sourcePath: Path = ""
     convenience init(path: Path) throws {
-        self.init(templateString: try path.read())
+        self.init(templateString: try path.read(), environment: SourceryTemplate.sourceryEnvironment())
         sourcePath = path
+    }
+
+    convenience init(templateString: String) {
+        self.init(templateString: templateString, environment: SourceryTemplate.sourceryEnvironment())
+    }
+
+    private static func sourceryEnvironment() -> Stencil.Environment {
+        let ext = Stencil.Extension()
+        ext.registerFilter("upperFirst") { (any: Any?) in
+            guard let s = any as? String else {
+                return any
+            }
+            let first = String(s.characters.prefix(1)).capitalized
+            let other = String(s.characters.dropFirst())
+            return first + other
+        }
+        return Stencil.Environment(extensions: [ext])
     }
 }
 

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -45,7 +45,7 @@ class GeneratorSpec: QuickSpec {
 
             func generate(_ template: String) -> String {
                 return (try? Generator.generate(types,
-                        template: Template(templateString: template))) ?? ""
+                        template: SourceryTemplate(templateString: template))) ?? ""
             }
 
             it("generates types.all by skipping protocols") {
@@ -66,6 +66,10 @@ class GeneratorSpec: QuickSpec {
 
             it("generates types.enums") {
                 expect(generate("Found {{ types.enums.count }} enums, first: {{ types.enums.first.name }}")).to(equal("Found 2 enums, first: Options"))
+            }
+
+            it("generates uppercase") {
+                expect(generate("{{\"helloWorld\" | upperFirst }}")).to(equal("HelloWorld"))
             }
 
             it("feeds types.implementing specific protocol") {


### PR DESCRIPTION
We don't have a canonical way for users to add Stencil filters to Sourcery without modifying Sourcery itself. Would be open to looking into implementing a nicer way to do this.

Regardless, I have a hunch that this particular filter will be useful to many Sourcery users. The `capitalize` filter in Stencil is for human readable text, not for manipulating source identifiers like in Sourcery. I wanted to make a transformation from lowerCamelCase to UpperCamelCase on an enum case name, but that's currently not possible with stencil. See commit comment for more details.