### PR TITLE
fix validation errors in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,8 +22,6 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
   - Packages
   - SourceryTests/Stub
-  - *.generated.swift
-  - *.stencil
 
 type_body_length:
   - 700 #warning
@@ -53,6 +51,6 @@ custom_rules:
 
   explicit_failure_calls:
     name: "Avoid asserting 'false'"
-    regex: "((assert|precondition)\(false)"
+    regex: '((assert|precondition)\(false)'
     message: "Use assertionFailure() or preconditionFailure() instead."
     severity: warning


### PR DESCRIPTION
SwiftLint is migrating to a more robust YAML parser (libYAML, see https://github.com/realm/SwiftLint/pull/1411). The previous parser wasn't spec-compliant and actually accepted invalid YAML sequences as input.

This commit makes .swiftlint.yml pass validation at http://www.yamllint.com.

SwiftLint has also _never_ supported wilcards in the 'excluded' key of its YAML configuration file, so just remove those.