### PR TITLE
Implemented automatic inline code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ---
 
+## Master
+
+### New Features
+
+- Added support for inline code generation without requiring explicit `// sourcery:inline` comments in the source files. To use, use `sourcery:inline:auto` in a template: `// sourcery:inline:auto:MyType`
+
 ## 0.5.9
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -594,6 +594,32 @@ class MyType {
 
 Sourcery will generate the template code and then perform replacement in your source file. Inlined generated code is not parsed to avoid chicken-egg problem.
 
+#### Automatic inline code generation
+
+To avoid having to place the markup in your source files, you can use `inline:auto`:
+
+```swift
+// in template:
+
+{% for type in types.all %}
+// sourcery:inline:auto:{{ type.name }}
+// sourcery:end
+{% endfor %}
+
+// in source code:
+
+class MyType {}
+
+// after running Sourcery:
+
+class MyType {
+// sourcery:inline:auto:MyType
+// sourcery:end
+}
+```
+
+The needed markup will be automatically added at the end of the type.
+
 ### Per file code generation
 
 Sourcery supports generating code in a separate file per type, you just need to put `file` annotation in a template, e.g.

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		E291DE1CB3B72BAA22DEDEDA /* StencilTemplateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D0D4A5AF091CD15550FD /* StencilTemplateSpec.swift */; };
 		E291DF1320ACA969F7A8CBAE /* AnnotationsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DCDA23F3C1A44331A245 /* AnnotationsParser.swift */; };
 		E291DF22F03C87C646576942 /* AnnotationsParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DCF0A8E779EC67C9A37E /* AnnotationsParserSpec.swift */; };
+		F24C39151E85304100BC1F3A /* TypeDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24C39141E85304100BC1F3A /* TypeDefinition.swift */; };
+		F2AA8A841E8549FD00E66BDC /* TypeDefinition.swift in SwiftTemplates */ = {isa = PBXBuildFile; fileRef = F24C39141E85304100BC1F3A /* TypeDefinition.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -130,6 +132,7 @@
 			dstPath = SwiftTemplateRuntime;
 			dstSubfolderSpec = 7;
 			files = (
+				F2AA8A841E8549FD00E66BDC /* TypeDefinition.swift in SwiftTemplates */,
 				CD724D731E366F0A0002E632 /* PhantomProtocols.swift in SwiftTemplates */,
 				CDEF5F101E26A47B000DB954 /* FileParserResult.swift in SwiftTemplates */,
 				CDBEC15D1E242C710090E881 /* Attribute.swift in SwiftTemplates */,
@@ -265,6 +268,7 @@
 		E291DF28602426F7A4C8D737 /* GeneratorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratorSpec.swift; sourceTree = "<group>"; };
 		E291DF48D4FBBB43C1F7EF8A /* TypeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeSpec.swift; sourceTree = "<group>"; };
 		E291DFE1A3D6905537EE86D9 /* ComposerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposerSpec.swift; sourceTree = "<group>"; };
+		F24C39141E85304100BC1F3A /* TypeDefinition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeDefinition.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -396,6 +400,7 @@
 				098442741E2241F10051E1A1 /* Attribute.swift */,
 				CDEF5F0E1E26A471000DB954 /* FileParserResult.swift */,
 				E291DD290C35DCDEF29742F1 /* PhantomProtocols.swift */,
+				F24C39141E85304100BC1F3A /* TypeDefinition.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -798,6 +803,7 @@
 				CD9C459D1DFAF76D00161C2C /* main.swift in Sources */,
 				CD812F5B1DFDCC1A0088B2F6 /* Enum.swift in Sources */,
 				CD812F5C1DFDCC1A0088B2F6 /* Protocol.swift in Sources */,
+				F24C39151E85304100BC1F3A /* TypeDefinition.swift in Sources */,
 				09C61F9F1E749DFC005EA58A /* Yams+Extensions.swift in Sources */,
 				09C6B0D21E11BA2500246CDF /* Class.swift in Sources */,
 				CDEF5F0F1E26A471000DB954 /* FileParserResult.swift in Sources */,

--- a/Sourcery/CodeGenerated/Coding.generated.swift
+++ b/Sourcery/CodeGenerated/Coding.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.5.8 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.5.9 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Foundation
@@ -82,6 +82,9 @@ extension TupleType: NSCoding {}
     // sourcery:end
 extension Type: NSCoding {}
     // sourcery:inline:Type.AutoCoding
+    // sourcery:end
+extension TypeDefinition: NSCoding {}
+    // sourcery:inline:TypeDefinition.AutoCoding
     // sourcery:end
 extension TypeName: NSCoding {}
     // sourcery:inline:TypeName.AutoCoding

--- a/Sourcery/CodeGenerated/Description.generated.swift
+++ b/Sourcery/CodeGenerated/Description.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.5.8 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.5.9 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 extension ArrayType {
@@ -165,6 +165,17 @@ extension Type {
         string += "parentName = \(self.parentName), "
         string += "parentTypes = \(self.parentTypes), "
         string += "attributes = \(self.attributes)"
+        return string
+    }
+}
+extension TypeDefinition {
+    override var description: String {
+        var string = "\(type(of: self)): "
+        string += "path = \(self.path), "
+        string += "bodyOffset = \(self.bodyOffset), "
+        string += "bodyStartPosition = \(self.bodyStartPosition), "
+        string += "bodyLength = \(self.bodyLength), "
+        string += "bodyEndPosition = \(self.bodyEndPosition)"
         return string
     }
 }

--- a/Sourcery/CodeGenerated/Diffable.generated.swift
+++ b/Sourcery/CodeGenerated/Diffable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.5.8 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.5.9 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 extension ArrayType: Diffable {
@@ -221,6 +221,19 @@ extension Type: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "containedTypes").trackDifference(actual: self.containedTypes, expected: rhs.containedTypes))
         results.append(contentsOf: DiffableResult(identifier: "parentName").trackDifference(actual: self.parentName, expected: rhs.parentName))
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: rhs.attributes))
+        return results
+    }
+}
+extension TypeDefinition: Diffable {
+    func diffAgainst(_ object: Any?) -> DiffableResult {
+        let results = DiffableResult()
+        guard let rhs = object as? TypeDefinition else {
+            results.append("Incorrect type <expected: TypeDefinition, received: \(type(of: object))>")
+            return results
+        }
+        results.append(contentsOf: DiffableResult(identifier: "path").trackDifference(actual: self.path, expected: rhs.path))
+        results.append(contentsOf: DiffableResult(identifier: "bodyOffset").trackDifference(actual: self.bodyOffset, expected: rhs.bodyOffset))
+        results.append(contentsOf: DiffableResult(identifier: "bodyLength").trackDifference(actual: self.bodyLength, expected: rhs.bodyLength))
         return results
     }
 }

--- a/Sourcery/CodeGenerated/Equality.generated.swift
+++ b/Sourcery/CodeGenerated/Equality.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.5.8 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.5.9 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 extension ArrayType {
@@ -161,6 +161,15 @@ extension Type {
         if self.parentName != rhs.parentName { return false }
         if self.attributes != rhs.attributes { return false }
         if self.kind != rhs.kind { return false }
+        return true
+    }
+}
+extension TypeDefinition {
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? TypeDefinition else { return false }
+        if self.path != rhs.path { return false }
+        if self.bodyOffset != rhs.bodyOffset { return false }
+        if self.bodyLength != rhs.bodyLength { return false }
         return true
     }
 }

--- a/Sourcery/CodeGenerated/JSExport.generated.swift
+++ b/Sourcery/CodeGenerated/JSExport.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.5.8 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.5.9 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import JavaScriptCore
@@ -254,6 +254,16 @@ extension TupleType: TupleTypeAutoJSExport {}
 }
 
 extension Type: TypeAutoJSExport {}
+
+@objc protocol TypeDefinitionAutoJSExport: JSExport {
+    var path: String { get }
+    var bodyOffset: Int { get }
+    var bodyStartPosition: Int { get }
+    var bodyLength: Int { get }
+    var bodyEndPosition: Int { get }
+}
+
+extension TypeDefinition: TypeDefinitionAutoJSExport {}
 
 @objc protocol TypeNameAutoJSExport: JSExport {
     var name: String { get }

--- a/Sourcery/CodeGenerated/Typed.generated.swift
+++ b/Sourcery/CodeGenerated/Typed.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.5.8 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.5.9 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 extension AssociatedValue {

--- a/Sourcery/Models/Type.swift
+++ b/Sourcery/Models/Type.swift
@@ -169,6 +169,10 @@ class Type: NSObject, SourceryModel, Annotated {
 
     var attributes: [String: Attribute]
 
+    /// The definition in which the type is declared
+    // sourcery: skipEquality, skipDescription, skipJSExport
+    var definition: TypeDefinition?
+
     /// Underlying parser data, never to be used by anything else
     // sourcery: skipDescription, skipEquality, skipCoding, skipJSExport
     internal var __parserData: Any?
@@ -244,6 +248,7 @@ class Type: NSObject, SourceryModel, Annotated {
             self.parent = aDecoder.decode(forKey: "parent")
             self.supertype = aDecoder.decode(forKey: "supertype")
             guard let attributes: [String: Attribute] = aDecoder.decode(forKey: "attributes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["attributes"])); fatalError() }; self.attributes = attributes
+            self.definition = aDecoder.decode(forKey: "definition")
         }
 
         func encode(with aCoder: NSCoder) {
@@ -264,6 +269,7 @@ class Type: NSObject, SourceryModel, Annotated {
             aCoder.encode(self.parent, forKey: "parent")
             aCoder.encode(self.supertype, forKey: "supertype")
             aCoder.encode(self.attributes, forKey: "attributes")
+            aCoder.encode(self.definition, forKey: "definition")
         }
     // sourcery:end
 }

--- a/Sourcery/Models/TypeDefinition.swift
+++ b/Sourcery/Models/TypeDefinition.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+class TypeDefinition: NSObject, SourceryModel {
+
+    /// The path to the file of the definition
+    var path: String
+
+    /// The position of the starting `{` of the body of the type definition in the file where the type is defined
+    var bodyOffset: Int
+
+    /// The position right after the starting `{` of the type definition
+    var bodyStartPosition: Int {
+        return bodyOffset + 1
+    }
+
+    /// The length of the body of the definition
+    var bodyLength: Int
+
+    /// The position right before the closing `}` of the type definition
+    var bodyEndPosition: Int {
+        return bodyOffset + bodyLength
+    }
+
+    init(path: String, bodyOffset: Int, bodyLength: Int) {
+        self.path = path
+        self.bodyOffset = bodyOffset
+        self.bodyLength = bodyLength
+    }
+
+    // sourcery:inline:TypeDefinition.AutoCoding
+        required init?(coder aDecoder: NSCoder) {
+            guard let path: String = aDecoder.decode(forKey: "path") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["path"])); fatalError() }; self.path = path
+            self.bodyOffset = aDecoder.decode(forKey: "bodyOffset")
+            self.bodyLength = aDecoder.decode(forKey: "bodyLength")
+        }
+
+        func encode(with aCoder: NSCoder) {
+            aCoder.encode(self.path, forKey: "path")
+            aCoder.encode(self.bodyOffset, forKey: "bodyOffset")
+            aCoder.encode(self.bodyLength, forKey: "bodyLength")
+        }
+    // sourcery:end
+}

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -217,14 +217,13 @@ final class FileParser {
     }
 
     private func makeTypeDefinition(source: [String: SourceKitRepresentable]) -> TypeDefinition? {
-        guard let bodyOffset = source[SwiftDocKey.bodyOffset.rawValue] as? Int64,
-            let bodyLength = source[SwiftDocKey.bodyLength.rawValue] as? Int64,
+        guard let range = Substring.body.range(for: source),
             let path = path
             else {
                 return nil
         }
 
-        return TypeDefinition(path: path, bodyOffset: Int(bodyOffset), bodyLength: Int(bodyLength))
+        return TypeDefinition(path: path, bodyOffset: Int(range.offset), bodyLength: Int(range.length))
     }
 
     private func finishedParsing(types: [Type]) -> [Type] {

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -129,6 +129,7 @@ final class FileParser {
             type.annotations = annotations.from(source)
             type.attributes = parseDeclarationAttributes(source)
             type.setSource(source)
+            type.definition = makeTypeDefinition(source: source)
             types.append(type)
             return type
         }
@@ -213,6 +214,17 @@ final class FileParser {
         default:
             break
         }
+    }
+
+    private func makeTypeDefinition(source: [String: SourceKitRepresentable]) -> TypeDefinition? {
+        guard let bodyOffset = source[SwiftDocKey.bodyOffset.rawValue] as? Int64,
+            let bodyLength = source[SwiftDocKey.bodyLength.rawValue] as? Int64,
+            let path = path
+            else {
+                return nil
+        }
+
+        return TypeDefinition(path: path, bodyOffset: Int(bodyOffset), bodyLength: Int(bodyLength))
     }
 
     private func finishedParsing(types: [Type]) -> [Type] {

--- a/SourceryTests/Models/TypedSpec.generated.swift
+++ b/SourceryTests/Models/TypedSpec.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.5.8 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.5.9 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Quick


### PR DESCRIPTION
This PR implements #195 

To implement this, I made the following changes:

- Added a new class `TypeDefinition` that is used as a variable on `Type` to store the location (file, offset) where a type is defined
- Use this `definition` variable in `processInlineRanges` to add the markers automatically
- Added a test
- Re-ran sourcery on itself

The result is that you can include `// sourcery:inline:auto:MyType`. If no inline range is found by `processInlineRanges`, the comments are automatically added at the end of the declaration.