### PR TITLE
fix: aggregating enum case annotations from previous cases

### DIFF
--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -588,11 +588,16 @@ extension FileParser {
         }
 
         let annotations: [String: NSObject]
-        if var body = extract(.keyPrefix, from: source) {
+        if var body = extract(.keyPrefix, from: source)?.trimmingSuffix("case") {
+            // search backwards for possible enum cases separators
             if let semicolon = body.range(of: ";", options: [.backwards])?.upperBound {
                 body = body.substring(from: semicolon)
             } else if let comma = body.range(of: ",", options: [.backwards])?.upperBound {
                 body = body.substring(from: comma)
+            } else if let parenthesis = body.range(of: ")", options: [.backwards])?.upperBound {
+                body = body.substring(from: parenthesis)
+            } else if let `case` = body.range(of: "case", options: [.backwards])?.upperBound {
+                body = body.substring(from: `case`)
             } else if let brace = body.range(of: "{", options: [.backwards])?.upperBound {
                 body = body.substring(from: brace)
             }

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -240,7 +240,7 @@ class FileParserSpec: QuickSpec {
                     }
 
                     it("extracts cases with annotations properly") {
-                        expect(parse("enum Foo {\n // sourcery: annotation\ncase optionA(Int); case optionB }"))
+                        expect(parse("enum Foo {\n // sourcery: annotation\ncase optionA(Int)\n case optionB }"))
                                 .to(equal([
                                     Enum(name: "Foo",
                                          cases: [
@@ -253,7 +253,7 @@ class FileParserSpec: QuickSpec {
                     }
 
                     it("extracts cases with inline annotations properly") {
-                        expect(parse("enum Foo {\n /* sourcery: annotation */case optionA(Int); case optionB }"))
+                        expect(parse("enum Foo {\n /* sourcery: annotation */case optionA(Int)\n case optionB }"))
                             .to(equal([
                                 Enum(name: "Foo",
                                      cases: [
@@ -266,7 +266,7 @@ class FileParserSpec: QuickSpec {
                     }
 
                     it("extracts associated value annotations properly") {
-                        let result = parse("enum Foo {\n case optionA(\n// sourcery: annotation\nInt); case optionB }")
+                        let result = parse("enum Foo {\n case optionA(\n// sourcery: annotation\nInt)\n case optionB }")
                         expect(result)
                             .to(equal([
                                 Enum(name: "Foo",


### PR DESCRIPTION
Resolves #236 
Bug was introduced by inline annotations support (#212)