### PR TITLE
Add support for special escaped enum cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### New Features
 - Variables with default initializer are now supported, e.g. `var variable = Type(...)`
+- Added support for special escaped names in enum cases e.g. `default` or `for`
 
 ### Bug Fixes
 - Using protocols doesn't expose variables using KVC, which meant some of the typeName properties weren't accessible via Templates, we fixed that using Sourcery itself to generate specific functions.

--- a/Sourcery/Parsing/Utils/Substring.swift
+++ b/Sourcery/Parsing/Utils/Substring.swift
@@ -33,7 +33,7 @@ internal enum Substring {
         case .nameSuffix:
             if let name = Substring.name.range(for: source), let key = Substring.key.range(for: source) {
                 let nameEnd = name.offset + name.length
-                return (name.offset + name.length, key.offset + key.length - nameEnd)
+                return (nameEnd, key.offset + key.length - nameEnd)
             }
         case .keyPrefix:
             return Substring.key.range(for: source).flatMap { (offset: 0, length: $0.offset) }

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -327,6 +327,18 @@ class FileParserSpec: QuickSpec {
                                 ]))
                     }
 
+                    it("extracts cases with special names") {
+                        expect(parse("enum Foo { case `default`; case `for`(something: Int, else: Float, `default`: Bool) }"))
+                                .to(equal([
+                                                  Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [Enum.Case(name: "default"), Enum.Case(name: "for", associatedValues:
+                                                  [
+                                                          Enum.Case.AssociatedValue(name: "something", typeName: "Int"),
+                                                          Enum.Case.AssociatedValue(name: "else", typeName: "Float"),
+                                                          Enum.Case.AssociatedValue(name: "default", typeName: "Bool"),
+                                                  ])])
+                                          ]))
+                    }
+
                     it("extracts multi-byte cases properly") {
                         expect(parse("enum JapaneseEnum {\ncase アイウエオ\n}"))
                             .to(equal([


### PR DESCRIPTION
This will allow us to parse `default` `for` etc cases