### PR TITLE
Enabled workaround for enums raw types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### New Features
 - You can now pass arbitrary values to templates with `--args` argument.
 - Added `open` access level
+- Now you can avoid inferring unknown protocols as enum raw types by adding conformance in extension (instead of `enum Foo: Equatable {}` do `enum Foo {}; extension Foo: Equatable {}`)
 
 ### Internal changes
 - Refactor code around typenames

--- a/Sourcery/Models/Enum.swift
+++ b/Sourcery/Models/Enum.swift
@@ -51,6 +51,7 @@ class Enum: Type {
     internal(set) var rawType: String? {
         didSet {
             if let rawType = rawType {
+                hasRawType = true
                 if let index = inheritedTypes.index(of: rawType) {
                     inheritedTypes.remove(at: index)
                 }
@@ -60,6 +61,8 @@ class Enum: Type {
             }
         }
     }
+
+    private(set) var hasRawType: Bool
 
     /// sourcery: skipEquality
     /// sourcery: skipDescription
@@ -93,10 +96,13 @@ class Enum: Type {
 
         self.cases = cases
         self.rawType = rawType
+        self.hasRawType = rawType != nil || !inheritedTypes.isEmpty
+
         super.init(name: name, accessLevel: accessLevel, isExtension: isExtension, variables: variables, methods: methods, inheritedTypes: inheritedTypes, containedTypes: containedTypes, typealiases: typealiases)
 
         if let rawType = rawType, let index = self.inheritedTypes.index(of: rawType) {
             self.inheritedTypes.remove(at: index)
         }
     }
+
 }

--- a/Sourcery/Parsing/Parser.swift
+++ b/Sourcery/Parsing/Parser.swift
@@ -393,7 +393,7 @@ final class Parser {
                     }
                 }
 
-                guard let rawTypeName = enumeration.inheritedTypes.first else { continue }
+                guard enumeration.hasRawType, let rawTypeName = enumeration.inheritedTypes.first else { continue }
                 if let rawTypeCandidate = unique[rawTypeName] {
                     if !(rawTypeCandidate is Protocol) {
                         enumeration.rawType = rawTypeCandidate.name

--- a/SourceryTests/ParserSpec.swift
+++ b/SourceryTests/ParserSpec.swift
@@ -561,6 +561,7 @@ class ParserSpec: QuickSpec {
                                     Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["SomeProtocol"], rawType: nil, cases: [Enum.Case(name: "optionA")]),
                                     Protocol(name: "SomeProtocol")
                                     ]))
+
                         }
 
                         it("extracts types inherited in extension properly") {
@@ -570,6 +571,16 @@ class ParserSpec: QuickSpec {
                                     Protocol(name: "SomeProtocol")
                                     ]))
                         }
+
+                        it("does not use extension to infer rawType") {
+                            expect(parse("enum Foo { case one }; extension Foo: Equatable {}")).to(equal([
+                                Enum(name: "Foo",
+                                     inheritedTypes: ["Equatable"],
+                                     cases: [Enum.Case(name: "one")]
+                                )
+                                ]))
+                        }
+
                     }
 
                     context("given enum containing rawType") {
@@ -618,12 +629,13 @@ class ParserSpec: QuickSpec {
                                 ]))
                         }
 
-                        it("extracts enums with custom values") {
-                            expect(parse("enum Foo: String { case optionA = \"Value\" }"))
-                                .to(equal([
-                                    Enum(name: "Foo", accessLevel: .internal, isExtension: false, rawType: "String", cases: [Enum.Case(name: "optionA", rawValue: "Value")])
-                                    ]))
-                        }
+                    }
+
+                    it("extracts enums with custom values") {
+                        expect(parse("enum Foo: String { case optionA = \"Value\" }"))
+                            .to(equal([
+                                Enum(name: "Foo", accessLevel: .internal, isExtension: false, rawType: "String", cases: [Enum.Case(name: "optionA", rawValue: "Value")])
+                                ]))
                     }
 
                     it("extracts enums without rawType") {


### PR DESCRIPTION
Enables workaround mentioned in #85  - `enum Foo { }; extension Foo: Equatable {}` will not infer `Equatable` as `rawType`