### PR TITLE
Update Built-In AutoHashable Template to Compile

### DIFF
--- a/Templates/AutoHashable.stencil
+++ b/Templates/AutoHashable.stencil
@@ -1,6 +1,6 @@
 // swiftlint:disable file_length
 
-fileprivate func combineHashes(hashes: [Int]) -> Int {
+fileprivate func combineHashes(_ hashes: [Int]) -> Int {
     var combinedHash = 5381
 
     for itemHash in hashes {
@@ -16,7 +16,7 @@ fileprivate func combineHashes(hashes: [Int]) -> Int {
 extension {{ type.name }}{% if not type.kind == "protocol" %}: Hashable{% endif %} {
     {% if type.supertype.based.Hashable or type.supertype.implements.AutoHashable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable {% endif %}
     {{ type.accessLevel }} var hashValue: Int {
-        return combineHashes({% for variable in type.variables %}{% if not variable.isStatic and not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0)
+        return combineHashes([{% for variable in type.variables %}{% if not variable.isStatic and not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0])
     }
 }
 {% endif %}{% endfor %}
@@ -29,11 +29,17 @@ extension {{ type.name }}: Hashable {
         switch self {
             {% for case in type.cases %}
             {% if case.hasAssociatedValue %} case .{{ case.name }}(let data): {% else %} case .{{ case.name }}: {% endif %}
-                {% ifnot case.hasAssociatedValue %} return combineHashes({% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}) {% else %}
-                    {% if case.associatedValues.count == 1 %}
-                        return data.hashValue
+                {% ifnot case.hasAssociatedValue %}
+                    {% if type.computedVariables.count == 0 %}
+                        return {{ forloop.counter }}.hashValue
                     {% else %}
-                        return combineHashes({% for associated in case.associatedValues %}data.{{ associated.externalName }}.hashValue{% if not forloop.last %}, {% endif %}{% endfor %}{% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %})
+                        return combineHashes([{{ forloop.counter }}, {% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}])
+                    {% endif %}
+                {% else %}
+                    {% if case.associatedValues.count == 1 %}
+                        return combineHashes([{{ forloop.counter }}, data.hashValue])
+                    {% else %}
+                        return combineHashes([{{ forloop.counter }}, {% for associated in case.associatedValues %}data.{{ associated.externalName }}.hashValue{% if not forloop.last %}, {% endif %}{% endfor %}{% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}])
                     {% endif %}
                 {% endif %}
 


### PR DESCRIPTION
For the current `AutoHashable.stencil` template that is distributed with Sourcery, given some [source code](https://gist.github.com/grantjbutler/d566019d7198643d2782346e6ee66b1c#file-source-swift), the [generated code](https://gist.github.com/grantjbutler/d566019d7198643d2782346e6ee66b1c#file-orig-generated-swift) will not compile and is semantically incorrect for the following reasons:

1. Implementations of `hashValue` on types call `combineHashes` with n arguments, whereas `combineHashes` takes in an array of integers.
2. Enumeration cases with no associated values call `combineHashes` directly with no arguments, resulting in all cases of an enumeration having the same hash value.
3. There is no checking that an associated value of an enum case implements `Hashable` and can then be used for calculating the hash value of the containing case.

This PR updates the template to address most of these issues<sup>[1]</sup>. Given the same source code, the [generated code](https://gist.github.com/grantjbutler/d566019d7198643d2782346e6ee66b1c#file-new-generated-swift) using this new template compiles and behaves as expected.

I could see about adding tests to warn about this in the future, if you think that's something worth adding. I can imagine two possibilities for a test:

1. Do a straight text comparison. Generate some code using the built-in template and store it on disk for use as a fixture. Then, for a test, regenerate the code and compare it to that fixture. If the string comparison fails, then the test fails.
2. Analyzing for valid Swift code. This could either be done by attempting to compile the source code that is generated by running Sourcery with the built-in templates, or possibly by using SourceKitten to try to analyze the source code (I'm assuming that, if the Swift code has some syntax error, then SourceKitten will surface the error and not complete the analysis of the code). If either operation fails (depending on which is implemented), then the test fails.

#### Footnotes

[1]: This PR addresses problems 1 and 2. It does not appear that problem 3 can be addressed as Sourcery currently does not return the necessary information for associated values to determine what protocols these associated values do or don't conform to. I suppose a simple solution to fix part of that would be to ignore any associated value where `isClosure` is `true`, but I don't know if that's the route you want to go down.