### PR TITLE
Add filter named `replace` to substitute one substring with another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Sourcery CHANGELOG
 
 ---
+## Master
+
+### New Features
+- Added a new filter `replace`. Usage: `{{ name|replace:"substring","replacement }}` - replaces occurrences of `substring` with `replacement` in `name` (case sensitive)
+
+### Internal Changes
+- N/A
+
 ## 0.5.2
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Available types:
 ### Custom Stencil tags and filter
 
 - `{{ name|upperFirst }}` - makes first letter in `name` uppercase
+- `{{ name|replace:"substring","replacement }}` - replaces occurances of `substring` with `replacement` in `name` (case sensitive)
 - `{% if name|contains: "Foo" %}` - check if `name` contains arbitrary substring, can be negated with `!` prefix.
 - `{% if name|hasPrefix: "Foo" %}`- check if `name` starts with arbitrary substring, can be negated with `!` prefix.
 - `{% if name|hasSuffix: "Foo" %}`- check if `name` ends with arbitrary substring, can be negated with `!` prefix.

--- a/SourceryTests/Generating/StencilTemplateSpec.swift
+++ b/SourceryTests/Generating/StencilTemplateSpec.swift
@@ -36,6 +36,13 @@ class StencilTemplateSpec: QuickSpec {
                 expect(generate("{{ \"FooBar\" | !hasSuffix:\"Bar\" }}")).to(equal("false"))
                 expect(generate("{{ \"FooBar\" | !hasSuffix:\"Foo\" }}")).to(equal("true"))
             }
+            
+            it("removes instances of a substring") {
+                expect(generate("{{\"helloWorld\" | replace:\"hello\",\"hola\" }}")).to(equal("holaWorld"))
+                expect(generate("{{\"helloWorldhelloWorld\" | replace:\"hello\",\"hola\" }}")).to(equal("holaWorldholaWorld"))
+                expect(generate("{{\"helloWorld\" | replace:\"hello\",\"\" }}")).to(equal("World"))
+                expect(generate("{{\"helloWorld\" | replace:\"foo\",\"bar\" }}")).to(equal("helloWorld"))
+            }
 
         }
     }


### PR DESCRIPTION
According to the contribution guideline, I was supposed to open an Issue to discuss this first, but since this is something I need in my own project and I needed it now, it seemed simplest to just discuss in this Pull Request. That being said, feel free to not accept this, of course! I'm also happy to make changes, as desired.