### PR TITLE
Respect file extension in file annotation in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features
 
 - Added flag to check if `TypeName` is dictionary
+- Added generation non-swift files using `sourcery:file` annotation
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -593,6 +593,8 @@ Sourcery supports generating code in a separate file per type, you just need to 
 
 Sourcery will generate the template code and then write its annotated parts to corresponding files. In example above it will create `Generated/<type name>+TemplateName.generated.swift` file for each of scanned types.
 
+If you add an extension to the file name Sourcery will not append `generated.swift` extension.
+
 ## Installing
 
 <details>

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -322,12 +322,10 @@ extension Sourcery {
             .annotatedRanges
             .map { ($0, $1) }
             .forEach({ (filePath, range) in
-                let generatedBody = Sourcery.generationHeader + contents.bridge().substring(with: range)
-                let path: Path
-                if Path(filePath).extension != nil {
-                    path = outputPath + filePath
-                } else {
-                    path = outputPath + "\(filePath).generated.swift"
+                var generatedBody = contents.bridge().substring(with: range)
+                let path = outputPath + (Path(filePath).extension == nil ? "\(filePath).generated.swift" : filePath)
+                if path.extension == "swift" {
+                    generatedBody = Sourcery.generationHeader + generatedBody
                 }
                 if !path.parent().exists {
                     try path.parent().mkpath()

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -323,7 +323,12 @@ extension Sourcery {
             .map { ($0, $1) }
             .forEach({ (filePath, range) in
                 let generatedBody = Sourcery.generationHeader + contents.bridge().substring(with: range)
-                let path = outputPath + "\(filePath).generated.swift"
+                let path: Path
+                if Path(filePath).extension != nil {
+                    path = outputPath + filePath
+                } else {
+                    path = outputPath + "\(filePath).generated.swift"
+                }
                 if !path.parent().exists {
                     try path.parent().mkpath()
                 }


### PR DESCRIPTION
Resolves #175

With this you can wrap all template content in `sourcery:file` annotation to generate file with arbitrary name and extension.

There is yet one thing to be fixed - we always put a comment at the top of generated file, but it can be not valid for non-swift types of files. @krzysztofzablocki any ideas how to handle that?