### PR TITLE
fix: inlining multiple blocks in the same file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Added annotations for enum case associated values and method parameters
 - Added `isConvenienceInitializer` property for `Method`
 
+### Fixed
+
+- Inserting multiple inline code block in one file
+
 ## 0.5.9
 
 ### New Features

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -46,12 +46,10 @@ extension Definition {
         return try path?.read(.utf8)
     }
 
-    func appendingBody(with contentsToInsert: String) throws -> String? {
+    func rangeToAppendBody() throws -> NSRange? {
         guard let contents = try self.contents() else { return nil }
         guard let range = bodyRange(contents) else { return nil }
-
-        let rangeToInsert = NSRange(location: NSMaxRange(range), length: 0)
-        return contents.bridge().replacingCharacters(in: rangeToInsert, with: contentsToInsert)
+        return NSRange(location: NSMaxRange(range), length: 0)
     }
 
 }


### PR DESCRIPTION
Might fix #156 
The issue is that blocks of code which should be inserted into files were sorted by their location in generated file (were they are being cut from), instead of sorting them by the location in their destination files. This can lead to the situation when in one file we are inserting code in a wrong order (to preserve ranges we need to insert it starting from the end of file). In Sourcery own code base it can be reproduced in `Method.swift` when adding property to `MethodParameter`.