### PR TITLE
Enable multi-threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Sourcery CHANGELOG
 
 ---
+## Master
+
+### New Features
+- Sourcery will now use parallel parsing, expect more than 2x as fast execution 🚤 .
+
+### Bug Fixes
+
+### Internal Changes
+
+
 ## 0.5.1
 
 ### New Features

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		E291D8C0F0FE5B3DF91025CC /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DA16190CED2907BDEA06 /* Generator.swift */; };
 		E291D8DB06EC63770326562B /* Type+Stencil.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D04C9425FA502B37895D /* Type+Stencil.swift */; };
 		E291D90EC943AC5CBA99899A /* ComposerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DFE1A3D6905537EE86D9 /* ComposerSpec.swift */; };
+		E291D9FBE0B751C3C898E5B6 /* Array+Parallel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D6548CB0B086F0574D1B /* Array+Parallel.swift */; };
 		E291DA3352C0EDD1EB8DDCB3 /* FileParser+VariableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D37EF6AA39833209828F /* FileParser+VariableSpec.swift */; };
 		E291DBF5DD36D79E01E41270 /* TypeReflectionBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DBEB509979F90A2BDF94 /* TypeReflectionBox.swift */; };
 		E291DC5F2343BF3DE3334986 /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D2450093BB4B3A9ADFEC /* Stubs.swift */; };
@@ -138,6 +139,7 @@
 		E291D3D222F05C42C246CB73 /* EnumSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumSpec.swift; sourceTree = "<group>"; };
 		E291D3DB89E4D87FE8CB1A33 /* Composer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Composer.swift; sourceTree = "<group>"; };
 		E291D5CD7EEDC70CB423C0BE /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		E291D6548CB0B086F0574D1B /* Array+Parallel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Parallel.swift"; sourceTree = "<group>"; };
 		E291D86E6DD88E4A47D9BBD6 /* TypeName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeName.swift; sourceTree = "<group>"; };
 		E291D8D53A557DA9E6D27C3C /* VariableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableSpec.swift; sourceTree = "<group>"; };
 		E291DA16190CED2907BDEA06 /* Generator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Generator.swift; sourceTree = "<group>"; };
@@ -368,6 +370,7 @@
 			isa = PBXGroup;
 			children = (
 				E291DBAA16ABFED8C04CB42A /* FolderWatcher.swift */,
+				E291D6548CB0B086F0574D1B /* Array+Parallel.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -654,6 +657,7 @@
 				E291D8DB06EC63770326562B /* Type+Stencil.swift in Sources */,
 				E291DBF5DD36D79E01E41270 /* TypeReflectionBox.swift in Sources */,
 				E291D33EA3BB6FC777B3950E /* FolderWatcher.swift in Sources */,
+				E291D9FBE0B751C3C898E5B6 /* Array+Parallel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -42,14 +42,14 @@
 		E291D1C26BD65C6E109966AF /* CustomMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D139206162204C48F396 /* CustomMatchers.swift */; };
 		E291D33EA3BB6FC777B3950E /* FolderWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DBAA16ABFED8C04CB42A /* FolderWatcher.swift */; };
 		E291D48FD07450FD0A09D92E /* EnumSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D3D222F05C42C246CB73 /* EnumSpec.swift */; };
-		E291D4D8E67E26F4567EB5DE /* ParserComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D3DB89E4D87FE8CB1A33 /* ParserComposer.swift */; };
+		E291D4D8E67E26F4567EB5DE /* Composer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D3DB89E4D87FE8CB1A33 /* Composer.swift */; };
 		E291D4E250805568DBC33F7E /* TypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DF48D4FBBB43C1F7EF8A /* TypeSpec.swift */; };
 		E291D5ABECEE3435131D8D05 /* FileParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DBBBE7AF85DF7D7AF97D /* FileParser.swift */; };
 		E291D7114BA1479EC337A070 /* FileParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DD46F8BC3AA0E7E5FB4D /* FileParserSpec.swift */; };
 		E291D8BB621560C275813B1F /* SourcerySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DB1241856B9CFAAA25E7 /* SourcerySpec.swift */; };
 		E291D8C0F0FE5B3DF91025CC /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DA16190CED2907BDEA06 /* Generator.swift */; };
 		E291D8DB06EC63770326562B /* Type+Stencil.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D04C9425FA502B37895D /* Type+Stencil.swift */; };
-		E291D90EC943AC5CBA99899A /* ParserComposerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DFE1A3D6905537EE86D9 /* ParserComposerSpec.swift */; };
+		E291D90EC943AC5CBA99899A /* ComposerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DFE1A3D6905537EE86D9 /* ComposerSpec.swift */; };
 		E291DA3352C0EDD1EB8DDCB3 /* FileParser+VariableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D37EF6AA39833209828F /* FileParser+VariableSpec.swift */; };
 		E291DBF5DD36D79E01E41270 /* TypeReflectionBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DBEB509979F90A2BDF94 /* TypeReflectionBox.swift */; };
 		E291DC5F2343BF3DE3334986 /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D2450093BB4B3A9ADFEC /* Stubs.swift */; };
@@ -136,7 +136,7 @@
 		E291D30C065089B348EE7C42 /* DiffableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiffableSpec.swift; sourceTree = "<group>"; };
 		E291D37EF6AA39833209828F /* FileParser+VariableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileParser+VariableSpec.swift"; sourceTree = "<group>"; };
 		E291D3D222F05C42C246CB73 /* EnumSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumSpec.swift; sourceTree = "<group>"; };
-		E291D3DB89E4D87FE8CB1A33 /* ParserComposer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserComposer.swift; sourceTree = "<group>"; };
+		E291D3DB89E4D87FE8CB1A33 /* Composer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Composer.swift; sourceTree = "<group>"; };
 		E291D5CD7EEDC70CB423C0BE /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		E291D86E6DD88E4A47D9BBD6 /* TypeName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeName.swift; sourceTree = "<group>"; };
 		E291D8D53A557DA9E6D27C3C /* VariableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableSpec.swift; sourceTree = "<group>"; };
@@ -152,7 +152,7 @@
 		E291DD46F8BC3AA0E7E5FB4D /* FileParserSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileParserSpec.swift; sourceTree = "<group>"; };
 		E291DF28602426F7A4C8D737 /* GeneratorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratorSpec.swift; sourceTree = "<group>"; };
 		E291DF48D4FBBB43C1F7EF8A /* TypeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeSpec.swift; sourceTree = "<group>"; };
-		E291DFE1A3D6905537EE86D9 /* ParserComposerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserComposerSpec.swift; sourceTree = "<group>"; };
+		E291DFE1A3D6905537EE86D9 /* ComposerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposerSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -299,7 +299,7 @@
 		E291D114F84B90258AD76A35 /* Parsing */ = {
 			isa = PBXGroup;
 			children = (
-				E291DFE1A3D6905537EE86D9 /* ParserComposerSpec.swift */,
+				E291DFE1A3D6905537EE86D9 /* ComposerSpec.swift */,
 				E291DD46F8BC3AA0E7E5FB4D /* FileParserSpec.swift */,
 				E291DCF0A8E779EC67C9A37E /* AnnotationsParserSpec.swift */,
 				E291D37EF6AA39833209828F /* FileParser+VariableSpec.swift */,
@@ -359,7 +359,7 @@
 			children = (
 				E291D1A12EBFA4B3450C5894 /* Utils */,
 				E291DBBBE7AF85DF7D7AF97D /* FileParser.swift */,
-				E291D3DB89E4D87FE8CB1A33 /* ParserComposer.swift */,
+				E291D3DB89E4D87FE8CB1A33 /* Composer.swift */,
 			);
 			path = Parsing;
 			sourceTree = "<group>";
@@ -648,7 +648,7 @@
 				CD812F671DFDD3990088B2F6 /* Description.generated.swift in Sources */,
 				E291DDBDE2CF209C856B90D7 /* TypeName.swift in Sources */,
 				E291DDC342DD8A3BFD4D55B8 /* Template.swift in Sources */,
-				E291D4D8E67E26F4567EB5DE /* ParserComposer.swift in Sources */,
+				E291D4D8E67E26F4567EB5DE /* Composer.swift in Sources */,
 				E291DD2ED0B47ECB174FEAAD /* Substring.swift in Sources */,
 				E291DF1320ACA969F7A8CBAE /* AnnotationsParser.swift in Sources */,
 				E291D8DB06EC63770326562B /* Type+Stencil.swift in Sources */,
@@ -675,7 +675,7 @@
 				097E11F01E05E78600FEB751 /* TypealiasSpec.swift in Sources */,
 				E291D1C26BD65C6E109966AF /* CustomMatchers.swift in Sources */,
 				E291DCD43D41B7F8D7AAF7B9 /* DiffableSpec.swift in Sources */,
-				E291D90EC943AC5CBA99899A /* ParserComposerSpec.swift in Sources */,
+				E291D90EC943AC5CBA99899A /* ComposerSpec.swift in Sources */,
 				E291D7114BA1479EC337A070 /* FileParserSpec.swift in Sources */,
 				E291DF22F03C87C646576942 /* AnnotationsParserSpec.swift in Sources */,
 				E291DA3352C0EDD1EB8DDCB3 /* FileParser+VariableSpec.swift in Sources */,

--- a/Sourcery.xcodeproj/xcshareddata/xcbaselines/CD754C991D853F000082B512.xcbaseline/185A438A-414A-4AFE-BBD6-0F1070FE7F89.plist
+++ b/Sourcery.xcodeproj/xcshareddata/xcbaselines/CD754C991D853F000082B512.xcbaseline/185A438A-414A-4AFE-BBD6-0F1070FE7F89.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1.9507</real>
+					<real>0.93</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Sourcery/Parsing/Composer.swift
+++ b/Sourcery/Parsing/Composer.swift
@@ -5,7 +5,8 @@
 
 import Foundation
 
-struct ParserComposer {
+/// Responsible for composing results of `FileParser`.
+struct Composer {
     let verbose: Bool
 
     init(verbose: Bool = false) {
@@ -78,24 +79,9 @@ struct ParserComposer {
                 alias.type = resolveType(alias.typeName, type, typealiases)
             })
 
-            // find actual methods parameters types and their argument labels
+            // resolve type names
             for method in type.methods {
-                let argumentLabels: [String]
-                if let labels = method.selectorName.range(of: "(")
-                        .map({ method.selectorName.substring(from: $0.upperBound) })?
-                        .trimmingCharacters(in: CharacterSet(charactersIn: ")"))
-                        .components(separatedBy: ":")
-                        .dropLast() {
-                    argumentLabels = Array(labels)
-                } else {
-                    argumentLabels = []
-                }
-
                 for (index, parameter) in method.parameters.enumerated() {
-                    if index < argumentLabels.count {
-                        parameter.argumentLabel = argumentLabels[index]
-                    }
-
                     parameter.type = resolveType(parameter.typeName, type, typealiases)
                 }
 
@@ -180,9 +166,8 @@ struct ParserComposer {
         let containedType = containingType
                 .containedTypes
                 .filter {
-            $0.name == "\(containingType.name).\(possibleTypeName)" ||
-                    $0.name == possibleTypeName
-        }
+                    $0.name == "\(containingType.name).\(possibleTypeName)" || $0.name == possibleTypeName
+                }
                 .first
 
         return containedType?.name ?? possibleTypeName

--- a/Sourcery/Parsing/Composer.swift
+++ b/Sourcery/Parsing/Composer.swift
@@ -81,7 +81,7 @@ struct Composer {
 
             // resolve type names
             for method in type.methods {
-                for (index, parameter) in method.parameters.enumerated() {
+                for parameter in method.parameters {
                     parameter.type = resolveType(parameter.typeName, type, typealiases)
                 }
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -106,7 +106,7 @@ public class Sourcery {
 
         guard from.isDirectory else {
             let parserResult = try FileParser(verbose: verbose, path: from).parse()
-            return ParserComposer(verbose: verbose).uniqueTypes(parserResult)
+            return Composer(verbose: verbose).uniqueTypes(parserResult)
         }
 
         let sources = try from
@@ -129,7 +129,7 @@ public class Sourcery {
         }
 
         //! All files have been scanned, time to join extensions with base class
-        let types = ParserComposer(verbose: verbose).uniqueTypes(parserResult)
+        let types = Composer(verbose: verbose).uniqueTypes(parserResult)
 
         track("Found \(types.count) types.")
         return types

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -102,7 +102,6 @@ public class Sourcery {
 
     private func parseTypes(from: Path) throws -> [Type] {
         self.track("Scanning sources...", terminator: "")
-        var parserResult: ParserResult = ([], [])
 
         guard from.isDirectory else {
             let parserResult = try FileParser(verbose: verbose, path: from).parse()
@@ -114,18 +113,26 @@ public class Sourcery {
             .filter {
                 $0.extension == "swift"
             }
+            .map { try FileParser(verbose: verbose, path: $0) }
 
-        var lastIdx = 0
+        var previousUpdate = 0
+        var accumulator = 0
         let step = sources.count / 10 // every 10%
-        try sources.enumerated().forEach { idx, path in
-            if idx > lastIdx + step {
-                lastIdx = idx
-                let percentage = idx * 100 / sources.count
+
+        let results = sources.parallelMap({ $0.parse() }, progress: !(verbose || watcherEnabled) ? nil : { idx in
+            if accumulator > previousUpdate + step {
+                previousUpdate = accumulator
+                let percentage = accumulator * 100 / sources.count
                 self.track("Scanning sources... \(percentage)% (\(sources.count) files)", terminator: "")
             }
-            let result = try FileParser(verbose: verbose, path: path).parse()
-            parserResult.typealiases += result.typealiases
-            parserResult.types += result.types
+            accumulator += 1
+        })
+
+        let parserResult = results.reduce(ParserResult([], [])) { acc, next in
+            var result = acc
+            result.typealiases += next.typealiases
+            result.types += next.types
+            return result
         }
 
         //! All files have been scanned, time to join extensions with base class

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -204,7 +204,8 @@ public class Sourcery {
 
     private func track(_ message: Any, terminator: String = "\n", skipStatus: Bool = false) {
         if !watcherEnabled || verbose {
-            Swift.print(message, terminator: terminator)
+            //! console doesn't update in-place so always print on new line
+            Swift.print(message)
         }
 
         guard watcherEnabled && !skipStatus else { return }

--- a/Sourcery/Utils/Array+Parallel.swift
+++ b/Sourcery/Utils/Array+Parallel.swift
@@ -1,0 +1,45 @@
+//
+// Created by Krzysztof Zablocki on 06/01/2017.
+// Copyright (c) 2017 Pixle. All rights reserved.
+//
+
+import Foundation
+
+extension Array {
+    func parallelFlatMap<T>(transform: @escaping ((Element) -> [T])) -> [T] {
+        return parallelMap(transform).flatMap { $0 }
+    }
+
+    /// We have to roll our own solution because concurrentPerform will use slowPath if no NSApplication is available
+    func parallelMap<T>(_ transform: @escaping ((Element) -> T), progress: ((Int) -> Void)? = nil) -> [T] {
+        let count = self.count
+        let maxConcurrentJobs = ProcessInfo.processInfo.activeProcessorCount
+
+        guard count > 1 && maxConcurrentJobs > 1 else {
+            // skip GCD overhead if we'd only run one at a time anyway
+            return map(transform)
+        }
+
+        var result = [(Int, [T])]()
+        result.reserveCapacity(count)
+        let group = DispatchGroup()
+        let uuid = NSUUID().uuidString
+        let jobCount = Int(ceil(Double(count) / Double(maxConcurrentJobs)))
+
+        let queueLabelPrefix = "io.pixle.Sourcery.map.\(uuid)"
+        let resultAccumulatorQueue = DispatchQueue(label: "\(queueLabelPrefix).resultAccumulator")
+
+        for jobIndex in stride(from: 0, to: count, by: jobCount) {
+            let queue = DispatchQueue(label: "\(queueLabelPrefix).\(jobIndex / jobCount)")
+            queue.async(group: group) {
+                let jobElements = self[jobIndex..<Swift.min(count, jobIndex + jobCount)]
+                let jobIndexAndResults = (jobIndex, jobElements.map(transform))
+                resultAccumulatorQueue.sync {
+                    result.append(jobIndexAndResults)
+                }
+            }
+        }
+        group.wait()
+        return result.sorted { $0.0 < $1.0 }.flatMap { $0.1 }
+    }
+}

--- a/Sourcery/main.swift
+++ b/Sourcery/main.swift
@@ -73,9 +73,12 @@ func runCLI() {
         Argument<CustomArguments>("args", description: "Custom values to pass to templates.")
     ) { watcherEnabled, verboseLogging, source, template, output, args in
         do {
+            let start = CFAbsoluteTimeGetCurrent()
             if let keepAlive = try Sourcery(verbose: verboseLogging, arguments: args.arguments).processFiles(source, usingTemplates: template, output: output, watcherEnabled: watcherEnabled) {
                 RunLoop.current.run()
                 _ = keepAlive
+            } else {
+                print("Processing time \(CFAbsoluteTimeGetCurrent() - start) seconds")
             }
         } catch {
             print(error)

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -54,7 +54,7 @@ class GeneratorSpec: QuickSpec {
             let arguments: [String: NSObject] = ["some": "value" as NSString, "number": NSNumber(value: Float(4))]
 
             func generate(_ template: String) -> String {
-                let types = ParserComposer().uniqueTypes((types, []))
+                let types = Composer().uniqueTypes((types, []))
 
                 return (try? Generator.generate(types,
                         template: StencilTemplate(templateString: template),

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -21,7 +21,7 @@ class ParserComposerSpec: QuickSpec {
             describe("uniqueType") {
                 func parse(_ code: String) -> [Type] {
                     let parserResult = FileParser(contents: code).parse()
-                    return ParserComposer(verbose: false).uniqueTypes(parserResult)
+                    return Composer(verbose: false).uniqueTypes(parserResult)
                 }
 
                 context("given private types") {

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -15,7 +15,7 @@ class FileParserSpec: QuickSpec {
             describe("parse") {
                 func parse(_ code: String) -> [Type] {
                     let parserResult = FileParser(contents: code).parse()
-                    return ParserComposer(verbose: false).uniqueTypes(parserResult)
+                    return Composer(verbose: false).uniqueTypes(parserResult)
                 }
 
                 context("given it has methods") {


### PR DESCRIPTION
Ready for review but don't merge yet because I have a PR on sourcekitten to prevent some thread issues as they have 2 global state variables.

It should make parsing at least 2x as fast 🚤 🐎 
e.g. Running on code base of 300 swift files:
before: `system 83% cpu 5.248 total`
after: `system 455% cpu 2.835 total`