### PR TITLE
fix: escaping reserved variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Added parsing array types
 
+### Bug Fixes
+
+- Fixed escaping variables with reserved names
+
 ## 0.5.7
 
 ### Bug Fixes

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -214,11 +214,11 @@ class FileParserSpec: QuickSpec {
                     it("extracts cases with special names") {
                         expect(parse("enum Foo { case `default`; case `for`(something: Int, else: Float, `default`: Bool) }"))
                                 .to(equal([
-                                                  Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [EnumCase(name: "default"), EnumCase(name: "for", associatedValues:
+                                                  Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [EnumCase(name: "`default`"), EnumCase(name: "`for`", associatedValues:
                                                   [
                                                           AssociatedValue(name: "something", typeName: TypeName("Int")),
                                                           AssociatedValue(name: "else", typeName: TypeName("Float")),
-                                                          AssociatedValue(name: "default", typeName: TypeName("Bool"))
+                                                          AssociatedValue(name: "`default`", typeName: TypeName("Bool"))
                                                   ])])
                                           ]))
                     }


### PR DESCRIPTION
See https://github.com/SwiftGen/StencilSwiftKit/blob/master/Sources/Filters.swift#L15

The reason for this change is that when we try to generate property with the same name, or use it without `self.` we loose it's escaping (SourceKitten/SourceKite returns it unescaped), and generated code does not compile