### PR TITLE
Implement Diff matchers

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,7 @@
 coverage:
   ignore:
     - Sourcery/main.swift
+    - Sourcery/CodeGenerated/*
     - Pods/*
   status:
     patch: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ---
 ## Master
+### New Features
+- You can now access `supertype` of a class
 
 ### Bug Fixes
 - Fix dealing with multibyte characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Bug Fixes
 - Fix dealing with multibyte characters
 
+## Internal changes
+- TDD Development is now easier thanks to Diffable results, no longer we need to scan wall of text on failures, instead we see exactly what's different.
+
 ## 0.4.7
 ### New Features
 - Added `contains`, `hasPrefix`, `hasPrefix` filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Master
 ### New Features
 - You can now access `supertype` of a class
+- Associated values will now automatically use idx as name if no name is provided
 
 ### Bug Fixes
 - Fix dealing with multibyte characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 - Fix dealing with multibyte characters
+- `types.implementing` and `types.based` should include protocols that are based on other protocols
 
 ## Internal changes
 - TDD Development is now easier thanks to Diffable results, no longer we need to scan wall of text on failures, instead we see exactly what's different.

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		CD475D6F1DE9B98B009AD8B0 /* Result in Resources */ = {isa = PBXBuildFile; fileRef = CD475D6E1DE9B98B009AD8B0 /* Result */; };
 		CD53EE661D897C1F00F5886C /* Source in Resources */ = {isa = PBXBuildFile; fileRef = CD53EE651D897C1F00F5886C /* Source */; };
 		CD53EE681D897D2900F5886C /* Templates in Resources */ = {isa = PBXBuildFile; fileRef = CD53EE671D897D2900F5886C /* Templates */; };
+		CD666A9A1E0BEF4F0045D31A /* Diffable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD666A991E0BEF4F0045D31A /* Diffable.swift */; };
+		CD666A9C1E0BF0A10045D31A /* Diffable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD666A9B1E0BF0A10045D31A /* Diffable.generated.swift */; };
 		CD812F5A1DFDCC1A0088B2F6 /* AccessLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD812F541DFDCC1A0088B2F6 /* AccessLevel.swift */; };
 		CD812F5B1DFDCC1A0088B2F6 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD812F551DFDCC1A0088B2F6 /* Enum.swift */; };
 		CD812F5C1DFDCC1A0088B2F6 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD812F561DFDCC1A0088B2F6 /* Protocol.swift */; };
@@ -32,6 +34,7 @@
 		CDBD141F1DFFC2CC00FF9F21 /* Description.stencil in Resources */ = {isa = PBXBuildFile; fileRef = CDBD141D1DFFC2CC00FF9F21 /* Description.stencil */; };
 		CDBD14201DFFC2CC00FF9F21 /* Equality.stencil in Resources */ = {isa = PBXBuildFile; fileRef = CDBD141E1DFFC2CC00FF9F21 /* Equality.stencil */; };
 		E291D13413D92A8C36A07A86 /* VariableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D8D53A557DA9E6D27C3C /* VariableSpec.swift */; };
+		E291D1C26BD65C6E109966AF /* CustomMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D139206162204C48F396 /* CustomMatchers.swift */; };
 		E291D48FD07450FD0A09D92E /* EnumSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D3D222F05C42C246CB73 /* EnumSpec.swift */; };
 		E291D4E250805568DBC33F7E /* TypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DF48D4FBBB43C1F7EF8A /* TypeSpec.swift */; };
 		E291D5ABECEE3435131D8D05 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DBBBE7AF85DF7D7AF97D /* Parser.swift */; };
@@ -79,6 +82,8 @@
 		CD475D6E1DE9B98B009AD8B0 /* Result */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Result; sourceTree = "<group>"; };
 		CD53EE651D897C1F00F5886C /* Source */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Source; sourceTree = "<group>"; };
 		CD53EE671D897D2900F5886C /* Templates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Templates; sourceTree = "<group>"; };
+		CD666A991E0BEF4F0045D31A /* Diffable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Diffable.swift; sourceTree = "<group>"; };
+		CD666A9B1E0BF0A10045D31A /* Diffable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Diffable.generated.swift; sourceTree = "<group>"; };
 		CD754C8B1D853F000082B512 /* Sourcery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sourcery.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD754C951D853F000082B512 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CD754C9A1D853F000082B512 /* SourceryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SourceryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -95,6 +100,7 @@
 		CDBD141D1DFFC2CC00FF9F21 /* Description.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Description.stencil; sourceTree = "<group>"; };
 		CDBD141E1DFFC2CC00FF9F21 /* Equality.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Equality.stencil; sourceTree = "<group>"; };
 		D7C9B21117B6C7EB409B9D49 /* Pods_Sourcery.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sourcery.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E291D139206162204C48F396 /* CustomMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomMatchers.swift; sourceTree = "<group>"; };
 		E291D2450093BB4B3A9ADFEC /* Stubs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
 		E291D3D222F05C42C246CB73 /* EnumSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumSpec.swift; sourceTree = "<group>"; };
 		E291D78F72297EDB30B2A757 /* ParserSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserSpec.swift; sourceTree = "<group>"; };
@@ -186,6 +192,7 @@
 		CD754C9D1D853F000082B512 /* SourceryTests */ = {
 			isa = PBXGroup;
 			children = (
+				E291D0AE58E620796FB2B57D /* Helpers */,
 				E291D8DDDA3F3377871F27A4 /* Models */,
 				E291D36844A70DF851656DE8 /* Stub */,
 				CD754CA01D853F000082B512 /* Info.plist */,
@@ -207,6 +214,7 @@
 				CD812F581DFDCC1A0088B2F6 /* Type.swift */,
 				097E11ED1E05E76900FEB751 /* Typealias.swift */,
 				CD812F591DFDCC1A0088B2F6 /* Variable.swift */,
+				CD666A991E0BEF4F0045D31A /* Diffable.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -214,6 +222,7 @@
 		CD812F601DFDCD900088B2F6 /* CodeGenerated */ = {
 			isa = PBXGroup;
 			children = (
+				CD666A9B1E0BF0A10045D31A /* Diffable.generated.swift */,
 				CD812F611DFDCDA10088B2F6 /* Equality.generated.swift */,
 				CD812F661DFDD3990088B2F6 /* Description.generated.swift */,
 			);
@@ -227,6 +236,14 @@
 				CDBD141E1DFFC2CC00FF9F21 /* Equality.stencil */,
 			);
 			path = Templates;
+			sourceTree = "<group>";
+		};
+		E291D0AE58E620796FB2B57D /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				E291D139206162204C48F396 /* CustomMatchers.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		E291D36844A70DF851656DE8 /* Stub */ = {
@@ -489,6 +506,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD666A9A1E0BEF4F0045D31A /* Diffable.swift in Sources */,
 				E291D5ABECEE3435131D8D05 /* Parser.swift in Sources */,
 				CD9C459D1DFAF76D00161C2C /* main.swift in Sources */,
 				CD812F5B1DFDCC1A0088B2F6 /* Enum.swift in Sources */,
@@ -501,6 +519,7 @@
 				E291DCA363FD8EBF0455C712 /* Sourcery.swift in Sources */,
 				CD812F5E1DFDCC1A0088B2F6 /* Type.swift in Sources */,
 				CD812F5F1DFDCC1A0088B2F6 /* Variable.swift in Sources */,
+				CD666A9C1E0BF0A10045D31A /* Diffable.generated.swift in Sources */,
 				097E11EE1E05E76900FEB751 /* Typealias.swift in Sources */,
 				CD812F671DFDD3990088B2F6 /* Description.generated.swift in Sources */,
 			);
@@ -521,6 +540,7 @@
 				E291D48FD07450FD0A09D92E /* EnumSpec.swift in Sources */,
 				E291DC5F2343BF3DE3334986 /* Stubs.swift in Sources */,
 				097E11F01E05E78600FEB751 /* TypealiasSpec.swift in Sources */,
+				E291D1C26BD65C6E109966AF /* CustomMatchers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		E291D8C0F0FE5B3DF91025CC /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DA16190CED2907BDEA06 /* Generator.swift */; };
 		E291DC5F2343BF3DE3334986 /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D2450093BB4B3A9ADFEC /* Stubs.swift */; };
 		E291DCA363FD8EBF0455C712 /* Sourcery.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DB6A95BAECDB6E978A76 /* Sourcery.swift */; };
+		E291DCD43D41B7F8D7AAF7B9 /* DiffableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D30C065089B348EE7C42 /* DiffableSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,6 +103,7 @@
 		D7C9B21117B6C7EB409B9D49 /* Pods_Sourcery.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sourcery.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E291D139206162204C48F396 /* CustomMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomMatchers.swift; sourceTree = "<group>"; };
 		E291D2450093BB4B3A9ADFEC /* Stubs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
+		E291D30C065089B348EE7C42 /* DiffableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiffableSpec.swift; sourceTree = "<group>"; };
 		E291D3D222F05C42C246CB73 /* EnumSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumSpec.swift; sourceTree = "<group>"; };
 		E291D78F72297EDB30B2A757 /* ParserSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserSpec.swift; sourceTree = "<group>"; };
 		E291D8D53A557DA9E6D27C3C /* VariableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableSpec.swift; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 				0967DA601E0341400084F702 /* ProtocolSpec.swift */,
 				E291D3D222F05C42C246CB73 /* EnumSpec.swift */,
 				097E11EF1E05E78600FEB751 /* TypealiasSpec.swift */,
+				E291D30C065089B348EE7C42 /* DiffableSpec.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -541,6 +544,7 @@
 				E291DC5F2343BF3DE3334986 /* Stubs.swift in Sources */,
 				097E11F01E05E78600FEB751 /* TypealiasSpec.swift in Sources */,
 				E291D1C26BD65C6E109966AF /* CustomMatchers.swift in Sources */,
+				E291DCD43D41B7F8D7AAF7B9 /* DiffableSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sourcery/CodeGenerated/Diffable.generated.swift
+++ b/Sourcery/CodeGenerated/Diffable.generated.swift
@@ -1,0 +1,95 @@
+// Generated using Sourcery 0.4.7 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+extension Enum {
+     override func diffAgainst(_ object: Any?) -> DiffableResult {
+        var results = DiffableResult()
+
+        guard let rhs = object as? Enum else {
+          results.append("Incorrect type, expected Enum, received: \(type(of: object))")
+          return results
+        }
+        if self.cases != rhs.cases { results.append("Incorrect cases, expected \(self.cases), received: \(rhs.cases)") }
+        if self.rawType != rhs.rawType { results.append("Incorrect rawType, expected \(self.rawType), received: \(rhs.rawType)") }
+
+        results.append(contentsOf: super.diffAgainst(object))
+        return results
+    }
+}
+
+extension Protocol {
+     override func diffAgainst(_ object: Any?) -> DiffableResult {
+        var results = DiffableResult()
+
+        results.append(contentsOf: super.diffAgainst(object))
+        return results
+    }
+}
+
+extension Struct {
+     override func diffAgainst(_ object: Any?) -> DiffableResult {
+        var results = DiffableResult()
+
+        results.append(contentsOf: super.diffAgainst(object))
+        return results
+    }
+}
+
+extension Type: Diffable {
+    func diffAgainst(_ object: Any?) -> DiffableResult {
+        var results = DiffableResult()
+
+        guard let rhs = object as? Type else {
+          results.append("Incorrect type, expected Type, received: \(type(of: object))")
+          return results
+        }
+        if self.typealiases != rhs.typealiases { results.append("Incorrect typealiases, expected \(self.typealiases), received: \(rhs.typealiases)") }
+        if self.isExtension != rhs.isExtension { results.append("Incorrect isExtension, expected \(self.isExtension), received: \(rhs.isExtension)") }
+        if self.accessLevel != rhs.accessLevel { results.append("Incorrect accessLevel, expected \(self.accessLevel), received: \(rhs.accessLevel)") }
+        if self.isGeneric != rhs.isGeneric { results.append("Incorrect isGeneric, expected \(self.isGeneric), received: \(rhs.isGeneric)") }
+        if self.localName != rhs.localName { results.append("Incorrect localName, expected \(self.localName), received: \(rhs.localName)") }
+        if self.variables != rhs.variables { results.append("Incorrect variables, expected \(self.variables), received: \(rhs.variables)") }
+        if self.annotations != rhs.annotations { results.append("Incorrect annotations, expected \(self.annotations), received: \(rhs.annotations)") }
+        if self.inheritedTypes != rhs.inheritedTypes { results.append("Incorrect inheritedTypes, expected \(self.inheritedTypes), received: \(rhs.inheritedTypes)") }
+        if self.containedTypes != rhs.containedTypes { results.append("Incorrect containedTypes, expected \(self.containedTypes), received: \(rhs.containedTypes)") }
+        if self.parentName != rhs.parentName { results.append("Incorrect parentName, expected \(self.parentName), received: \(rhs.parentName)") }
+
+        return results
+    }
+}
+
+extension Typealias: Diffable {
+    func diffAgainst(_ object: Any?) -> DiffableResult {
+        var results = DiffableResult()
+
+        guard let rhs = object as? Typealias else {
+          results.append("Incorrect type, expected Typealias, received: \(type(of: object))")
+          return results
+        }
+        if self.aliasName != rhs.aliasName { results.append("Incorrect aliasName, expected \(self.aliasName), received: \(rhs.aliasName)") }
+        if self.typeName != rhs.typeName { results.append("Incorrect typeName, expected \(self.typeName), received: \(rhs.typeName)") }
+        if self.parentName != rhs.parentName { results.append("Incorrect parentName, expected \(self.parentName), received: \(rhs.parentName)") }
+
+        return results
+    }
+}
+
+extension Variable: Diffable {
+    func diffAgainst(_ object: Any?) -> DiffableResult {
+        var results = DiffableResult()
+
+        guard let rhs = object as? Variable else {
+          results.append("Incorrect type, expected Variable, received: \(type(of: object))")
+          return results
+        }
+        if self.name != rhs.name { results.append("Incorrect name, expected \(self.name), received: \(rhs.name)") }
+        if self.typeName != rhs.typeName { results.append("Incorrect typeName, expected \(self.typeName), received: \(rhs.typeName)") }
+        if self.isComputed != rhs.isComputed { results.append("Incorrect isComputed, expected \(self.isComputed), received: \(rhs.isComputed)") }
+        if self.isStatic != rhs.isStatic { results.append("Incorrect isStatic, expected \(self.isStatic), received: \(rhs.isStatic)") }
+        if self.readAccess != rhs.readAccess { results.append("Incorrect readAccess, expected \(self.readAccess), received: \(rhs.readAccess)") }
+        if self.writeAccess != rhs.writeAccess { results.append("Incorrect writeAccess, expected \(self.writeAccess), received: \(rhs.writeAccess)") }
+        if self.annotations != rhs.annotations { results.append("Incorrect annotations, expected \(self.annotations), received: \(rhs.annotations)") }
+
+        return results
+    }
+}

--- a/Sourcery/CodeGenerated/Diffable.generated.swift
+++ b/Sourcery/CodeGenerated/Diffable.generated.swift
@@ -3,14 +3,14 @@
 
 extension Enum {
      override func diffAgainst(_ object: Any?) -> DiffableResult {
-        var results = DiffableResult()
+        let results = DiffableResult()
 
         guard let rhs = object as? Enum else {
-          results.append("Incorrect type, expected Enum, received: \(type(of: object))")
+          results.append("Incorrect type <expected: Enum, received: \(type(of: object))>")
           return results
         }
-        if self.cases != rhs.cases { results.append("Incorrect cases, expected \(self.cases), received: \(rhs.cases)") }
-        if self.rawType != rhs.rawType { results.append("Incorrect rawType, expected \(self.rawType), received: \(rhs.rawType)") }
+        if self.cases != rhs.cases { results.append("Incorrect cases <expected: \(self.cases), received: \(rhs.cases)>") }
+        if self.rawType != rhs.rawType { results.append("Incorrect rawType <expected: \(self.rawType), received: \(rhs.rawType)>") }
 
         results.append(contentsOf: super.diffAgainst(object))
         return results
@@ -19,7 +19,7 @@ extension Enum {
 
 extension Protocol {
      override func diffAgainst(_ object: Any?) -> DiffableResult {
-        var results = DiffableResult()
+        let results = DiffableResult()
 
         results.append(contentsOf: super.diffAgainst(object))
         return results
@@ -28,7 +28,7 @@ extension Protocol {
 
 extension Struct {
      override func diffAgainst(_ object: Any?) -> DiffableResult {
-        var results = DiffableResult()
+        let results = DiffableResult()
 
         results.append(contentsOf: super.diffAgainst(object))
         return results
@@ -37,22 +37,22 @@ extension Struct {
 
 extension Type: Diffable {
     func diffAgainst(_ object: Any?) -> DiffableResult {
-        var results = DiffableResult()
+        let results = DiffableResult()
 
         guard let rhs = object as? Type else {
-          results.append("Incorrect type, expected Type, received: \(type(of: object))")
+          results.append("Incorrect type <expected: Type, received: \(type(of: object))>")
           return results
         }
-        if self.typealiases != rhs.typealiases { results.append("Incorrect typealiases, expected \(self.typealiases), received: \(rhs.typealiases)") }
-        if self.isExtension != rhs.isExtension { results.append("Incorrect isExtension, expected \(self.isExtension), received: \(rhs.isExtension)") }
-        if self.accessLevel != rhs.accessLevel { results.append("Incorrect accessLevel, expected \(self.accessLevel), received: \(rhs.accessLevel)") }
-        if self.isGeneric != rhs.isGeneric { results.append("Incorrect isGeneric, expected \(self.isGeneric), received: \(rhs.isGeneric)") }
-        if self.localName != rhs.localName { results.append("Incorrect localName, expected \(self.localName), received: \(rhs.localName)") }
-        if self.variables != rhs.variables { results.append("Incorrect variables, expected \(self.variables), received: \(rhs.variables)") }
-        if self.annotations != rhs.annotations { results.append("Incorrect annotations, expected \(self.annotations), received: \(rhs.annotations)") }
-        if self.inheritedTypes != rhs.inheritedTypes { results.append("Incorrect inheritedTypes, expected \(self.inheritedTypes), received: \(rhs.inheritedTypes)") }
-        if self.containedTypes != rhs.containedTypes { results.append("Incorrect containedTypes, expected \(self.containedTypes), received: \(rhs.containedTypes)") }
-        if self.parentName != rhs.parentName { results.append("Incorrect parentName, expected \(self.parentName), received: \(rhs.parentName)") }
+        if self.typealiases != rhs.typealiases { results.append("Incorrect typealiases <expected: \(self.typealiases), received: \(rhs.typealiases)>") }
+        if self.isExtension != rhs.isExtension { results.append("Incorrect isExtension <expected: \(self.isExtension), received: \(rhs.isExtension)>") }
+        if self.accessLevel != rhs.accessLevel { results.append("Incorrect accessLevel <expected: \(self.accessLevel), received: \(rhs.accessLevel)>") }
+        if self.isGeneric != rhs.isGeneric { results.append("Incorrect isGeneric <expected: \(self.isGeneric), received: \(rhs.isGeneric)>") }
+        if self.localName != rhs.localName { results.append("Incorrect localName <expected: \(self.localName), received: \(rhs.localName)>") }
+        if self.variables != rhs.variables { results.append("Incorrect variables <expected: \(self.variables), received: \(rhs.variables)>") }
+        if self.annotations != rhs.annotations { results.append("Incorrect annotations <expected: \(self.annotations), received: \(rhs.annotations)>") }
+        if self.inheritedTypes != rhs.inheritedTypes { results.append("Incorrect inheritedTypes <expected: \(self.inheritedTypes), received: \(rhs.inheritedTypes)>") }
+        if self.containedTypes != rhs.containedTypes { results.append("Incorrect containedTypes <expected: \(self.containedTypes), received: \(rhs.containedTypes)>") }
+        if self.parentName != rhs.parentName { results.append("Incorrect parentName <expected: \(self.parentName), received: \(rhs.parentName)>") }
 
         return results
     }
@@ -60,15 +60,15 @@ extension Type: Diffable {
 
 extension Typealias: Diffable {
     func diffAgainst(_ object: Any?) -> DiffableResult {
-        var results = DiffableResult()
+        let results = DiffableResult()
 
         guard let rhs = object as? Typealias else {
-          results.append("Incorrect type, expected Typealias, received: \(type(of: object))")
+          results.append("Incorrect type <expected: Typealias, received: \(type(of: object))>")
           return results
         }
-        if self.aliasName != rhs.aliasName { results.append("Incorrect aliasName, expected \(self.aliasName), received: \(rhs.aliasName)") }
-        if self.typeName != rhs.typeName { results.append("Incorrect typeName, expected \(self.typeName), received: \(rhs.typeName)") }
-        if self.parentName != rhs.parentName { results.append("Incorrect parentName, expected \(self.parentName), received: \(rhs.parentName)") }
+        if self.aliasName != rhs.aliasName { results.append("Incorrect aliasName <expected: \(self.aliasName), received: \(rhs.aliasName)>") }
+        if self.typeName != rhs.typeName { results.append("Incorrect typeName <expected: \(self.typeName), received: \(rhs.typeName)>") }
+        if self.parentName != rhs.parentName { results.append("Incorrect parentName <expected: \(self.parentName), received: \(rhs.parentName)>") }
 
         return results
     }
@@ -76,19 +76,19 @@ extension Typealias: Diffable {
 
 extension Variable: Diffable {
     func diffAgainst(_ object: Any?) -> DiffableResult {
-        var results = DiffableResult()
+        let results = DiffableResult()
 
         guard let rhs = object as? Variable else {
-          results.append("Incorrect type, expected Variable, received: \(type(of: object))")
+          results.append("Incorrect type <expected: Variable, received: \(type(of: object))>")
           return results
         }
-        if self.name != rhs.name { results.append("Incorrect name, expected \(self.name), received: \(rhs.name)") }
-        if self.typeName != rhs.typeName { results.append("Incorrect typeName, expected \(self.typeName), received: \(rhs.typeName)") }
-        if self.isComputed != rhs.isComputed { results.append("Incorrect isComputed, expected \(self.isComputed), received: \(rhs.isComputed)") }
-        if self.isStatic != rhs.isStatic { results.append("Incorrect isStatic, expected \(self.isStatic), received: \(rhs.isStatic)") }
-        if self.readAccess != rhs.readAccess { results.append("Incorrect readAccess, expected \(self.readAccess), received: \(rhs.readAccess)") }
-        if self.writeAccess != rhs.writeAccess { results.append("Incorrect writeAccess, expected \(self.writeAccess), received: \(rhs.writeAccess)") }
-        if self.annotations != rhs.annotations { results.append("Incorrect annotations, expected \(self.annotations), received: \(rhs.annotations)") }
+        if self.name != rhs.name { results.append("Incorrect name <expected: \(self.name), received: \(rhs.name)>") }
+        if self.typeName != rhs.typeName { results.append("Incorrect typeName <expected: \(self.typeName), received: \(rhs.typeName)>") }
+        if self.isComputed != rhs.isComputed { results.append("Incorrect isComputed <expected: \(self.isComputed), received: \(rhs.isComputed)>") }
+        if self.isStatic != rhs.isStatic { results.append("Incorrect isStatic <expected: \(self.isStatic), received: \(rhs.isStatic)>") }
+        if self.readAccess != rhs.readAccess { results.append("Incorrect readAccess <expected: \(self.readAccess), received: \(rhs.readAccess)>") }
+        if self.writeAccess != rhs.writeAccess { results.append("Incorrect writeAccess <expected: \(self.writeAccess), received: \(rhs.writeAccess)>") }
+        if self.annotations != rhs.annotations { results.append("Incorrect annotations <expected: \(self.annotations), received: \(rhs.annotations)>") }
 
         return results
     }

--- a/Sourcery/CodeGenerated/Diffable.generated.swift
+++ b/Sourcery/CodeGenerated/Diffable.generated.swift
@@ -9,10 +9,42 @@ extension Enum {
           results.append("Incorrect type <expected: Enum, received: \(type(of: object))>")
           return results
         }
-        if self.cases != rhs.cases { results.append("Incorrect cases <expected: \(self.cases), received: \(rhs.cases)>") }
-        if self.rawType != rhs.rawType { results.append("Incorrect rawType <expected: \(self.rawType), received: \(rhs.rawType)>") }
+         results.append(contentsOf: DiffableResult(identifier: "cases").trackDifference(actual: self.cases, expected: rhs.cases))
+         results.append(contentsOf: DiffableResult(identifier: "rawType").trackDifference(actual: self.rawType, expected: rhs.rawType))
 
         results.append(contentsOf: super.diffAgainst(object))
+        return results
+    }
+}
+
+extension Enum.Case: Diffable {
+    func diffAgainst(_ object: Any?) -> DiffableResult {
+        let results = DiffableResult()
+
+        guard let rhs = object as? Enum.Case else {
+          results.append("Incorrect type <expected: Enum.Case, received: \(type(of: object))>")
+          return results
+        }
+         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: rhs.name))
+         results.append(contentsOf: DiffableResult(identifier: "rawValue").trackDifference(actual: self.rawValue, expected: rhs.rawValue))
+         results.append(contentsOf: DiffableResult(identifier: "associatedValues").trackDifference(actual: self.associatedValues, expected: rhs.associatedValues))
+         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: rhs.annotations))
+
+        return results
+    }
+}
+
+extension Enum.Case.AssociatedValue: Diffable {
+    func diffAgainst(_ object: Any?) -> DiffableResult {
+        let results = DiffableResult()
+
+        guard let rhs = object as? Enum.Case.AssociatedValue else {
+          results.append("Incorrect type <expected: Enum.Case.AssociatedValue, received: \(type(of: object))>")
+          return results
+        }
+         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: rhs.name))
+         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: rhs.typeName))
+
         return results
     }
 }
@@ -43,16 +75,16 @@ extension Type: Diffable {
           results.append("Incorrect type <expected: Type, received: \(type(of: object))>")
           return results
         }
-        if self.typealiases != rhs.typealiases { results.append("Incorrect typealiases <expected: \(self.typealiases), received: \(rhs.typealiases)>") }
-        if self.isExtension != rhs.isExtension { results.append("Incorrect isExtension <expected: \(self.isExtension), received: \(rhs.isExtension)>") }
-        if self.accessLevel != rhs.accessLevel { results.append("Incorrect accessLevel <expected: \(self.accessLevel), received: \(rhs.accessLevel)>") }
-        if self.isGeneric != rhs.isGeneric { results.append("Incorrect isGeneric <expected: \(self.isGeneric), received: \(rhs.isGeneric)>") }
-        if self.localName != rhs.localName { results.append("Incorrect localName <expected: \(self.localName), received: \(rhs.localName)>") }
-        if self.variables != rhs.variables { results.append("Incorrect variables <expected: \(self.variables), received: \(rhs.variables)>") }
-        if self.annotations != rhs.annotations { results.append("Incorrect annotations <expected: \(self.annotations), received: \(rhs.annotations)>") }
-        if self.inheritedTypes != rhs.inheritedTypes { results.append("Incorrect inheritedTypes <expected: \(self.inheritedTypes), received: \(rhs.inheritedTypes)>") }
-        if self.containedTypes != rhs.containedTypes { results.append("Incorrect containedTypes <expected: \(self.containedTypes), received: \(rhs.containedTypes)>") }
-        if self.parentName != rhs.parentName { results.append("Incorrect parentName <expected: \(self.parentName), received: \(rhs.parentName)>") }
+         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: rhs.typealiases))
+         results.append(contentsOf: DiffableResult(identifier: "isExtension").trackDifference(actual: self.isExtension, expected: rhs.isExtension))
+         results.append(contentsOf: DiffableResult(identifier: "accessLevel").trackDifference(actual: self.accessLevel, expected: rhs.accessLevel))
+         results.append(contentsOf: DiffableResult(identifier: "isGeneric").trackDifference(actual: self.isGeneric, expected: rhs.isGeneric))
+         results.append(contentsOf: DiffableResult(identifier: "localName").trackDifference(actual: self.localName, expected: rhs.localName))
+         results.append(contentsOf: DiffableResult(identifier: "variables").trackDifference(actual: self.variables, expected: rhs.variables))
+         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: rhs.annotations))
+         results.append(contentsOf: DiffableResult(identifier: "inheritedTypes").trackDifference(actual: self.inheritedTypes, expected: rhs.inheritedTypes))
+         results.append(contentsOf: DiffableResult(identifier: "containedTypes").trackDifference(actual: self.containedTypes, expected: rhs.containedTypes))
+         results.append(contentsOf: DiffableResult(identifier: "parentName").trackDifference(actual: self.parentName, expected: rhs.parentName))
 
         return results
     }
@@ -66,9 +98,9 @@ extension Typealias: Diffable {
           results.append("Incorrect type <expected: Typealias, received: \(type(of: object))>")
           return results
         }
-        if self.aliasName != rhs.aliasName { results.append("Incorrect aliasName <expected: \(self.aliasName), received: \(rhs.aliasName)>") }
-        if self.typeName != rhs.typeName { results.append("Incorrect typeName <expected: \(self.typeName), received: \(rhs.typeName)>") }
-        if self.parentName != rhs.parentName { results.append("Incorrect parentName <expected: \(self.parentName), received: \(rhs.parentName)>") }
+         results.append(contentsOf: DiffableResult(identifier: "aliasName").trackDifference(actual: self.aliasName, expected: rhs.aliasName))
+         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: rhs.typeName))
+         results.append(contentsOf: DiffableResult(identifier: "parentName").trackDifference(actual: self.parentName, expected: rhs.parentName))
 
         return results
     }
@@ -82,13 +114,13 @@ extension Variable: Diffable {
           results.append("Incorrect type <expected: Variable, received: \(type(of: object))>")
           return results
         }
-        if self.name != rhs.name { results.append("Incorrect name <expected: \(self.name), received: \(rhs.name)>") }
-        if self.typeName != rhs.typeName { results.append("Incorrect typeName <expected: \(self.typeName), received: \(rhs.typeName)>") }
-        if self.isComputed != rhs.isComputed { results.append("Incorrect isComputed <expected: \(self.isComputed), received: \(rhs.isComputed)>") }
-        if self.isStatic != rhs.isStatic { results.append("Incorrect isStatic <expected: \(self.isStatic), received: \(rhs.isStatic)>") }
-        if self.readAccess != rhs.readAccess { results.append("Incorrect readAccess <expected: \(self.readAccess), received: \(rhs.readAccess)>") }
-        if self.writeAccess != rhs.writeAccess { results.append("Incorrect writeAccess <expected: \(self.writeAccess), received: \(rhs.writeAccess)>") }
-        if self.annotations != rhs.annotations { results.append("Incorrect annotations <expected: \(self.annotations), received: \(rhs.annotations)>") }
+         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: rhs.name))
+         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: rhs.typeName))
+         results.append(contentsOf: DiffableResult(identifier: "isComputed").trackDifference(actual: self.isComputed, expected: rhs.isComputed))
+         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: rhs.isStatic))
+         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: rhs.readAccess))
+         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: rhs.writeAccess))
+         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: rhs.annotations))
 
         return results
     }

--- a/Sourcery/Generating/Generator.swift
+++ b/Sourcery/Generating/Generator.swift
@@ -123,6 +123,9 @@ enum Generator {
 
         var processed = [String: Bool]()
         types.forEach { type in
+            if let supertype = type.inheritedTypes.first.flatMap({ typesByName[$0] }), supertype.isClass {
+                type.supertype = supertype
+            }
             processed[type.name] = true
             updateTypeRelationship(for: type, typesByName: typesByName, processed: &processed)
         }

--- a/Sourcery/Generating/Generator.swift
+++ b/Sourcery/Generating/Generator.swift
@@ -49,7 +49,7 @@ private class TypesReflectionBox: NSObject {
     /// Lists all encountered types, even if they are not known e.g. Apple or 3rd party frameworks
     lazy var based: [String: [Type]] = {
         var content = [String: [Type]]()
-        self.all.forEach { type in
+        self.types.forEach { type in
             type.based.keys.forEach { name in
                 var list = content[name] ?? [Type]()
                 list.append(type)
@@ -75,7 +75,7 @@ private class TypesReflectionBox: NSObject {
     /// Contains reference to types implementing any known protocol
     lazy var implementing: [String: [Type]] = {
         var content = [String: [Type]]()
-        self.all.forEach { type in
+        self.types.forEach { type in
             type.implements.keys.forEach { name in
                 var list = content[name] ?? [Type]()
                 list.append(type)

--- a/Sourcery/Models/Diffable.swift
+++ b/Sourcery/Models/Diffable.swift
@@ -21,10 +21,12 @@ protocol Diffable {
 protocol AutoDiffable {}
 
 @objc class DiffableResult: NSObject {
-    private(set) var results: [String]
+    private var results: [String]
+    internal var identifier: String?
 
-    init(results: [String] = []) {
+    init(results: [String] = [], identifier: String? = nil) {
         self.results = results
+        self.identifier = identifier
     }
 
     func append(_ element: String) {
@@ -32,29 +34,50 @@ protocol AutoDiffable {}
     }
 
     func append(contentsOf contents: DiffableResult) {
-        results.append(contentsOf: contents.results)
+        if !contents.isEmpty {
+            results.append(contents.description)
+        }
     }
 
     var isEmpty: Bool { return results.isEmpty }
 
     override var description: String {
-        return results.joined(separator: "\n")
+        guard !results.isEmpty else { return "" }
+        return "\(identifier.flatMap { "\($0) " } ?? "")" + results.joined(separator: "\n")
     }
+}
 
-    func trackDifference<T: Equatable>(actual: T, expected: T) {
+extension DiffableResult {
+
+    @discardableResult func trackDifference<T: Equatable>(actual: T, expected: T) -> DiffableResult {
         if actual != expected {
-            append("Item \(actual) is not equal to \(expected)")
+            let result = DiffableResult(results: ["<expected: \(actual), received: \(expected)>"])
+            append(contentsOf: result)
         }
+        return self
     }
 
-    func trackDifference<T: Equatable>(actual: T, expected: T) where T: Diffable {
-        append(contentsOf: actual.diffAgainst(expected))
+    @discardableResult func trackDifference<T: Equatable>(actual: T?, expected: T?) -> DiffableResult {
+        if actual != expected {
+            let result = DiffableResult(results: ["<expected: \(actual), received: \(expected)>"])
+            append(contentsOf: result)
+        }
+        return self
     }
 
-    func trackDifference<T: Equatable>(actual: [T], expected: [T]) where T: Diffable {
+    @discardableResult func trackDifference<T: Equatable>(actual: T, expected: T) -> DiffableResult where T: Diffable {
+        let diffResult = actual.diffAgainst(expected)
+        append(contentsOf: diffResult)
+        return self
+    }
+
+    @discardableResult func trackDifference<T: Equatable>(actual: [T], expected: [T]) -> DiffableResult where T: Diffable {
+        let diffResult = DiffableResult()
+        defer { append(contentsOf: diffResult) }
+
         guard actual.count == expected.count else {
-            append("Different count \(actual.count) vs \(expected.count)")
-            return
+            diffResult.append("Different count \(actual.count) vs \(expected.count)")
+            return self
         }
 
         for (idx, item) in actual.enumerated() {
@@ -62,25 +85,53 @@ protocol AutoDiffable {}
             diff.trackDifference(actual: item, expected: expected[idx])
             if !diff.isEmpty {
                 let string = "idx \(idx): \(diff)"
-                append(string)
+                diffResult.append(string)
             }
         }
+
+        return self
     }
 
-    func trackDifference<K: Equatable, T: Equatable>(actual: [K: T], expected: [K: T]) where T: Diffable {
+    @discardableResult func trackDifference<T: Equatable>(actual: [T], expected: [T]) -> DiffableResult {
+        let diffResult = DiffableResult()
+        defer { append(contentsOf: diffResult) }
+
+        guard actual.count == expected.count else {
+            diffResult.append("Different count \(actual.count) vs \(expected.count)")
+            return self
+        }
+
+        for (idx, item) in actual.enumerated() {
+            if item != expected[idx] {
+                let string = "idx \(idx): <expected: \(actual), received: \(expected)>"
+                diffResult.append(string)
+            }
+        }
+
+        return self
+    }
+
+    @discardableResult func trackDifference<K: Equatable, T: Equatable>(actual: [K: T], expected: [K: T]) -> DiffableResult where T: Diffable {
+        let diffResult = DiffableResult()
+        defer { append(contentsOf: diffResult) }
+
         guard actual.count == expected.count else {
             append("Different count \(actual.count) vs \(expected.count)")
 
             if expected.count > actual.count {
-                let missingKeys = Array(expected.keys.filter { actual[$0] == nil }.map { String(describing: $0) })
-                append("Missing keys: \(missingKeys.joined(separator: ", "))")
+                let missingKeys = Array(expected.keys.filter {
+                    actual[$0] == nil
+                }.map {
+                    String(describing: $0)
+                })
+                diffResult.append("Missing keys: \(missingKeys.joined(separator: ", "))")
             }
-            return
+            return self
         }
 
         for (key, actualElement) in actual {
             guard let expectedElement = expected[key] else {
-                results.append("Missing key \"\(key)\"")
+                diffResult.append("Missing key \"\(key)\"")
                 continue
             }
 
@@ -88,8 +139,44 @@ protocol AutoDiffable {}
             diff.trackDifference(actual: actualElement, expected: expectedElement)
             if !diff.isEmpty {
                 let string = "key \"\(key)\": \(diff)"
-                results.append(string)
+                diffResult.append(string)
             }
         }
+
+        return self
+    }
+
+// MARK: - NSObject diffing
+
+    @discardableResult func trackDifference<K: Equatable, T: NSObjectProtocol>(actual: [K: T], expected: [K: T]) -> DiffableResult {
+        let diffResult = DiffableResult()
+        defer { append(contentsOf: diffResult) }
+
+        guard actual.count == expected.count else {
+            append("Different count \(actual.count) vs \(expected.count)")
+
+            if expected.count > actual.count {
+                let missingKeys = Array(expected.keys.filter {
+                    actual[$0] == nil
+                    }.map {
+                        String(describing: $0)
+                })
+                diffResult.append("Missing keys: \(missingKeys.joined(separator: ", "))")
+            }
+            return self
+        }
+
+        for (key, actualElement) in actual {
+            guard let expectedElement = expected[key] else {
+                diffResult.append("Missing key \"\(key)\"")
+                continue
+            }
+
+            if !actualElement.isEqual(expectedElement) {
+                diffResult.append("key \"\(key)\": <expected: \(actual), received: \(expected)>")
+            }
+        }
+
+        return self
     }
 }

--- a/Sourcery/Models/Diffable.swift
+++ b/Sourcery/Models/Diffable.swift
@@ -1,0 +1,23 @@
+//
+//  Diffable.swift
+//  Sourcery
+//
+//  Created by Krzysztof Zabłocki on 22/12/2016.
+//  Copyright © 2016 Pixle. All rights reserved.
+//
+
+import Foundation
+
+typealias DiffableResult = [String]
+
+protocol Diffable {
+
+    /// Returns `DiffableResult` for the given objects.
+    ///
+    /// - Parameter object: Object to diff against.
+    /// - Returns: Diffable results.
+    func diffAgainst(_ object: Any?) -> DiffableResult
+}
+
+/// Phantom protocol for code generation
+protocol AutoDiffable {}

--- a/Sourcery/Models/Diffable.swift
+++ b/Sourcery/Models/Diffable.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-typealias DiffableResult = [String]
-
 protocol Diffable {
 
     /// Returns `DiffableResult` for the given objects.
@@ -21,3 +19,77 @@ protocol Diffable {
 
 /// Phantom protocol for code generation
 protocol AutoDiffable {}
+
+@objc class DiffableResult: NSObject {
+    private(set) var results: [String]
+
+    init(results: [String] = []) {
+        self.results = results
+    }
+
+    func append(_ element: String) {
+        results.append(element)
+    }
+
+    func append(contentsOf contents: DiffableResult) {
+        results.append(contentsOf: contents.results)
+    }
+
+    var isEmpty: Bool { return results.isEmpty }
+
+    override var description: String {
+        return results.joined(separator: "\n")
+    }
+
+    func trackDifference<T: Equatable>(actual: T, expected: T) {
+        if actual != expected {
+            append("Item \(actual) is not equal to \(expected)")
+        }
+    }
+
+    func trackDifference<T: Equatable>(actual: T, expected: T) where T: Diffable {
+        append(contentsOf: actual.diffAgainst(expected))
+    }
+
+    func trackDifference<T: Equatable>(actual: [T], expected: [T]) where T: Diffable {
+        guard actual.count == expected.count else {
+            append("Different count \(actual.count) vs \(expected.count)")
+            return
+        }
+
+        for (idx, item) in actual.enumerated() {
+            let diff = DiffableResult()
+            diff.trackDifference(actual: item, expected: expected[idx])
+            if !diff.isEmpty {
+                let string = "idx \(idx): \(diff)"
+                append(string)
+            }
+        }
+    }
+
+    func trackDifference<K: Equatable, T: Equatable>(actual: [K: T], expected: [K: T]) where T: Diffable {
+        guard actual.count == expected.count else {
+            append("Different count \(actual.count) vs \(expected.count)")
+
+            if expected.count > actual.count {
+                let missingKeys = Array(expected.keys.filter { actual[$0] == nil }.map { String(describing: $0) })
+                append("Missing keys: \(missingKeys.joined(separator: ", "))")
+            }
+            return
+        }
+
+        for (key, actualElement) in actual {
+            guard let expectedElement = expected[key] else {
+                results.append("Missing key \"\(key)\"")
+                continue
+            }
+
+            let diff = DiffableResult()
+            diff.trackDifference(actual: actualElement, expected: expectedElement)
+            if !diff.isEmpty {
+                let string = "key \"\(key)\": \(diff)"
+                results.append(string)
+            }
+        }
+    }
+}

--- a/Sourcery/Models/Enum.swift
+++ b/Sourcery/Models/Enum.swift
@@ -6,8 +6,8 @@
 import Foundation
 
 class Enum: Type {
-    class Case: NSObject {
-        class AssociatedValue: NSObject {
+    class Case: NSObject, AutoDiffable {
+        class AssociatedValue: NSObject, AutoDiffable {
             let name: String?
             let typeName: String
 

--- a/Sourcery/Models/Type.swift
+++ b/Sourcery/Models/Type.swift
@@ -99,6 +99,11 @@ class Type: NSObject {
         }
     }
 
+    /// Superclass definition if any
+    /// sourcery: skipEquality
+    /// sourcery: skipDescription
+    var supertype: Type?
+
     /// sourcery: skipEquality
     /// Underlying parser data, never to be used by anything else
     /// sourcery: skipDescription

--- a/Sourcery/Models/Type.swift
+++ b/Sourcery/Models/Type.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Defines Swift Type
-class Type: NSObject {
+class Type: NSObject, AutoDiffable {
 
     /// All local typealiases
     var typealiases: [String: Typealias] {

--- a/Sourcery/Models/Typealias.swift
+++ b/Sourcery/Models/Typealias.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class Typealias: NSObject {
+class Typealias: NSObject, AutoDiffable {
     /// New typealias name
     let aliasName: String
 

--- a/Sourcery/Models/Variable.swift
+++ b/Sourcery/Models/Variable.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Defines a variable
 
-class Variable: NSObject {
+class Variable: NSObject, AutoDiffable {
     /// Variable name
     let name: String
 

--- a/Sourcery/Parsing/Parser.swift
+++ b/Sourcery/Parsing/Parser.swift
@@ -472,12 +472,12 @@ extension Parser {
 
         /// name: type, otherType
         let components = body.components(separatedBy: ",")
-        return components.flatMap { element in
+        return components.enumerated().flatMap { idx, element in
             let nameType = element.components(separatedBy: ":").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
 
             switch nameType.count {
             case 1:
-                return Enum.Case.AssociatedValue(name: nil, typeName: nameType.first ?? "")
+                return Enum.Case.AssociatedValue(name: "\(idx)", typeName: nameType.first ?? "")
             case 2:
                 return Enum.Case.AssociatedValue(name: nameType.first, typeName: nameType.last ?? "")
             default:

--- a/Sourcery/Templates/Diffable.stencil
+++ b/Sourcery/Templates/Diffable.stencil
@@ -2,13 +2,13 @@
 
 extension {{ type.name }}{% if not type.supertype.implements.AutoDiffable %}: Diffable {% endif %} {
     {% if type.based.Type %} override {% endif %}func diffAgainst(_ object: Any?) -> DiffableResult {
-        var results = DiffableResult()
+        let results = DiffableResult()
     {% if type.storedVariables.count %}
         guard let rhs = object as? {{ type.name }} else {
-          results.append("Incorrect type, expected {{ type.name }}, received: \(type(of: object))")
+          results.append("Incorrect type <expected: {{ type.name }}, received: \(type(of: object))>")
           return results
         }
-        {% for variable in type.storedVariables %}{% if not variable.annotations.skipEquality %}if self.{{ variable.name }} != rhs.{{ variable.name }} { results.append("Incorrect {{ variable.name }}, expected \(self.{{variable.name}}), received: \(rhs.{{variable.name}})") }
+        {% for variable in type.storedVariables %}{% if not variable.annotations.skipEquality %}if self.{{ variable.name }} != rhs.{{ variable.name }} { results.append("Incorrect {{ variable.name }} <expected: \(self.{{variable.name}}), received: \(rhs.{{variable.name}})>") }
         {% endif %}{% endfor %}
     {% endif %}
         {% if type.supertype.implements.AutoDiffable %}results.append(contentsOf: super.diffAgainst(object)) {% endif %}

--- a/Sourcery/Templates/Diffable.stencil
+++ b/Sourcery/Templates/Diffable.stencil
@@ -1,0 +1,18 @@
+{% for type in types.implementing.AutoDiffable %}
+
+extension {{ type.name }}{% if not type.supertype.implements.AutoDiffable %}: Diffable {% endif %} {
+    {% if type.based.Type %} override {% endif %}func diffAgainst(_ object: Any?) -> DiffableResult {
+        var results = DiffableResult()
+    {% if type.storedVariables.count %}
+        guard let rhs = object as? {{ type.name }} else {
+          results.append("Incorrect type, expected {{ type.name }}, received: \(type(of: object))")
+          return results
+        }
+        {% for variable in type.storedVariables %}{% if not variable.annotations.skipEquality %}if self.{{ variable.name }} != rhs.{{ variable.name }} { results.append("Incorrect {{ variable.name }}, expected \(self.{{variable.name}}), received: \(rhs.{{variable.name}})") }
+        {% endif %}{% endfor %}
+    {% endif %}
+        {% if type.supertype.implements.AutoDiffable %}results.append(contentsOf: super.diffAgainst(object)) {% endif %}
+        return results
+    }
+}
+{% endfor %}

--- a/Sourcery/Templates/Diffable.stencil
+++ b/Sourcery/Templates/Diffable.stencil
@@ -8,7 +8,7 @@ extension {{ type.name }}{% if not type.supertype.implements.AutoDiffable %}: Di
           results.append("Incorrect type <expected: {{ type.name }}, received: \(type(of: object))>")
           return results
         }
-        {% for variable in type.storedVariables %}{% if not variable.annotations.skipEquality %}if self.{{ variable.name }} != rhs.{{ variable.name }} { results.append("Incorrect {{ variable.name }} <expected: \(self.{{variable.name}}), received: \(rhs.{{variable.name}})>") }
+        {% for variable in type.storedVariables %}{% if not variable.annotations.skipEquality %} results.append(contentsOf: DiffableResult(identifier: "{{ variable.name }}").trackDifference(actual: self.{{ variable.name }}, expected: rhs.{{ variable.name }}))
         {% endif %}{% endfor %}
     {% endif %}
         {% if type.supertype.implements.AutoDiffable %}results.append(contentsOf: super.diffAgainst(object)) {% endif %}

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -98,6 +98,10 @@ class GeneratorSpec: QuickSpec {
                    expect(generate("{{ type.Complex.accessLevel }}")).to(equal("public"))
                 }
 
+                it("can access supertype") {
+                    expect(generate("{{ type.FooSubclass.supertype.name }}")).to(equal("Foo"))
+                }
+
                 it("generates type.TypeName") {
                     expect(generate("{{ type.Foo.name }} has {{ type.Foo.variables.first.name }} variable")).to(equal("Foo has intValue variable"))
                 }

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -69,7 +69,7 @@ class GeneratorSpec: QuickSpec {
             }
 
             it("feeds types.implementing specific protocol") {
-                expect(generate("Found {{ types.implementing.KnownProtocol.count }} types")).to(equal("Found 6 types"))
+                expect(generate("Found {{ types.implementing.KnownProtocol.count }} types")).to(equal("Found 7 types"))
                 expect(generate("Found {{ types.implementing.Decodable.count|default:\"0\" }} types")).to(equal("Found 0 types"))
                 expect(generate("Found {{ types.implementing.Foo.count|default:\"0\" }} types")).to(equal("Found 0 types"))
                 expect(generate("Found {{ types.implementing.NSObject.count|default:\"0\" }} types")).to(equal("Found 0 types"))
@@ -85,7 +85,7 @@ class GeneratorSpec: QuickSpec {
             }
 
             it("feeds types.based specific type or protocol") {
-                expect(generate("Found {{ types.based.KnownProtocol.count }} types")).to(equal("Found 6 types"))
+                expect(generate("Found {{ types.based.KnownProtocol.count }} types")).to(equal("Found 7 types"))
                 expect(generate("Found {{ types.based.Decodable.count }} types")).to(equal("Found 4 types"))
                 expect(generate("Found {{ types.based.Foo.count }} types")).to(equal("Found 2 types"))
                 expect(generate("Found {{ types.based.NSObject.count }} types")).to(equal("Found 1 types"))

--- a/SourceryTests/Helpers/CustomMatchers.swift
+++ b/SourceryTests/Helpers/CustomMatchers.swift
@@ -1,0 +1,112 @@
+//
+// Created by Krzysztof Zabłocki on 22/12/2016.
+// Copyright (c) 2016 Pixle. All rights reserved.
+//
+
+@testable
+import Sourcery
+
+import Nimble
+import Quick
+
+/// A Nimble matcher that succeeds when the actual value is equal to the expected value.
+/// Values can support equal by supporting the Equatable protocol.
+///
+/// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
+public func equal<T: Equatable>(_ expectedValue: T?) -> NonNilMatcherFunc<T> where T: Diffable {
+    return NonNilMatcherFunc { actualExpression, failureMessage in
+        failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
+        let actualValue = try actualExpression.evaluate()
+        let matches = actualValue == expectedValue && expectedValue != nil
+        if expectedValue == nil || actualValue == nil {
+            if expectedValue == nil {
+                failureMessage.postfixActual = " (use beNil() to match nils)"
+            }
+            return false
+        }
+
+        if !matches, let result = expectedValue?.diffAgainst(actualValue) {
+            prepare(failureMessage, results: result, actual: stringify(actualValue))
+        }
+        return matches
+    }
+}
+
+/// A Nimble matcher that succeeds when the actual collection is equal to the expected collection.
+/// Items must implement the Equatable protocol.
+public func equal<T: Equatable>(_ expectedValue: [T]?) -> NonNilMatcherFunc<[T]> where T: Diffable {
+    return NonNilMatcherFunc { actualExpression, failureMessage in
+        failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
+        let actualValue = try actualExpression.evaluate()
+        if expectedValue == nil || actualValue == nil {
+            if expectedValue == nil {
+                failureMessage.postfixActual = " (use beNil() to match nils)"
+            }
+            return false
+        }
+
+        // swiftlint:disable:next force_unwrapping
+        let matches = expectedValue! == actualValue!
+
+        if !matches, let expected = expectedValue, let actual = actualValue, actual.count == expected.count {
+            var results = DiffableResult()
+            for (idx, item) in expected.enumerated() {
+                let diff = item.diffAgainst(actual[idx])
+                if !diff.isEmpty {
+                    let string = "idx \(idx): " + diff.joined(separator: "\n")
+                    results.append(string)
+                }
+            }
+
+            prepare(failureMessage, results: results, actual: stringify(actual))
+        }
+
+        return matches
+    }
+}
+
+/// A Nimble matcher that succeeds when the actual value is equal to the expected value.
+/// Values can support equal by supporting the Equatable protocol.
+///
+/// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
+public func equal<T: Equatable, C: Equatable>(_ expectedValue: [T: C]?) -> NonNilMatcherFunc<[T: C]> where C: Diffable {
+    return NonNilMatcherFunc { actualExpression, failureMessage in
+        failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
+        let actualValue = try actualExpression.evaluate()
+        if expectedValue == nil || actualValue == nil {
+            if expectedValue == nil {
+                failureMessage.postfixActual = " (use beNil() to match nils)"
+            }
+            return false
+        }
+
+        // swiftlint:disable:next force_unwrapping
+        let matches = expectedValue! == actualValue!
+
+        if !matches, let expected = expectedValue, let actual = actualValue, actual.keys.count == expected.keys.count {
+            var results = DiffableResult()
+            for (key, item) in expected {
+                guard let actualItem = actual[key] else {
+                    results.append("Missing item for \"\(key)\"")
+                    continue
+                }
+
+                let diff = item.diffAgainst(actualItem)
+                if !diff.isEmpty {
+                    let string = "key \"\(key)\": " + diff.joined(separator: "\n")
+                    results.append(string)
+                }
+            }
+
+            prepare(failureMessage, results: results, actual: stringify(actual))
+        }
+
+        return matches
+    }
+}
+
+fileprivate func prepare(_ message: FailureMessage, results: DiffableResult, actual: String) {
+    if !results.isEmpty {
+        message.stringValue = results.joined(separator: "\n") + "\n Actual: \(actual)\(message.postfixActual)"
+    }
+}

--- a/SourceryTests/Models/DiffableSpec.swift
+++ b/SourceryTests/Models/DiffableSpec.swift
@@ -1,0 +1,123 @@
+//
+// Created by Krzysztof Zabłocki on 23/12/2016.
+// Copyright (c) 2016 Pixle. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import Sourcery
+
+class DiffableSpec: QuickSpec {
+    override func spec() {
+        describe ("DiffableResults") {
+            var sut = DiffableResult()
+
+            beforeEach {
+                sut = DiffableResult()
+            }
+
+            describe("isEmpty") {
+                context("given its empty") {
+                    it("returns true") {
+                        expect(sut.isEmpty).to(beTrue())
+                    }
+                }
+
+                context("given its not empty") {
+                    it("returns false") {
+                        sut.append("Something")
+
+                        expect(sut.isEmpty).to(beFalse())
+                    }
+                }
+            }
+
+            it("appends element") {
+                sut.append("Expected value")
+
+                expect("\(sut)").to(equal("Expected value"))
+            }
+
+            it("ads newline separator between elements") {
+                sut.append("Value 1")
+                sut.append("Value 2")
+
+                expect("\(sut)").to(equal("Value 1\nValue 2"))
+            }
+
+            it("joins 2 diffable results") {
+                sut.append("Value 1")
+                sut.append(contentsOf: DiffableResult(results: ["Value 2"]))
+
+                expect("\(sut)").to(equal("Value 1\nValue 2"))
+            }
+
+            describe("trackDifference") {
+                context("given not diffable elements") {
+                    it("ads them if they aren't equal") {
+                        sut.trackDifference(actual: 3, expected: 5)
+
+                        expect("\(sut)").to(equal("Item 3 is not equal to 5"))
+                    }
+
+                    it("doesn't add them if they are equal") {
+                        sut.trackDifference(actual: 3, expected: 3)
+
+                        expect("\(sut)").to(equal(""))
+                    }
+                }
+
+                context("given diffable elements") {
+                    it("ads them if they aren't equal") {
+                        sut.trackDifference(actual: Type(name: "Foo"), expected: Type(name: "Bar"))
+
+                        expect("\(sut)").to(equal("Incorrect localName <expected: Foo, received: Bar>"))
+                    }
+
+                    it("doesn't add them if they are equal") {
+                        sut.trackDifference(actual: Type(name: "Foo"), expected: Type(name: "Foo"))
+
+                        expect("\(sut)").to(equal(""))
+                    }
+
+                    context("given arrays") {
+                        it("finds difference in count") {
+                            sut.trackDifference(
+                                    actual: [Type(name: "Foo")],
+                                    expected: [Type(name: "Foo"), Type(name: "Foo2")])
+
+                            expect("\(sut)").to(equal("Different count 1 vs 2"))
+                        }
+
+                        it("finds difference at given idx count") {
+                            sut.trackDifference(
+                                    actual: [Type(name: "Foo"), Type(name: "Foo")],
+                                    expected: [Type(name: "Foo"), Type(name: "Foo2")])
+
+                            expect("\(sut)").to(equal("idx 1: Incorrect localName <expected: Foo, received: Foo2>"))
+                        }
+                    }
+
+                    context("given dictionaries") {
+                        it("finds difference in count") {
+                            sut.trackDifference(
+                                    actual: ["Key": Type(name: "Foo")],
+                                    expected: ["Key": Type(name: "Foo"), "Something": Type(name: "Bar")])
+
+                            expect("\(sut)").to(equal("Different count 1 vs 2\nMissing keys: Something"))
+                        }
+
+                        it("finds difference at given key count") {
+                            sut.trackDifference(
+                                    actual: ["Key": Type(name: "Foo"), "Something": Type(name: "FooBar")],
+                                    expected: ["Key": Type(name: "Foo"), "Something": Type(name: "Bar")])
+
+                            expect("\(sut)").to(equal("key \"Something\": Incorrect localName <expected: FooBar, received: Bar>"))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SourceryTests/Models/DiffableSpec.swift
+++ b/SourceryTests/Models/DiffableSpec.swift
@@ -46,6 +46,14 @@ class DiffableSpec: QuickSpec {
                 expect("\(sut)").to(equal("Value 1\nValue 2"))
             }
 
+            it("processes identifier for all elements") {
+                sut.identifier = "Prefixed"
+                sut.append("Value 1")
+                sut.append("Value 2")
+
+                expect("\(sut)").to(equal("Prefixed Value 1\nValue 2"))
+            }
+
             it("joins 2 diffable results") {
                 sut.append("Value 1")
                 sut.append(contentsOf: DiffableResult(results: ["Value 2"]))
@@ -58,7 +66,7 @@ class DiffableSpec: QuickSpec {
                     it("ads them if they aren't equal") {
                         sut.trackDifference(actual: 3, expected: 5)
 
-                        expect("\(sut)").to(equal("Item 3 is not equal to 5"))
+                        expect("\(sut)").to(equal("<expected: 3, received: 5>"))
                     }
 
                     it("doesn't add them if they are equal") {
@@ -72,7 +80,7 @@ class DiffableSpec: QuickSpec {
                     it("ads them if they aren't equal") {
                         sut.trackDifference(actual: Type(name: "Foo"), expected: Type(name: "Bar"))
 
-                        expect("\(sut)").to(equal("Incorrect localName <expected: Foo, received: Bar>"))
+                        expect("\(sut)").to(equal("localName <expected: Foo, received: Bar>"))
                     }
 
                     it("doesn't add them if they are equal") {
@@ -90,12 +98,20 @@ class DiffableSpec: QuickSpec {
                             expect("\(sut)").to(equal("Different count 1 vs 2"))
                         }
 
-                        it("finds difference at given idx count") {
+                        it("finds difference at given idx") {
                             sut.trackDifference(
                                     actual: [Type(name: "Foo"), Type(name: "Foo")],
                                     expected: [Type(name: "Foo"), Type(name: "Foo2")])
 
-                            expect("\(sut)").to(equal("idx 1: Incorrect localName <expected: Foo, received: Foo2>"))
+                            expect("\(sut)").to(equal("idx 1: localName <expected: Foo, received: Foo2>"))
+                        }
+
+                        it("finds difference at multiple idx") {
+                            sut.trackDifference(
+                                    actual: [Type(name: "FooBar"), Type(name: "Foo")],
+                                    expected: [Type(name: "Foo"), Type(name: "Foo2")])
+
+                            expect("\(sut)").to(equal("idx 0: localName <expected: FooBar, received: Foo>\nidx 1: localName <expected: Foo, received: Foo2>"))
                         }
                     }
 
@@ -113,7 +129,7 @@ class DiffableSpec: QuickSpec {
                                     actual: ["Key": Type(name: "Foo"), "Something": Type(name: "FooBar")],
                                     expected: ["Key": Type(name: "Foo"), "Something": Type(name: "Bar")])
 
-                            expect("\(sut)").to(equal("key \"Something\": Incorrect localName <expected: FooBar, received: Bar>"))
+                            expect("\(sut)").to(equal("key \"Something\": localName <expected: FooBar, received: Bar>"))
                         }
                     }
                 }

--- a/SourceryTests/ParserSpec.swift
+++ b/SourceryTests/ParserSpec.swift
@@ -403,7 +403,7 @@ class ParserSpec: QuickSpec {
                         expect(parse("enum Foo {\n // sourcery: annotation\ncase optionA(Int)\n case optionB }"))
                                 .to(equal([
                                         Enum(name: "Foo", cases: [Enum.Case(name: "optionA",
-                                                associatedValues: [Enum.Case.AssociatedValue(name: nil, typeName: "Int")],
+                                                associatedValues: [Enum.Case.AssociatedValue(name: "0", typeName: "Int")],
                                                 annotations: ["annotation": NSNumber(value: true)]), Enum.Case(name: "optionB")])
                                 ]))
                     }
@@ -480,7 +480,7 @@ class ParserSpec: QuickSpec {
                                 .to(equal([
                                     Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases:
                                         [
-                                            Enum.Case(name: "optionA", associatedValues: [Enum.Case.AssociatedValue(name: nil, typeName: "Observable<Int>")]),
+                                            Enum.Case(name: "optionA", associatedValues: [Enum.Case.AssociatedValue(name: "0", typeName: "Observable<Int>")]),
                                             Enum.Case(name: "optionB", associatedValues: [Enum.Case.AssociatedValue(name: "named", typeName: "Float")])
                                         ])
                                 ]))


### PR DESCRIPTION
When working on tests I often find myself having to scan a lot of logs just to see whats different, this is annoying. 

I've implemented diffing for tests.

From this:
<img width="600" alt="before" src="https://cloud.githubusercontent.com/assets/1468993/21425370/0e3dd990-c849-11e6-877a-6dc80ae8f039.png">

to this:

<img width="373" alt="after" src="https://cloud.githubusercontent.com/assets/1468993/21425376/11e9ad94-c849-11e6-882a-e7927a3b2b08.png">