### PR TITLE
Improve inferring types of variables with initial value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### New Features
 - Added a new filter `replace`. Usage: `{{ name|replace:"substring","replacement" }}` - replaces occurrences of `substring` with `replacement` in `name` (case sensitive)
+- Improved support for inferring types of variables with initial values
 - Sourcery will now use parallel parsing, expect more than 2x as fast execution.
 - Sourcery will now cache source artifacts, in many scenarios it will lead to order of magnitude faster processing.
 - e.g. on big codebase of over 300 swift files:

--- a/Sourcery/Generating/Template/Stencil/StencilTemplate.swift
+++ b/Sourcery/Generating/Template/Stencil/StencilTemplate.swift
@@ -142,7 +142,7 @@ extension String {
 
     fileprivate func upperFirst() -> String {
         let first = String(characters.prefix(1)).capitalized
-        let other = String(characters.dropFirst())
+        let other = dropFirst()
         return first + other
     }
 

--- a/Sourcery/Models/TypeName.swift
+++ b/Sourcery/Models/TypeName.swift
@@ -54,9 +54,9 @@ final class TypeName: NSObject, AutoDiffable, NSCoding {
             if name.hasSuffix("?") || name.hasSuffix("!") {
                 self.unwrappedTypeName = String(name.characters.dropLast())
             } else if name.hasPrefix("Optional<") {
-                self.unwrappedTypeName = String(name.characters.dropFirst("Optional<".characters.count).dropLast())
+                self.unwrappedTypeName = name.drop(first: "Optional<".characters.count, last: 1)
             } else {
-                self.unwrappedTypeName = String(name.characters.dropFirst("ImplicitlyUnwrappedOptional<".characters.count).dropLast())
+                self.unwrappedTypeName = name.drop(first: "ImplicitlyUnwrappedOptional<".characters.count, last: 1)
             }
         } else {
             self.unwrappedTypeName = name

--- a/Sourcery/Parsing/Composer.swift
+++ b/Sourcery/Parsing/Composer.swift
@@ -227,7 +227,7 @@ struct Composer {
     }
 
     fileprivate func parseTupleElements(_ name: String) -> [TupleElement] {
-        let trimmedBracketsName = String(name.characters.dropFirst().dropLast())
+        let trimmedBracketsName = name.dropFirstAndLast()
         return trimmedBracketsName
             .commaSeparated()
             .map({ $0.trimmingCharacters(in: .whitespaces) })

--- a/Sourcery/Parsing/Utils/Extensions.swift
+++ b/Sourcery/Parsing/Utils/Extensions.swift
@@ -1,5 +1,21 @@
 extension String {
 
+    func dropFirst(_ n: Int = 1) -> String {
+        return String(characters.dropFirst(n))
+    }
+
+    func dropLast(_ n: Int = 1) -> String {
+        return String(characters.dropLast(n))
+    }
+
+    func dropFirstAndLast(_ n: Int = 1) -> String {
+        return drop(first: n, last: n)
+    }
+
+    func drop(first: Int, last: Int) -> String {
+        return String(characters.dropFirst(first).dropLast(last))
+    }
+
     /// Wraps brackets if needed to make a valid type name
     func bracketsBalancing() -> String {
         let wrapped = "(\(self))"
@@ -9,7 +25,7 @@ extension String {
     /// Returns true if given string can represent a valid tuple type name
     func isValidTupleName() -> Bool {
         guard hasPrefix("(") && hasSuffix(")") else { return false }
-        let trimmedBracketsName = String(characters.dropFirst().dropLast())
+        let trimmedBracketsName = dropFirstAndLast()
         return trimmedBracketsName.bracketsBalanced() && trimmedBracketsName.commaSeparated().count > 1
     }
 
@@ -25,7 +41,7 @@ extension String {
 
     /// Returns components separated with a comma respecting nested types
     func commaSeparated() -> [String] {
-        return components(separatedBy: ",", excludingDelimiterBetween: ("<(", ")>"))
+        return components(separatedBy: ",", excludingDelimiterBetween: ("<[(", ")]>"))
     }
 
     /// Returns components separated with colon respecting nested types
@@ -35,15 +51,20 @@ extension String {
 
     func components(separatedBy delimiter: Character, excludingDelimiterBetween between: (open: String, close: String)) -> [String] {
         var boundingCharactersCount: Int = 0
+        var quotesCount: Int = 0
         var item = ""
         var items = [String]()
+
         for char in characters {
             if between.open.characters.contains(char) {
                 boundingCharactersCount += 1
             } else if between.close.characters.contains(char) {
                 boundingCharactersCount -= 1
             }
-            if char == delimiter && boundingCharactersCount == 0 {
+            if char == "\"" {
+                quotesCount += 1
+            }
+            if char == delimiter && boundingCharactersCount == 0 && quotesCount % 2 == 0 {
                 items.append(item)
                 item = ""
             } else {

--- a/SourceryTests/Parsing/FileParser+VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser+VariableSpec.swift
@@ -33,10 +33,55 @@ class FileParserVariableSpec: QuickSpec {
                     expect(parse("var name: String")).to(equal(Variable(name: "name", typeName: TypeName("String"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
                 }
 
-                it("extracts property with default initializer correctly") {
-                    expect(parse("var name = String()")).to(equal(Variable(name: "name", typeName: TypeName("String"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
-                    expect(parse("var name = Parent.Children.init()")).to(equal(Variable(name: "name", typeName: TypeName("Parent.Children"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
-                    expect(parse("var name: String? = String()")).to(equal(Variable(name: "name", typeName: TypeName("String?"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
+                context("given variable with initial value") {
+                    it("extracts property with default initializer correctly") {
+                        expect(parse("var name = String()")?.typeName).to(equal(TypeName("String")))
+                        expect(parse("var name = Parent.Children.init()")?.typeName).to(equal(TypeName("Parent.Children")))
+                        expect(parse("var name: String? = String()")?.typeName).to(equal(TypeName("String?")))
+                    }
+
+                    it("extracts property with literal value correctrly") {
+                        expect(parse("var name = 1")?.typeName).to(equal(TypeName("Int")))
+                        expect(parse("var name = 1.0")?.typeName).to(equal(TypeName("Double")))
+                        expect(parse("var name = \"1\"")?.typeName).to(equal(TypeName("String")))
+                        expect(parse("var name = true")?.typeName).to(equal(TypeName("Bool")))
+                        expect(parse("var name = false")?.typeName).to(equal(TypeName("Bool")))
+                        expect(parse("var name = nil")?.typeName).to(equal(TypeName("Optional")))
+                        expect(parse("var name = Optional.none")?.typeName).to(equal(TypeName("<<unknown type, please add type attribution to variable 'var name = Optional.none'>>")))
+                        expect(parse("var name = Optional.some(1)")?.typeName).to(equal(TypeName("<<unknown type, please add type attribution to variable 'var name = Optional.some(1)'>>")))
+                    }
+
+                    it("extracts property with array literal value correctly") {
+                        expect(parse("var name = [Int]()")?.typeName).to(equal(TypeName("[Int]")))
+                        expect(parse("var name = [1]")?.typeName).to(equal(TypeName("[Int]")))
+                        expect(parse("var name = [1, 2]")?.typeName).to(equal(TypeName("[Int]")))
+                        expect(parse("var name = [1, \"a\"]")?.typeName).to(equal(TypeName("[Any]")))
+                        expect(parse("var name = [1, nil]")?.typeName).to(equal(TypeName("[Int?]")))
+                        expect(parse("var name = [1, [1, 2]]")?.typeName).to(equal(TypeName("[Any]")))
+                        expect(parse("var name = [[1, 2], [1, 2]]")?.typeName).to(equal(TypeName("[[Int]]")))
+                        expect(parse("var name = [Int()]")?.typeName).to(equal(TypeName("[Int]")))
+                    }
+
+                    it("extracts property with dictionary literal value correctly") {
+                        expect(parse("var name = [Int: Int]()")?.typeName).to(equal(TypeName("[Int: Int]")))
+                        expect(parse("var name = [1: 2]")?.typeName).to(equal(TypeName("[Int: Int]")))
+                        expect(parse("var name = [1: 2, 2: 3]")?.typeName).to(equal(TypeName("[Int: Int]")))
+                        expect(parse("var name = [1: 1, 2: \"a\"]")?.typeName).to(equal(TypeName("[Int: Any]")))
+                        expect(parse("var name = [1: 1, 2: nil]")?.typeName).to(equal(TypeName("[Int: Int?]")))
+                        expect(parse("var name = [1: 1, 2: [1, 2]]")?.typeName).to(equal(TypeName("[Int: Any]")))
+                        expect(parse("var name = [[1: 1, 2: 2], [1: 1, 2: 2]]")?.typeName).to(equal(TypeName("[[Int: Int]]")))
+                        expect(parse("var name = [1: [1: 1, 2: 2], 2: [1: 1, 2: 2]]")?.typeName).to(equal(TypeName("[Int: [Int: Int]]")))
+                        expect(parse("var name = [Int(): String()]")?.typeName).to(equal(TypeName("[Int: String]")))
+                    }
+
+                    it("extracts property with tuple literal value correctly") {
+                        expect(parse("var name = (1, 2)")?.typeName).to(equal(TypeName("(Int, Int)")))
+                        expect(parse("var name = (1, b: \"[2,3]\", c: 1)")?.typeName).to(equal(TypeName("(Int, b: String, c: Int)")))
+                        expect(parse("var name = (_: 1, b: 2)")?.typeName).to(equal(TypeName("(Int, b: Int)")))
+                        expect(parse("var name = ((1, 2), [\"a\": \"b\"])")?.typeName).to(equal(TypeName("((Int, Int), [String: String])")))
+                        expect(parse("var name = ((1, 2), [1, 2])")?.typeName).to(equal(TypeName("((Int, Int), [Int])")))
+                        expect(parse("var name = ((1, 2), [\"a,b\": \"b\"])")?.typeName).to(equal(TypeName("((Int, Int), [String: String])")))
+                    }
                 }
 
                 it("extracts standard let property correctly") {


### PR DESCRIPTION
Resolves #111 

Here I've tried approach described in https://github.com/jpsim/SourceKitten/issues/240 with passing "-j4" argument to `SwiftDocs`. This way we get information for inferred literal types. 

But there are some limitations. As we are getting docs for a single file it does not infer literals (i.e. array) that uses type defined in another file (instead it has `<<error type>>`). So for example if we have `var some = ["a": TypeName("a")]` property in `Type` it will fail to infer type correctly. We also process it manually not correctly, so the type will be `[\"\": TypeName`.

I think we can try to solve that by compiling all the files, but I will need to investigate how `sourcekitten` does that as in `SourceKittenFramework` there are only methods to get docs for single file.