### PR TITLE
Add .swifttemplate discovery in path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Subsequent time: 0.882099032402039 seconds
 
 ### Bug Fixes
 - Method `accessLevel` was not exposed as string so not accessible properly via templates, fixed that.
+- Fixes on Swift Templates
 
 ## 0.5.2
 

--- a/Sourcery/Models/TypeName.swift
+++ b/Sourcery/Models/TypeName.swift
@@ -120,7 +120,7 @@ final class TypeName: NSObject, AutoDiffable, NSCoding {
 
 }
 
-final class TupleElement: NSObject, AutoDiffable, Typed {
+final class TupleElement: NSObject, AutoDiffable, Typed, NSCoding {
     let name: String
     let typeName: TypeName
 
@@ -151,7 +151,7 @@ final class TupleElement: NSObject, AutoDiffable, Typed {
     // } TupleElement.NSCoding
 }
 
-final class TupleType: NSObject, AutoDiffable {
+final class TupleType: NSObject, AutoDiffable, NSCoding {
     let name: String
 
     let elements: [TupleElement]

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -236,7 +236,7 @@ public class Sourcery {
         return try from
             .recursiveChildren()
             .filter {
-                $0.extension == "stencil"
+                $0.extension == "stencil" || $0.extension == "swifttemplate"
         }
     }
 


### PR DESCRIPTION
I don't know if this was intentional, but .swifttemplate files were not yet discovered using the regular command.

I also needed to add two NSCoding protocol conformances in order to be able to correctly parse my codebase, please see the error below (that is fixed with this PR)

```
Scanning sources...
Found 59 types.
Loading templates...
Loaded 1 templates.
Generating code...
2017-01-13 05:45:07.566348 Sourcery[15918:10098665] -[Sourcery.TupleElement encodeWithCoder:]: unrecognized selector sent to instance 0x608000275200
2017-01-13 05:45:07.570931 Sourcery[15918:10098665] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[Sourcery.TupleElement encodeWithCoder:]: unrecognized selector sent to instance 0x608000275200'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff76b69e7b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x00007fff8b754cad objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff76bebcb4 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
	3   CoreFoundation                      0x00007fff76adbfb5 ___forwarding___ + 1061
	4   CoreFoundation                      0x00007fff76adbb08 _CF_forwarding_prep_0 + 120
	5   Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	6   Foundation                          0x00007fff7854dfdc -[NSKeyedArchiver _encodeArrayOfObjects:forKey:] + 460
	7   Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	8   Sourcery                            0x000000010008a946 _TFC8Sourcery9TupleType6encodefT4withCSo7NSCoder_T_ + 342
	9   Sourcery                            0x000000010008a9ba _TToFC8Sourcery9TupleType6encodefT4withCSo7NSCoder_T_ + 58
	10  Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	11  Sourcery                            0x00000001000887a3 _TFC8Sourcery8TypeName6encodefT4withCSo7NSCoder_T_ + 1427
	12  Sourcery                            0x000000010008881a _TToFC8Sourcery8TypeName6encodefT4withCSo7NSCoder_T_ + 58
	13  Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	14  Sourcery                            0x000000010007fbef _TFC8Sourcery9Typealias6encodefT4withCSo7NSCoder_T_ + 319
	15  Sourcery                            0x000000010007ff4a _TToFC8Sourcery9Typealias6encodefT4withCSo7NSCoder_T_ + 58
	16  Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	17  Foundation                          0x00007fff7854dfdc -[NSKeyedArchiver _encodeArrayOfObjects:forKey:] + 460
	18  Foundation                          0x00007fff7855f21e -[NSDictionary(NSDictionary) encodeWithCoder:] + 927
	19  Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	20  Sourcery                            0x0000000100064399 _TFC8Sourcery4Type6encodefT4withCSo7NSCoder_T_ + 169
	21  Sourcery                            0x000000010003f666 _TFC8Sourcery6Struct6encodefT4withCSo7NSCoder_T_ + 70
	22  Sourcery                            0x000000010003f6ba _TToFC8Sourcery6Struct6encodefT4withCSo7NSCoder_T_ + 58
	23  Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	24  Foundation                          0x00007fff7854dfdc -[NSKeyedArchiver _encodeArrayOfObjects:forKey:] + 460
	25  Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	26  Sourcery                            0x00000001000475d7 _TFC8Sourcery17GenerationContext6encodefT4withCSo7NSCoder_T_ + 151
	27  Sourcery                            0x00000001000478ca _TToFC8Sourcery17GenerationContext6encodefT4withCSo7NSCoder_T_ + 58
	28  Foundation                          0x00007fff7854ca2a _encodeObject + 1241
	29  Foundation                          0x00007fff78588562 +[NSKeyedArchiver archivedDataWithRootObject:] + 156
	30  Sourcery                            0x000000010006c89d _TFC8Sourcery13SwiftTemplate6renderfzT5typesGSaCS_4Type_9argumentsGVs10DictionarySSCSo8NSObject__SS + 2013
	31  Sourcery                            0x000000010006f8e6 _TTWC8Sourcery13SwiftTemplateS_8TemplateS_FS1_6renderfzT5typesGSaCS_4Type_9argumentsGVs10DictionarySSCSo8NSObject__SS + 86
	32  Sourcery                            0x0000000100045d43 _TZFO8Sourcery9Generator8generatefzTGSaCS_4Type_8templatePS_8Template_9argumentsGVs10DictionarySSCSo8NSObject__SS + 211
	33  Sourcery                            0x0000000100054814 _TFC8Sourcery8SourceryP33_DB5C4364BFA94633EE953DD412A08C308generatefzTPS_8Template_8forTypesGSaCS_4Type__SS + 1812
	34  Sourcery                            0x0000000100053d57 _TFFC8Sourcery8SourceryP33_DB5C4364BFA94633EE953DD412A08C308generateFzT12templatePathV7PathKit4Path6outputS2_5typesGSaCS_4Type__T_U0_FzPS_8Template_T_ + 247
	35  Sourcery                            0x0000000100057f78 _TPA__TFFC8Sourcery8SourceryP33_DB5C4364BFA94633EE953DD412A08C308generateFzT12templatePathV7PathKit4Path6outputS2_5typesGSaCS_4Type__T_U0_FzPS_8Template_T_ + 152
	36  libswiftCore.dylib                  0x0000000100734dd5 _TFEsPs8Sequence7forEachfzFzWx8Iterator7Element_T_T_ + 389
	37  Sourcery                            0x00000001000534af _TFC8Sourcery8SourceryP33_DB5C4364BFA94633EE953DD412A08C308generatefzT12templatePathV7PathKit4Path6outputS2_5typesGSaCS_4Type__T_ + 1295
	38  Sourcery                            0x000000010004e97b _TFC8Sourcery8Sourcery12processFilesfzTV7PathKit4Path14usingTemplatesS2_6outputS2_14watcherEnabledSb13cacheDisabledSb_GSqGSaCOS_13FolderWatcher5Local__ + 843
	39  Sourcery                            0x000000010003253a _TFF8Sourcery6runCLIFT_T_U_FTSbSbV7PathKit4PathS1_S1_VS_15CustomArguments_T_ + 570
	40  Sourcery                            0x0000000100032a52 _TTRXFo_dSbdSboV7PathKit4PathoS0_oS0_oV8Sourcery15CustomArguments_zoPs5Error__XFo_iSbiSbiS0_iS0_iS0_iS2__zoPS3___ + 178
	41  Sourcery                            0x00000001000332f9 _TPA__TTRXFo_dSbdSboV7PathKit4PathoS0_oS0_oV8Sourcery15CustomArguments_zoPs5Error__XFo_iSbiSbiS0_iS0_iS0_iS2__zoPS3___ + 137
	42  Commander                           0x0000000100299bf1 _TFF9Commander7commandu4_RxS_18ArgumentDescriptor_S0_0_S0_1_S0_2_S0_3_S0_rFTxq_q0_q1_q2_q3_FzTwx9ValueTypew_S1_w0_S1_w1_S1_w2_S1_w3_S1__T__PS_11CommandType_U_FzCS_14ArgumentParserT_ + 3569
	43  Commander                           0x000000010029a631 _TPA__TFF9Commander7commandu4_RxS_18ArgumentDescriptor_S0_0_S0_1_S0_2_S0_3_S0_rFTxq_q0_q1_q2_q3_FzTwx9ValueTypew_S1_w0_S1_w1_S1_w2_S1_w3_S1__T__PS_11CommandType_U_FzCS_14ArgumentParserT_ + 593
	44  Commander                           0x0000000100281652 _TFV9Commander16AnonymousCommand3runfzCS_14ArgumentParserT_ + 82
	45  Commander                           0x0000000100281794 _TTWV9Commander16AnonymousCommandS_11CommandTypeS_FS1_3runfzCS_14ArgumentParserT_ + 68
	46  Commander                           0x00000001002826a5 _TFE9CommanderPS_11CommandType3runfGSqSS_Os5Never + 1109
	47  Sourcery                            0x000000010003221c _TF8Sourcery6runCLIFT_T_ + 2732
	48  Sourcery                            0x0000000100030b03 main + 307
	49  libdyld.dylib                       0x00007fff8c038255 start + 1
	50  ???                                 0x0000000000000004 0x0 + 4
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```