### PR TITLE
Suppress swift templates warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Inserting multiple inline code block in one file
+- Suppress warnings when compiling swift templates
 
 ## 0.5.9
 

--- a/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
+++ b/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
@@ -97,7 +97,13 @@ class SwiftTemplate: Template {
             assert(diff.isEmpty)
         #endif
 
-        let arguments = [mainFile.description] + runtimeFiles + ["-Onone", "-module-name", "Sourcery"] + ["-o"] + [binaryFile.description]
+        let arguments = [mainFile.description] +
+            runtimeFiles + [
+                "-suppress-warnings",
+                "-Onone",
+                "-module-name", "Sourcery",
+                "-o", binaryFile.description
+        ]
 
         let compilationResult = try Process.runCommand(path: "/usr/bin/swiftc",
                                             arguments: arguments,


### PR DESCRIPTION
In case of warnings in swift templates we are still treating them as errors and that fails rendering.