### PR TITLE
Add type for Enum.Case.AssociatedValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Sourcery CHANGELOG
 
 ---
+
+## Master
+### New Features
+
+- You can now access types of enum's associated values
+
 ## 0.4.8
 ### New Features
 - You can now access `supertype` of a class

--- a/Sourcery/CodeGenerated/Equality.generated.swift
+++ b/Sourcery/CodeGenerated/Equality.generated.swift
@@ -1,5 +1,14 @@
-// Generated using Sourcery 0.4.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.4.8 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
+
+extension DiffableResult {
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? DiffableResult else { return false }
+        if self.identifier != rhs.identifier { return false }
+
+        return true
+    }
+}
 
 extension Enum {
     override func isEqual(_ object: Any?) -> Bool {
@@ -28,6 +37,7 @@ extension Enum.Case.AssociatedValue {
         guard let rhs = object as? Enum.Case.AssociatedValue else { return false }
         if self.name != rhs.name { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.type != rhs.type { return false }
 
         return true
     }

--- a/Sourcery/Models/Enum.swift
+++ b/Sourcery/Models/Enum.swift
@@ -15,6 +15,25 @@ class Enum: Type {
             /// sourcery: skipDescription
             var type: Type?
 
+            /// Is the variable optional?
+            var isOptional: Bool {
+                if typeName.hasSuffix("?") || typeName.hasPrefix("Optional<") {
+                    return true
+                }
+                return false
+            }
+
+            /// sourcery: skipEquality
+            /// sourcery: skipDescription
+            var unwrappedTypeName: String {
+                guard isOptional else { return typeName }
+                if typeName.hasSuffix("?") {
+                    return String(typeName.characters.dropLast())
+                } else {
+                    return String(typeName.characters.dropFirst("Optional<".characters.count).dropLast())
+                }
+            }
+
             init(name: String?, typeName: String) {
                 self.name = name
                 self.typeName = typeName

--- a/Sourcery/Models/Enum.swift
+++ b/Sourcery/Models/Enum.swift
@@ -11,6 +11,10 @@ class Enum: Type {
             let name: String?
             let typeName: String
 
+            /// sourcery: skipEquality
+            /// sourcery: skipDescription
+            var type: Type?
+
             init(name: String?, typeName: String) {
                 self.name = name
                 self.typeName = typeName

--- a/Sourcery/Models/Enum.swift
+++ b/Sourcery/Models/Enum.swift
@@ -11,7 +11,6 @@ class Enum: Type {
             let name: String?
             let typeName: String
 
-            /// sourcery: skipEquality
             /// sourcery: skipDescription
             var type: Type?
 
@@ -23,7 +22,6 @@ class Enum: Type {
                 return false
             }
 
-            /// sourcery: skipEquality
             /// sourcery: skipDescription
             var unwrappedTypeName: String {
                 guard isOptional else { return typeName }

--- a/Sourcery/Parsing/Parser.swift
+++ b/Sourcery/Parsing/Parser.swift
@@ -377,7 +377,11 @@ final class Parser {
             if let enumeration = type as? Enum, enumeration.rawType == nil {
                 enumeration.cases.forEach { enumCase in
                     enumCase.associatedValues.forEach { associatedValue in
-                        associatedValue.type = unique[associatedValue.typeName]
+                        if let actualTypeName = typeName(for: associatedValue.unwrappedTypeName) {
+                            associatedValue.type = unique[actualTypeName]
+                        } else {
+                            associatedValue.type = unique[associatedValue.unwrappedTypeName]
+                        }
                     }
                 }
 

--- a/Sourcery/Parsing/Parser.swift
+++ b/Sourcery/Parsing/Parser.swift
@@ -375,6 +375,12 @@ final class Parser {
 
         for (_, type) in unique {
             if let enumeration = type as? Enum, enumeration.rawType == nil {
+                enumeration.cases.forEach { enumCase in
+                    enumCase.associatedValues.forEach { associatedValue in
+                        associatedValue.type = unique[associatedValue.typeName]
+                    }
+                }
+
                 guard let rawTypeName = enumeration.inheritedTypes.first else { continue }
                 if let rawTypeCandidate = unique[rawTypeName] {
                     if !(rawTypeCandidate is Protocol) {

--- a/SourceryTests/ParserSpec.swift
+++ b/SourceryTests/ParserSpec.swift
@@ -496,6 +496,74 @@ class ParserSpec: QuickSpec {
                                                   ])
                                           ]))
                     }
+
+                    context("given associated value with its type existing") {
+
+                        it("extracts associated value's type") {
+                            let types = parse("protocol Baz {}; class Bar: Baz {}; enum Foo { case optionA(key: Bar) }")
+                            let enumeration = types[2] as? Enum
+                            let enumCases = enumeration?.cases
+                            expect(enumCases?.count) == 1
+
+                            let associatedValues = enumCases?.first?.associatedValues
+                            expect(associatedValues?.count) == 1
+
+                            let associatedValue = associatedValues?.first
+                            expect(associatedValue?.name) == "key"
+                            expect(associatedValue?.typeName) == "Bar"
+                            expect(associatedValue?.type?.name) == "Bar"
+                            expect(associatedValue?.type?.inheritedTypes) == ["Baz"]
+                        }
+
+                        it("extracts associated value's optional type") {
+                            let types = parse("protocol Baz {}; class Bar: Baz {}; enum Foo { case optionA(key: Bar?) }")
+                            let enumeration = types[2] as? Enum
+                            let enumCases = enumeration?.cases
+                            expect(enumCases?.count) == 1
+
+                            let associatedValues = enumCases?.first?.associatedValues
+                            expect(associatedValues?.count) == 1
+
+                            let associatedValue = associatedValues?.first
+                            expect(associatedValue?.name) == "key"
+                            expect(associatedValue?.typeName) == "Bar?"
+                            expect(associatedValue?.type?.name) == "Bar"
+                            expect(associatedValue?.type?.inheritedTypes) == ["Baz"]
+                        }
+
+                        it("extracts associated value's typealias") {
+                            let types = parse("typealias Bar2 = Bar; protocol Baz {}; class Bar: Baz {}; enum Foo { case optionA(key: Bar2) }")
+                            let enumeration = types[2] as? Enum
+                            let enumCases = enumeration?.cases
+                            expect(enumCases?.count) == 1
+
+                            let associatedValues = enumCases?.first?.associatedValues
+                            expect(associatedValues?.count) == 1
+
+                            let associatedValue = associatedValues?.first
+                            expect(associatedValue?.name) == "key"
+                            expect(associatedValue?.typeName) == "Bar2"
+                            expect(associatedValue?.type?.name) == "Bar"
+                            expect(associatedValue?.type?.inheritedTypes) == ["Baz"]
+                        }
+
+                        it("extracts associated value's same (indirect) enum type") {
+                            let types = parse("protocol Baz {}; indirect enum Foo: Baz { case optionA(key: Foo) }")
+                            let enumeration = types[1] as? Enum
+                            let enumCases = enumeration?.cases
+                            expect(enumCases?.count) == 1
+
+                            let associatedValues = enumCases?.first?.associatedValues
+                            expect(associatedValues?.count) == 1
+
+                            let associatedValue = associatedValues?.first
+                            expect(associatedValue?.name) == "key"
+                            expect(associatedValue?.typeName) == "Foo"
+                            expect(associatedValue?.type?.name) == "Foo"
+                            expect(associatedValue?.type?.inheritedTypes) == ["Baz"]
+                        }
+
+                    }
                 }
 
                 context("given protocol") {

--- a/SourceryTests/ParserSpec.swift
+++ b/SourceryTests/ParserSpec.swift
@@ -509,10 +509,9 @@ class ParserSpec: QuickSpec {
                             expect(associatedValues?.count) == 1
 
                             let associatedValue = associatedValues?.first
-                            expect(associatedValue?.name) == "key"
-                            expect(associatedValue?.typeName) == "Bar"
-                            expect(associatedValue?.type?.name) == "Bar"
-                            expect(associatedValue?.type?.inheritedTypes) == ["Baz"]
+                            let expectedAssociatedValue = Enum.Case.AssociatedValue(name: "key", typeName: "Bar")
+                            expectedAssociatedValue.type = Type(name: "Bar", inheritedTypes: ["Baz"])
+                            expect(associatedValue) == expectedAssociatedValue
                         }
 
                         it("extracts associated value's optional type") {
@@ -525,10 +524,9 @@ class ParserSpec: QuickSpec {
                             expect(associatedValues?.count) == 1
 
                             let associatedValue = associatedValues?.first
-                            expect(associatedValue?.name) == "key"
-                            expect(associatedValue?.typeName) == "Bar?"
-                            expect(associatedValue?.type?.name) == "Bar"
-                            expect(associatedValue?.type?.inheritedTypes) == ["Baz"]
+                            let expectedAssociatedValue = Enum.Case.AssociatedValue(name: "key", typeName: "Bar?")
+                            expectedAssociatedValue.type = Type(name: "Bar", inheritedTypes: ["Baz"])
+                            expect(associatedValue) == expectedAssociatedValue
                         }
 
                         it("extracts associated value's typealias") {
@@ -541,10 +539,9 @@ class ParserSpec: QuickSpec {
                             expect(associatedValues?.count) == 1
 
                             let associatedValue = associatedValues?.first
-                            expect(associatedValue?.name) == "key"
-                            expect(associatedValue?.typeName) == "Bar2"
-                            expect(associatedValue?.type?.name) == "Bar"
-                            expect(associatedValue?.type?.inheritedTypes) == ["Baz"]
+                            let expectedAssociatedValue = Enum.Case.AssociatedValue(name: "key", typeName: "Bar2")
+                            expectedAssociatedValue.type = Type(name: "Bar", inheritedTypes: ["Baz"])
+                            expect(associatedValue) == expectedAssociatedValue
                         }
 
                         it("extracts associated value's same (indirect) enum type") {
@@ -557,10 +554,9 @@ class ParserSpec: QuickSpec {
                             expect(associatedValues?.count) == 1
 
                             let associatedValue = associatedValues?.first
-                            expect(associatedValue?.name) == "key"
-                            expect(associatedValue?.typeName) == "Foo"
-                            expect(associatedValue?.type?.name) == "Foo"
-                            expect(associatedValue?.type?.inheritedTypes) == ["Baz"]
+                            let expectedAssociatedValue = Enum.Case.AssociatedValue(name: "key", typeName: "Foo")
+                            expectedAssociatedValue.type = Enum(name: "Foo", inheritedTypes: ["Baz"], cases: enumCases!)
+                            expect(associatedValue) == expectedAssociatedValue
                         }
 
                     }


### PR DESCRIPTION
Hi @krzysztofzablocki !
I want to examine what protocol is used in `Enum.Case.AssociatedValue`'s type,
but currently `typeName` is only supported, and I think we need `type` accessor too,
just as `Variable` has.

### Stencil example

```
{% for inherited in case.associatedValues.0.type.inheritedTypes %}
{% if inherited == "SomeProtocol" %}
// do something
{% endif %}
{% endfor %}
```

