### PR TITLE
Inline annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Added `isMutable` property for `Variable`
 - Added support for scanning multiple targets
 - Added access level filters and disabled filtering private declarations
+- Added support for inline comments for annotations with `/*` and `*/`
+- Added annotations for enum case associated values and method parameters
 
 ## 0.5.9
 

--- a/README.md
+++ b/README.md
@@ -527,19 +527,19 @@ Available types:
 Sourcery supports annotating your classes and variables with special annotations, similar how attributes work in Rust / Java
 
 ```swift
-/// sourcery: skipPersistence
+// sourcery: skipPersistence
 /// Some documentation comment
-/// sourcery: anotherAnnotation = 232, yetAnotherAnnotation = "value"
+// sourcery: anotherAnnotation = 232, yetAnotherAnnotation = "value"
 /// Documentation
 var precomputedHash: Int
 ```
 
 If you want to attribute multiple items with same attributes, you can use section annotations:
 ```swift
-/// sourcery:begin: skipEquality, skipPersistence
+// sourcery:begin: skipEquality, skipPersistence
   var firstVariable: Int
   var secondVariable: Int
-/// sourcery:end
+// sourcery:end
 ```
 
 #### Rules:
@@ -548,6 +548,7 @@ If you want to attribute multiple items with same attributes, you can use sectio
 - You can add multiline annotations
 - You can interleave annotations with documentation
 - Sourcery scans all `sourcery:` annotations in the given comment block above the source until first non-comment/doc line
+- Using `/*` and `*/` for annotation comment you can put it on the same line with your code. This is usefull for annotating methods parameters, enum case associated values. All such annotations should be placed in one comment block. When using inline annotations for enum cases, cases must be separated with `;`
 
 #### Format:
 

--- a/Sourcery/CodeGenerated/Description.generated.swift
+++ b/Sourcery/CodeGenerated/Description.generated.swift
@@ -13,10 +13,10 @@ extension ArrayType {
 extension AssociatedValue {
     override var description: String {
         var string = "\(type(of: self)): "
-        string += "localName = \(self.localName), "
-        string += "externalName = \(self.externalName), "
-        string += "annotations = \(self.annotations), "
-        string += "typeName = \(self.typeName)"
+        string += "localName = \(String(describing: self.localName)), "
+        string += "externalName = \(String(describing: self.externalName)), "
+        string += "typeName = \(String(describing: self.typeName)), "
+        string += "annotations = \(String(describing: self.annotations))"
         return string
     }
 }
@@ -110,7 +110,8 @@ extension MethodParameter {
         string += "argumentLabel = \(String(describing: self.argumentLabel)), "
         string += "name = \(String(describing: self.name)), "
         string += "typeName = \(String(describing: self.typeName)), "
-        string += "typeAttributes = \(String(describing: self.typeAttributes))"
+        string += "typeAttributes = \(String(describing: self.typeAttributes)), "
+        string += "annotations = \(String(describing: self.annotations))"
         return string
     }
 }

--- a/Sourcery/CodeGenerated/Description.generated.swift
+++ b/Sourcery/CodeGenerated/Description.generated.swift
@@ -13,9 +13,10 @@ extension ArrayType {
 extension AssociatedValue {
     override var description: String {
         var string = "\(type(of: self)): "
-        string += "localName = \(String(describing: self.localName)), "
-        string += "externalName = \(String(describing: self.externalName)), "
-        string += "typeName = \(String(describing: self.typeName))"
+        string += "localName = \(self.localName), "
+        string += "externalName = \(self.externalName), "
+        string += "annotations = \(self.annotations), "
+        string += "typeName = \(self.typeName)"
         return string
     }
 }

--- a/Sourcery/CodeGenerated/Diffable.generated.swift
+++ b/Sourcery/CodeGenerated/Diffable.generated.swift
@@ -24,6 +24,7 @@ extension AssociatedValue: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "localName").trackDifference(actual: self.localName, expected: rhs.localName))
         results.append(contentsOf: DiffableResult(identifier: "externalName").trackDifference(actual: self.externalName, expected: rhs.externalName))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: rhs.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: rhs.annotations))
         return results
     }
 }
@@ -154,6 +155,7 @@ extension MethodParameter: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "argumentLabel").trackDifference(actual: self.argumentLabel, expected: rhs.argumentLabel))
         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: rhs.name))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: rhs.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: rhs.annotations))
         return results
     }
 }

--- a/Sourcery/CodeGenerated/Equality.generated.swift
+++ b/Sourcery/CodeGenerated/Equality.generated.swift
@@ -16,6 +16,7 @@ extension AssociatedValue {
         if self.localName != rhs.localName { return false }
         if self.externalName != rhs.externalName { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.annotations != rhs.annotations { return false }
         return true
     }
 }

--- a/Sourcery/CodeGenerated/Equality.generated.swift
+++ b/Sourcery/CodeGenerated/Equality.generated.swift
@@ -116,6 +116,7 @@ extension MethodParameter {
         if self.argumentLabel != rhs.argumentLabel { return false }
         if self.name != rhs.name { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.annotations != rhs.annotations { return false }
         return true
     }
 }

--- a/Sourcery/CodeGenerated/JSExport.generated.swift
+++ b/Sourcery/CodeGenerated/JSExport.generated.swift
@@ -16,6 +16,7 @@ extension ArrayType: ArrayTypeAutoJSExport {}
     var externalName: String? { get }
     var typeName: TypeName { get }
     var type: Type? { get }
+    var annotations: [String: NSObject] { get }
     var isOptional: Bool { get }
     var isImplicitlyUnwrappedOptional: Bool { get }
     var unwrappedTypeName: String { get }
@@ -147,6 +148,7 @@ extension Method: MethodAutoJSExport {}
     var typeName: TypeName { get }
     var type: Type? { get }
     var typeAttributes: [String: Attribute] { get }
+    var annotations: [String: NSObject] { get }
     var isOptional: Bool { get }
     var isImplicitlyUnwrappedOptional: Bool { get }
     var unwrappedTypeName: String { get }

--- a/Sourcery/Models/Enum.swift
+++ b/Sourcery/Models/Enum.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-final class AssociatedValue: NSObject, SourceryModel, AutoDescription, Typed {
+final class AssociatedValue: NSObject, SourceryModel, AutoDescription, Typed, Annotated {
     let localName: String?
     let externalName: String?
     let typeName: TypeName
@@ -14,15 +14,19 @@ final class AssociatedValue: NSObject, SourceryModel, AutoDescription, Typed {
     /// sourcery: skipDescription
     var type: Type?
 
-    init(localName: String?, externalName: String?, typeName: TypeName, type: Type? = nil) {
+    /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
+    var annotations: [String: NSObject] = [:]
+
+    init(localName: String?, externalName: String?, typeName: TypeName, type: Type? = nil, annotations: [String: NSObject] = [:]) {
         self.localName = localName
         self.externalName = externalName
         self.typeName = typeName
         self.type = type
+        self.annotations = annotations
     }
 
-    convenience init(name: String? = nil, typeName: TypeName, type: Type? = nil) {
-        self.init(localName: name, externalName: name, typeName: typeName, type: type)
+    convenience init(name: String? = nil, typeName: TypeName, type: Type? = nil, annotations: [String: NSObject] = [:]) {
+        self.init(localName: name, externalName: name, typeName: typeName, type: type, annotations: annotations)
     }
 
     // sourcery:inline:AssociatedValue.AutoCoding
@@ -31,6 +35,7 @@ final class AssociatedValue: NSObject, SourceryModel, AutoDescription, Typed {
             self.externalName = aDecoder.decode(forKey: "externalName")
             guard let typeName: TypeName = aDecoder.decode(forKey: "typeName") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typeName"])); fatalError() }; self.typeName = typeName
             self.type = aDecoder.decode(forKey: "type")
+            guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
         }
 
         func encode(with aCoder: NSCoder) {
@@ -38,6 +43,7 @@ final class AssociatedValue: NSObject, SourceryModel, AutoDescription, Typed {
             aCoder.encode(self.externalName, forKey: "externalName")
             aCoder.encode(self.typeName, forKey: "typeName")
             aCoder.encode(self.type, forKey: "type")
+            aCoder.encode(self.annotations, forKey: "annotations")
         }
         // sourcery:end
 

--- a/Sourcery/Models/Method.swift
+++ b/Sourcery/Models/Method.swift
@@ -3,7 +3,7 @@ import Foundation
 //typealias used to avoid types ambiguty in tests
 typealias SourceryMethod = Method
 
-final class MethodParameter: NSObject, SourceryModel, Typed {
+final class MethodParameter: NSObject, SourceryModel, Typed, Annotated {
     /// Parameter external name
     var argumentLabel: String?
 
@@ -19,22 +19,27 @@ final class MethodParameter: NSObject, SourceryModel, Typed {
 
     var typeAttributes: [String: Attribute] { return typeName.attributes }
 
+    /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
+    var annotations: [String: NSObject] = [:]
+
     /// Underlying parser data, never to be used by anything else
     // sourcery: skipEquality, skipDescription, skipCoding, skipJSExport
     internal var __parserData: Any?
 
-    init(argumentLabel: String?, name: String = "", typeName: TypeName, type: Type? = nil) {
+    init(argumentLabel: String?, name: String = "", typeName: TypeName, type: Type? = nil, annotations: [String: NSObject] = [:]) {
         self.typeName = typeName
         self.argumentLabel = argumentLabel
         self.name = name
         self.type = type
+        self.annotations = annotations
     }
 
-    init(name: String = "", typeName: TypeName, type: Type? = nil) {
+    init(name: String = "", typeName: TypeName, type: Type? = nil, annotations: [String: NSObject] = [:]) {
         self.typeName = typeName
         self.argumentLabel = name
         self.name = name
         self.type = type
+        self.annotations = annotations
     }
 
     // sourcery:inline:MethodParameter.AutoCoding
@@ -43,6 +48,7 @@ final class MethodParameter: NSObject, SourceryModel, Typed {
             guard let name: String = aDecoder.decode(forKey: "name") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["name"])); fatalError() }; self.name = name
             guard let typeName: TypeName = aDecoder.decode(forKey: "typeName") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typeName"])); fatalError() }; self.typeName = typeName
             self.type = aDecoder.decode(forKey: "type")
+            guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
         }
 
         func encode(with aCoder: NSCoder) {
@@ -50,6 +56,7 @@ final class MethodParameter: NSObject, SourceryModel, Typed {
             aCoder.encode(self.name, forKey: "name")
             aCoder.encode(self.typeName, forKey: "typeName")
             aCoder.encode(self.type, forKey: "type")
+            aCoder.encode(self.annotations, forKey: "annotations")
         }
         // sourcery:end
 }

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -128,7 +128,7 @@ final class FileParser {
             }
 
             type.isGeneric = isGeneric(source: source)
-            type.annotations = annotations.from(source)
+            type.annotations = parseAnnotations(from: source)
             type.attributes = parseDeclarationAttributes(source)
             type.setSource(source)
             type.definition = makeTypeDefinition(source: source)
@@ -423,7 +423,7 @@ extension FileParser {
             computed = false
         }
 
-        let variable = Variable(name: name, typeName: typeName, accessLevel: (read: accesibility, write: writeAccessibility), isComputed: computed, isStatic: isStatic, attributes: parseDeclarationAttributes(source), annotations: annotations.from(source))
+        let variable = Variable(name: name, typeName: typeName, accessLevel: (read: accesibility, write: writeAccessibility), isComputed: computed, isStatic: isStatic, attributes: parseDeclarationAttributes(source), annotations: parseAnnotations(from: source))
         variable.setSource(source)
 
         return variable
@@ -435,8 +435,15 @@ extension FileParser {
 extension FileParser {
 
     internal func parseMethod(_ source: [String: SourceKitRepresentable]) -> Method? {
-        guard let (name, kind, accesibility) = parseTypeRequirements(source),
-            let fullName = extract(.name, from: source) else { return nil }
+        let requirements = parseTypeRequirements(source)
+        guard
+            let kind = requirements?.kind,
+            let accessibility = requirements?.accessibility,
+            var name = requirements?.name,
+            var fullName = extract(.name, from: source) else { return nil }
+
+        fullName = fullName.strippingComments()
+        name = name.strippingComments()
 
         let isStatic = kind == .functionMethodStatic
         let isClass = kind == .functionMethodClass
@@ -492,7 +499,7 @@ extension FileParser {
             }
         }
 
-        let method = Method(name: fullName, selectorName: name, returnTypeName: TypeName(returnTypeName), throws: `throws`, accessLevel: accesibility, isStatic: isStatic, isClass: isClass, isFailableInitializer: isFailableInitializer, attributes: parseDeclarationAttributes(source), annotations: annotations.from(source))
+        let method = Method(name: fullName, selectorName: name, returnTypeName: TypeName(returnTypeName), throws: `throws`, accessLevel: accessibility, isStatic: isStatic, isClass: isClass, isFailableInitializer: isFailableInitializer, attributes: parseDeclarationAttributes(source), annotations: parseAnnotations(from: source))
         method.setSource(source)
 
         return method
@@ -502,8 +509,20 @@ extension FileParser {
         guard let (name, _, _) = parseTypeRequirements(source),
             let type = source[SwiftDocKey.typeName.rawValue] as? String else { return nil }
 
+        let annotations: [String: NSObject]
+        if var body = extract(.keyPrefix, from: source) {
+            if let comma = body.range(of: ",", options: [.backwards])?.upperBound {
+                body = body.substring(from: comma)
+            } else if let parenthesis = body.range(of: "(", options: [.backwards])?.upperBound {
+                body = body.substring(from: parenthesis)
+            }
+            annotations = AnnotationsParser(contents: body).all
+        } else {
+            annotations = [:]
+        }
+
         let typeName = TypeName(type, attributes: parseTypeAttributes(type))
-        let parameter = MethodParameter(name: name, typeName: typeName)
+        let parameter = MethodParameter(name: name, typeName: typeName, annotations: annotations)
         parameter.setSource(source)
         return parameter
     }
@@ -539,7 +558,22 @@ extension FileParser {
              print("\(logPrefix)parseEnumCase: Unknown enum case body format \(wrappedBody)")
         }
 
-        let enumCase = EnumCase(name: name, rawValue: rawValue, associatedValues: associatedValues, annotations: annotations.from(source))
+        let annotations: [String: NSObject]
+        if var body = extract(.keyPrefix, from: source) {
+            if let semicolon = body.range(of: ";", options: [.backwards])?.upperBound {
+                body = body.substring(from: semicolon)
+            } else if let comma = body.range(of: ",", options: [.backwards])?.upperBound {
+                body = body.substring(from: comma)
+            } else if let brace = body.range(of: "{", options: [.backwards])?.upperBound {
+                body = body.substring(from: brace)
+            }
+
+            annotations = AnnotationsParser(contents: body).all
+        } else {
+            annotations = [:]
+        }
+
+        let enumCase = EnumCase(name: name, rawValue: rawValue, associatedValues: associatedValues, annotations: annotations)
         enumCase.setSource(source)
         return enumCase
     }
@@ -558,15 +592,8 @@ extension FileParser {
             .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
             .enumerated()
             .map { index, body in
-                var body = body
                 let annotations = AnnotationsParser(contents: body).all
-                let bodyLines = body.lines()
-                if bodyLines.count > 1 {
-                    body = bodyLines.filter({ line in !line.content.hasPrefix("//") }).map({ $0.content }).joined(separator:"")
-                }
-                if let annotationStart = body.range(of: "/*")?.lowerBound, let annotationEnd = body.range(of: "*/")?.upperBound {
-                    body = body.replacingCharacters(in: annotationStart ..< annotationEnd, with: "")
-                }
+                let body = body.strippingComments()
                 let nameAndType = body.colonSeparated().map({ $0.trimmingCharacters(in: .whitespaces) })
                 let defaultName: String? = index == 0 && items.count == 1 ? nil : "\(index)"
 
@@ -730,6 +757,40 @@ extension FileParser {
 
 }
 
+// MARK: - Annotations
+
+extension FileParser {
+
+    func parseAnnotations(from source: [String: SourceKitRepresentable], fromKeyword: String? = nil) -> Annotations {
+        guard let prefix = extract(.keyPrefix, from: source),
+            let keyRange = Substring.key.range(for: source),
+            let keyLocation = self.contents.location(fromByteOffset: Int(keyRange.offset)),
+            let keyLine = self.contents.lineAndCharacter(forCharacterOffset: keyLocation) else {
+
+            return self.annotations.from(source)
+        }
+
+        let annotationStart: NSRange = prefix.bridge().range(of: "/*", options: [.backwards])
+        guard annotationStart.location != NSNotFound,
+            let annotationStartLine = self.contents.lineAndCharacter(forCharacterOffset: annotationStart.location),
+            annotationStartLine.line == keyLine.line else {
+
+            return self.annotations.from(source)
+        }
+
+        if let fromKeyword = fromKeyword {
+            let keywordStart = prefix.bridge().range(of: fromKeyword, options: [.backwards])
+
+            guard keywordStart.location != NSNotFound && keywordStart.location > annotationStart.location else {
+                return self.annotations.from(source)
+            }
+        }
+
+        return AnnotationsParser(contents: prefix.bridge().substring(from: annotationStart.location)).all
+    }
+
+}
+
 // MARK: - Helpres
 extension FileParser {
 
@@ -757,4 +818,28 @@ extension FileParser {
         return contents.bridge().substringWithByteRange(start: from.offset, length: to.offset + to.length - from.offset)
     }
 
+}
+
+extension String {
+    
+    func strippingComments() -> String {
+        var finished: Bool
+        var stripped = self
+        repeat {
+            finished = true
+            let lines = stripped.lines()
+            if lines.count > 1 {
+                stripped = lines.filter({ line in !line.content.hasPrefix("//") }).map({ $0.content }).joined(separator:"")
+                finished = false
+            }
+            if let annotationStart = stripped.range(of: "/*")?.lowerBound, let annotationEnd = stripped.range(of: "*/")?.upperBound {
+                stripped = stripped.replacingCharacters(in: annotationStart ..< annotationEnd, with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                finished = false
+            }
+        } while !finished
+        
+        return stripped
+    }
+    
 }

--- a/SourceryTests/Parsing/AnnotationsParserSpec.swift
+++ b/SourceryTests/Parsing/AnnotationsParserSpec.swift
@@ -19,16 +19,16 @@ class AnnotationsParserSpec: QuickSpec {
                 }
 
                 it("extracts single annotation") {
-                    let annotations = ["skipEquability": NSNumber(value: true)]
+                    let annotations = ["skipEquality": NSNumber(value: true)]
 
-                    expect(parse("skipEquability")).to(equal(annotations))
+                    expect(parse("skipEquality")).to(equal(annotations))
                 }
 
                 it("extracts multiple annotations on the same line") {
-                    let annotations = ["skipEquability": NSNumber(value: true),
+                    let annotations = ["skipEquality": NSNumber(value: true),
                                        "jsonKey": "json_key" as NSString]
 
-                    expect(parse("skipEquability, jsonKey = \"json_key\"")).to(equal(annotations))
+                    expect(parse("skipEquality, jsonKey = \"json_key\"")).to(equal(annotations))
                 }
             }
             describe("parse(content:)") {
@@ -36,13 +36,18 @@ class AnnotationsParserSpec: QuickSpec {
                     return AnnotationsParser(contents: content).all
                 }
 
+                it("extracts inline annotations") {
+                    let result = parse("/* sourcery: skipEquality */var name: Int { return 2 }")
+                    expect(result).to(equal(["skipEquality": NSNumber(value: true)]))
+                }
+
                 it("extracts multi-line annotations, including numbers") {
-                    let annotations = ["skipEquability": NSNumber(value: true),
+                    let annotations = ["skipEquality": NSNumber(value: true),
                                        "placeholder": "geo:37.332112,-122.0329753?q=1 Infinite Loop" as NSString,
                                        "jsonKey": "[\"json_key\": key, \"json_value\": value]" as NSString,
                                        "thirdProperty": NSNumber(value: -3)]
 
-                    let result = parse("// sourcery: skipEquability, jsonKey = [\"json_key\": key, \"json_value\": value]\n" +
+                    let result = parse("// sourcery: skipEquality, jsonKey = [\"json_key\": key, \"json_value\": value]\n" +
                                                "// sourcery: thirdProperty = -3\n" +
                                                "// sourcery: placeholder = \"geo:37.332112,-122.0329753?q=1 Infinite Loop\"\n" +
                                                "var name: Int { return 2 }")

--- a/SourceryTests/Parsing/FileParser + MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser + MethodsSpec.swift
@@ -218,10 +218,40 @@ class FileParserMethodsSpec: QuickSpec {
                     }
                 }
 
-                it("extracts sourcery annotations") {
+                it("extracts method annotations") {
                     expect(parse("class Foo {\n // sourcery: annotation\nfunc foo() }")).to(equal([
                         Class(name: "Foo", methods: [
                             Method(name: "foo()", annotations: ["annotation": NSNumber(value: true)])
+                            ])
+                        ]))
+                }
+
+                it("extracts method inline annotations") {
+                    expect(parse("class Foo {\n /* sourcery: annotation */func foo() }")).to(equal([
+                        Class(name: "Foo", methods: [
+                            Method(name: "foo()", annotations: ["annotation": NSNumber(value: true)])
+                            ])
+                        ]))
+                }
+
+                it("extracts parameter annotations") {
+                    expect(parse("class Foo {\n func foo(\n// sourcery: annotationA\na: Int,\n// sourcery: annotationB\nb: Int) }")).to(equal([
+                        Class(name: "Foo", methods: [
+                            Method(name: "foo(a: Int,b: Int)", selectorName: "foo(a:b:)", parameters: [
+                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true)])
+                                ])
+                            ])
+                        ]))
+                }
+
+                it("extracts parameter inline annotations") {
+                    expect(parse("class Foo {\nfunc foo(/* sourcery: annotationA */a: Int, /* sourcery: annotationB*/b: Int) }")).to(equal([
+                        Class(name: "Foo", methods: [
+                            Method(name: "foo(a: Int, b: Int)", selectorName: "foo(a:b:)", parameters: [
+                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true)])
+                                ])
                             ])
                         ]))
                 }

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -243,6 +243,34 @@ class FileParserSpec: QuickSpec {
                                     ]))
                     }
 
+                    it("extracts associated value annotations properly") {
+                        let result = parse("enum Foo {\n case optionA(\n// sourcery: annotation\nInt)\n case optionB }")
+                        expect(result)
+                            .to(equal([
+                                Enum(name: "Foo",
+                                     cases: [
+                                        EnumCase(name: "optionA", associatedValues: [
+                                            AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: ["annotation": NSNumber(value: true)])
+                                            ]),
+                                        EnumCase(name: "optionB")
+                                    ])
+                                ]))
+                    }
+
+                    it("extracts associated value inline annotations properly") {
+                        let result = parse("enum Foo {\n case optionA(/* sourcery: annotation*/Int)\n case optionB }")
+                        expect(result)
+                            .to(equal([
+                                Enum(name: "Foo",
+                                     cases: [
+                                        EnumCase(name: "optionA", associatedValues: [
+                                            AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: ["annotation": NSNumber(value: true)])
+                                            ]),
+                                        EnumCase(name: "optionB")
+                                    ])
+                                ]))
+                    }
+
                     it("extracts variables properly") {
                         expect(parse("enum Foo { var x: Int { return 1 } }"))
                                 .to(equal([

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -231,7 +231,7 @@ class FileParserSpec: QuickSpec {
                     }
 
                     it("extracts cases with annotations properly") {
-                        expect(parse("enum Foo {\n // sourcery: annotation\ncase optionA(Int)\n case optionB }"))
+                        expect(parse("enum Foo {\n // sourcery: annotation\ncase optionA(Int); case optionB }"))
                                 .to(equal([
                                     Enum(name: "Foo",
                                          cases: [
@@ -243,8 +243,21 @@ class FileParserSpec: QuickSpec {
                                     ]))
                     }
 
+                    it("extracts cases with inline annotations properly") {
+                        expect(parse("enum Foo {\n /* sourcery: annotation */case optionA(Int); case optionB }"))
+                            .to(equal([
+                                Enum(name: "Foo",
+                                     cases: [
+                                        EnumCase(name: "optionA", associatedValues: [
+                                            AssociatedValue(name: nil, typeName: TypeName("Int"))
+                                            ], annotations: ["annotation": NSNumber(value: true)]),
+                                        EnumCase(name: "optionB")
+                                    ])
+                                ]))
+                    }
+
                     it("extracts associated value annotations properly") {
-                        let result = parse("enum Foo {\n case optionA(\n// sourcery: annotation\nInt)\n case optionB }")
+                        let result = parse("enum Foo {\n case optionA(\n// sourcery: annotation\nInt); case optionB }")
                         expect(result)
                             .to(equal([
                                 Enum(name: "Foo",


### PR DESCRIPTION
Resolves #142 

I feel like annotations parser could become simpler if we use `SyntaxMap`. It provides comments and their positions, we need match them with definitions positions and extract their content. Will look at it some time later.