### PR TITLE
Fixes unknown tag 'endif' error for AutoHashable

### DIFF
--- a/Templates/AutoHashable.stencil
+++ b/Templates/AutoHashable.stencil
@@ -33,7 +33,7 @@ extension {{ type.name }}: Hashable {
                     {% if case.associatedValues.count == 1 %}
                         return data.hashValue
                     {% else %}
-                        return combineHashes({% for associated in case.associatedValues %}data.{{ associated.externalName }}.hashValue{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}{% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %})
+                        return combineHashes({% for associated in case.associatedValues %}data.{{ associated.externalName }}.hashValue{% if not forloop.last %}, {% endif %}{% endfor %}{% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %})
                     {% endif %}
                 {% endif %}
 


### PR DESCRIPTION
The AutoHashable template had one `{% endif %}` tag too much, which results in the following error:

```
Scanning sources...
Found 6 types.
Loading templates...
Loaded 1 templates.
Generating code...
Unknown template tag 'endif'
```