### PR TITLE
Fix AutoEquatable to only use stored variables, not all variables

### DIFF
--- a/Templates/AutoEquatable.stencil
+++ b/Templates/AutoEquatable.stencil
@@ -25,7 +25,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 {% if not type.kind == "protocol" %}extension {{ type.name }}: Equatable {} {% endif %}
 {% if type.supertype.based.Equatable or type.supertype.implements.AutoEquatable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable {% endif %}
 {{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
-    {% for variable in type.variables %}{% if not variable.isStatic and not variable.annotations.skipEquality %}guard {% if not variable.isOptional %}{% if not variable.annotations.arrayEquality %}lhs.{{ variable.name }} == rhs.{{ variable.name }}{% else %}compareArrays(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %}{% else %}compareOptionals(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %} else { return false }{% endif %}
+    {% for variable in type.storedVariables %}{% if not variable.isStatic and not variable.annotations.skipEquality %}guard {% if not variable.isOptional %}{% if not variable.annotations.arrayEquality %}lhs.{{ variable.name }} == rhs.{{ variable.name }}{% else %}compareArrays(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %}{% else %}compareOptionals(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %} else { return false }{% endif %}
     {% endfor %}
     return true
 }

--- a/Templates/AutoEquatable.stencil
+++ b/Templates/AutoEquatable.stencil
@@ -25,7 +25,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 {% if not type.kind == "protocol" %}extension {{ type.name }}: Equatable {} {% endif %}
 {% if type.supertype.based.Equatable or type.supertype.implements.AutoEquatable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable {% endif %}
 {{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
-    {% for variable in type.storedVariables %}{% if not variable.isStatic and not variable.annotations.skipEquality %}guard {% if not variable.isOptional %}{% if not variable.annotations.arrayEquality %}lhs.{{ variable.name }} == rhs.{{ variable.name }}{% else %}compareArrays(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %}{% else %}compareOptionals(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %} else { return false }{% endif %}
+    {% for variable in type.storedVariables %}{% if not variable.annotations.skipEquality %}guard {% if not variable.isOptional %}{% if not variable.annotations.arrayEquality %}lhs.{{ variable.name }} == rhs.{{ variable.name }}{% else %}compareArrays(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %}{% else %}compareOptionals(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %} else { return false }{% endif %}
     {% endfor %}
     return true
 }

--- a/Templates/AutoHashable.stencil
+++ b/Templates/AutoHashable.stencil
@@ -22,7 +22,7 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
 extension {{ type.name }}{% if not type.kind == "protocol" %}: Hashable{% endif %} {
     {% if type.supertype.based.Hashable or type.supertype.implements.AutoHashable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable {% endif %}
     {{ type.accessLevel }} var hashValue: Int {
-        return combineHashes([{% for variable in type.variables %}{% if not variable.isStatic and not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0])
+        return combineHashes([{% for variable in type.storedVariables %}{% if not variable.isStatic and not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0])
     }
 }
 {% endif %}{% endfor %}

--- a/Templates/AutoHashable.stencil
+++ b/Templates/AutoHashable.stencil
@@ -22,7 +22,7 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
 extension {{ type.name }}{% if not type.kind == "protocol" %}: Hashable{% endif %} {
     {% if type.supertype.based.Hashable or type.supertype.implements.AutoHashable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable {% endif %}
     {{ type.accessLevel }} var hashValue: Int {
-        return combineHashes([{% for variable in type.storedVariables %}{% if not variable.isStatic and not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0])
+        return combineHashes([{% for variable in type.storedVariables %}{% if not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0])
     }
 }
 {% endif %}{% endfor %}


### PR DESCRIPTION
cc @krzysztofzablocki @grantjbutler 