### PR TITLE
Style improvement auto-equatable template; #Trivial

### DIFF
--- a/Templates/AutoEquatable.stencil
+++ b/Templates/AutoEquatable.stencil
@@ -38,19 +38,18 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 extension {{ type.name }}: Equatable {}
 {{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
     switch (lhs, rhs) {
-        {% for case in type.cases %}
-        {% if case.hasAssociatedValue %} case (.{{ case.name }}(let lhs), .{{ case.name }}(let rhs)): {% else %} case (.{{ case.name }}, .{{ case.name }}): {% endif %}
-            {% ifnot case.hasAssociatedValue %} return true {% else %}
-                {% if case.associatedValues.count == 1 %}
-                    return lhs == rhs
-                {% else %}
-                    {% for associated in case.associatedValues %} if lhs.{{ associated.externalName }} != rhs.{{ associated.externalName }} { return false }
-                    {% endfor %} return true
-                    {% endif %}
-            {% endif %}
-
-        {% endfor %}
-        default: return false
+    {% for case in type.cases %}
+    {% if case.hasAssociatedValue %}case (.{{ case.name }}(let lhs), .{{ case.name }}(let rhs)): {% else %} case (.{{ case.name }}, .{{ case.name }}): {% endif %}
+        {% ifnot case.hasAssociatedValue %} return true {% else %}
+        {% if case.associatedValues.count == 1 %}
+        return lhs == rhs
+        {% else %}
+        {% for associated in case.associatedValues %}if lhs.{{ associated.externalName }} != rhs.{{ associated.externalName }} { return false }
+        {% endfor %}return true
+        {% endif %}
+        {% endif %}
+    {% endfor %}
+    default: return false
     }
 }
 {% endfor %}

--- a/Templates/AutoEquatable.stencil
+++ b/Templates/AutoEquatable.stencil
@@ -20,7 +20,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 }
 
 // MARK: - AutoEquatable for classes, protocols, structs
-{% for type in types.implementing.AutoEquatable %}{% if not type.kind == "enum" %}
+{% for type in types.based.AutoEquatable %}{% if not type.kind == "enum" %}
 // MARK: - {{ type.name }} AutoEquatable
 {% if not type.kind == "protocol" %}extension {{ type.name }}: Equatable {} {% endif %}
 {% if type.supertype.based.Equatable or type.supertype.implements.AutoEquatable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable {% endif %}
@@ -33,7 +33,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 {% endfor %}
 
 // MARK: - AutoEquatable for Enums
-{% for type in types.implementing.AutoEquatable|enum %}
+{% for type in types.based.AutoEquatable|enum %}
 // MARK: - {{ type.name }} AutoEquatable
 extension {{ type.name }}: Equatable {}
 {{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {

--- a/Templates/AutoEquatable.stencil
+++ b/Templates/AutoEquatable.stencil
@@ -20,7 +20,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 }
 
 // MARK: - AutoEquatable for classes, protocols, structs
-{% for type in types.based.AutoEquatable %}{% if not type.kind == "enum" %}
+{% for type in types.implementing.AutoEquatable %}{% if not type.kind == "enum" %}
 // MARK: - {{ type.name }} AutoEquatable
 {% if not type.kind == "protocol" %}extension {{ type.name }}: Equatable {} {% endif %}
 {% if type.supertype.based.Equatable or type.supertype.implements.AutoEquatable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable {% endif %}
@@ -33,7 +33,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 {% endfor %}
 
 // MARK: - AutoEquatable for Enums
-{% for type in types.based.AutoEquatable|enum %}
+{% for type in types.implementing.AutoEquatable|enum %}
 // MARK: - {{ type.name }} AutoEquatable
 extension {{ type.name }}: Equatable {}
 {{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {

--- a/Templates/AutoHashable.stencil
+++ b/Templates/AutoHashable.stencil
@@ -29,26 +29,26 @@ extension {{ type.name }}{% if not type.kind == "protocol" %}: Hashable{% endif 
 
 // MARK: - AutoHashable for Enums
 {% for type in types.implementing.AutoHashable|enum %}
+
 // MARK: - {{ type.name }} AutoHashable
 extension {{ type.name }}: Hashable {
     {{ type.accessLevel }} var hashValue: Int {
         switch self {
-            {% for case in type.cases %}
-            {% if case.hasAssociatedValue %} case .{{ case.name }}(let data): {% else %} case .{{ case.name }}: {% endif %}
-                {% ifnot case.hasAssociatedValue %}
-                    {% if type.computedVariables.count == 0 %}
-                        return {{ forloop.counter }}.hashValue
-                    {% else %}
-                        return combineHashes([{{ forloop.counter }}, {% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}])
-                    {% endif %}
-                {% else %}
-                    {% if case.associatedValues.count == 1 %}
-                        return combineHashes([{{ forloop.counter }}, data.hashValue])
-                    {% else %}
-                        return combineHashes([{{ forloop.counter }}, {% for associated in case.associatedValues %}data.{{ associated.externalName }}.hashValue{% if not forloop.last %}, {% endif %}{% endfor %}{% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}])
-                    {% endif %}
-                {% endif %}
-
+        {% for case in type.cases %}
+        {% if case.hasAssociatedValue %}case .{{ case.name }}(let data): {% else %} case .{{ case.name }}: {% endif %}
+            {% ifnot case.hasAssociatedValue %}
+            {% if type.computedVariables.count == 0 %}
+            return {{ forloop.counter }}.hashValue
+            {% else %}
+            return combineHashes([{{ forloop.counter }}, {% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}])
+            {% endif %}
+            {% else %}
+            {% if case.associatedValues.count == 1 %}
+            return combineHashes([{{ forloop.counter }}, data.hashValue])
+            {% else %}
+            return combineHashes([{{ forloop.counter }}, {% for associated in case.associatedValues %}data.{{ associated.externalName }}.hashValue{% if not forloop.last %}, {% endif %}{% endfor %}{% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}])
+            {% endif %}
+            {% endif %}
             {% endfor %}
         }
     }


### PR DESCRIPTION
Hi, the PR consists of two small changes in `AutoEquatable` template:
1. It generates code if the type is `based` and not `implementing` AutoEquatable.

This fixes the problem that for the following code Sourcery didn't generate code:
```swift
protocol TestResult: AutoEquatable {
    var referenceImagePath: String { get }
    var diffImagePath: String { get }
    var failedImagePath: String { get }
    var testName: String { get }
}

struct CompletedTestResult: TestResult {
    let referenceImagePath: String
    let diffImagePath: String
    let failedImagePath: String
    let testName: String
}
```

2. Small indents and spaces updates in the template which converts the following autogenerated code:
```swift
extension SnapshotTestImage: Equatable {}
internal func == (lhs: SnapshotTestImage, rhs: SnapshotTestImage) -> Bool {
    switch (lhs, rhs) {
         case (.diff(let lhs), .diff(let rhs)): 
                    return lhs == rhs

         case (.reference(let lhs), .reference(let rhs)): 
                    return lhs == rhs

         case (.failed(let lhs), .failed(let rhs)): 
                    return lhs == rhs

        default: return false
    }
}
```
Into
```swift
extension SnapshotTestImage: Equatable {}
internal func == (lhs: SnapshotTestImage, rhs: SnapshotTestImage) -> Bool {
    switch (lhs, rhs) {
    case (.diff(let lhs), .diff(let rhs)): 
        return lhs == rhs
    case (.reference(let lhs), .reference(let rhs)): 
        return lhs == rhs
    case (.failed(let lhs), .failed(let rhs)): 
        return lhs == rhs
    default: return false
    }
}
```

I think it looks clearer, but I can rollback for sure 😄 