### PR TITLE
Update AutoLenses to fix variable.type to .typeName

### DIFF
--- a/Templates/AutoLenses.stencil
+++ b/Templates/AutoLenses.stencil
@@ -28,7 +28,7 @@ func |> <A, B, C> (f: @escaping (A) -> B, g: @escaping (B) -> C) -> (A) -> C {
 {% for type in types.implementing.AutoLenses|struct %}
 extension {{ type.name }} {
 {% for variable in type.variables %}
-  static let {{ variable.name }}Lens = Lens<{{type.name}}, {{variable.type}}>(
+  static let {{ variable.name }}Lens = Lens<{{type.name}}, {{variable.typeName}}>(
     get: { $0.{{variable.name}} },
     set: { {{variable.name}}, {{type.name|lowercase}} in
        {{type.name}}({% for argument in type.variables %}{{argument.name}}: {% if variable.name == argument.name %}{{variable.name}}{% else %}{{type.name|lowercase}}.{{argument.name}}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})


### PR DESCRIPTION
The meaning of `.type` changed in some previous version, and the intended meaning is now `.typeName`. This is an update the AutoLenses template to account for that.