### PR TITLE
Fix associated value names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+- fixed parsing of associated values separater by newlines
 - fixed preserving order of inherited types
 - improved support for throwing methods in protocols
 - fixed extracting parameters of methods with closures in their bodies

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -542,7 +542,7 @@ extension FileParser {
 
         let items = body.commaSeparated()
         return items
-            .map({ $0.trimmingCharacters(in: .whitespaces) })
+            .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
             .enumerated()
             .map {
                 let nameAndType = $1.colonSeparated().map({ $0.trimmingCharacters(in: .whitespaces) })

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -50,6 +50,38 @@ class ParserComposerSpec: QuickSpec {
                         expect(parse("fileprivate struct Foo {}")).to(beEmpty())
                     }
                 }
+                context("given enum containing associated values") {
+                    it("trims whitespace from associated value names") {
+                        expect(parse("enum Foo {\n case bar(\nvalue: String,\n other: Int\n)\n}"))
+                                .to(equal([
+                                    Enum(name: "Foo",
+                                         accessLevel: .internal,
+                                         isExtension: false,
+                                         inheritedTypes: [],
+                                         rawTypeName: nil,
+                                         cases: [
+                                            EnumCase(
+                                                name: "bar",
+                                                rawValue: nil,
+                                                associatedValues: [
+                                                    AssociatedValue(
+                                                        localName: "value",
+                                                        externalName: "value",
+                                                        typeName: TypeName("String")
+                                                    ),
+                                                    AssociatedValue(
+                                                        localName: "other",
+                                                        externalName: "other",
+                                                        typeName: TypeName("Int")
+                                                    )
+                                                ],
+                                                annotations: [:]
+                                            )
+                                        ]
+                                         )
+                                    ]))
+                    }
+                }
 
                 context("given enum containing rawType") {
 


### PR DESCRIPTION
Newlines weren't trimmed from associated value labels, this is a small fix for that.