### PR TITLE
Combine hash values based on boost::hash_combine

### DIFF
--- a/Templates/AutoHashable.stencil
+++ b/Templates/AutoHashable.stencil
@@ -1,13 +1,19 @@
 // swiftlint:disable file_length
 
 fileprivate func combineHashes(_ hashes: [Int]) -> Int {
-    var combinedHash = 5381
+    return hashes.reduce(0, combineHashValues)
+}
 
-    for itemHash in hashes {
-        combinedHash = ((combinedHash << 5) &+ combinedHash) &+ itemHash
-    }
-
-    return combinedHash
+fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
+    #if arch(x86_64) || arch(arm64)
+        let magic: UInt = 0x9e3779b97f4a7c15
+    #elseif arch(i386) || arch(arm)
+        let magic: UInt = 0x9e3779b9
+    #endif
+    var lhs = UInt(bitPattern: initial)
+    let rhs = UInt(bitPattern: other)
+    lhs ^= rhs &+ magic &+ (lhs << 6) &+ (lhs >> 2)
+    return Int(bitPattern: lhs)
 }
 
 // MARK: - AutoHashable for classes, protocols, structs


### PR DESCRIPTION
# Changes

Previously, the bundled AutoHashable template used the 'djb2' algorithm. This changes the template to a [C++ 'boost::hash_combine' algorithm](http://www.boost.org/doc/libs/1_54_0/doc/html/hash/reference.html#boost.hash_combine), modified with a 64-bit magic number on 64-bit platforms.

Both magic numbers are derived from the reciprocal of the golden ratio, ϕ. See:

- http://alvaro-videla.com/2016/10/inside-java-s-threadlocalrandom.html
- http://brpreiss.com/books/opus4/html/page214.html

# Rationale

Dan Bernstein's djb2 works reasonably well, but 'boost::hash_combine' is supposedly more distributed, i.e. produces fewer collisions. Unfortunately, I cannot find standard info describing the distribution characteristics of the two. At the very least, (a) this version improves the 64-bit hash value function by using a 64-bit-appropriate magic number, (b) many, many people using Boost have been using its `hash_combine` function for at least a decade.

- djb2 is additive. Bernstein prefers an xor version of his algorithm, according to http://www.cse.yorku.ca/~oz/hash.html.
- In favor of 'boost::hash_combine': http://stackoverflow.com/a/27952689

# Tests

I cannot find tests for stencil template output. If there is a way to test templates that I missed, please let me know and I'll be happy to write tests.

I did copy these template changes into a project of my own. These changes compile and look good to me.