### PR TITLE
Support init functions for AutoMockable protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Internal changes
 
+- Improved `AutoMockable.stencil` to support protocols with `init` methods
 - Improved `AutoCases.stencil` to use `let` instead of computed `var`
 - Add the `lowerFirst` filter for Stencil templates.
 

--- a/Templates/AutoMockable.stencil
+++ b/Templates/AutoMockable.stencil
@@ -8,6 +8,14 @@
     {% endif %}
 {% endmacro %}
 
+{% macro methodCalledVariableName method %}
+{{ method.shortName }}Called
+{% endmacro %}
+
+{% macro methodReturnValueVariableName method %}
+{{ method.shortName }}ReturnValue
+{% endmacro %}
+
 {% for type in types.based.AutoMockable %}{% if type.kind == 'protocol' %}
 {% if not type.name == "AutoMockable" %}
 class {{ type.name }}Mock: {{ type.name }} {
@@ -19,9 +27,13 @@ class {{ type.name }}Mock: {{ type.name }} {
 {% for method in type.allMethods %}
     //MARK: - {{ method.shortName }}
 
-    {% if not method.isInitializer %}var {{ method.shortName }}Called = false{% endif %}
-    {% if method.parameters.count == 1 %}var {{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }}: {{ param.typeName.unwrappedTypeName }}?{% endfor %}{% else %}{% if not method.parameters.count == 0 %}var {{ method.shortName }}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?{% endif %}{% endif %}
-    {% if not method.returnTypeName.isVoid and not method.isInitializer %}var {{ method.shortName }}ReturnValue: {{ method.returnTypeName }}!{% endif %}
+    {% if not method.isInitializer %}var {% call methodCalledVariableName method %} = false{% endif %}
+    {% if method.parameters.count == 1 %}
+    var {{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }}: {{ param.typeName.unwrappedTypeName }}?{% endfor %}
+    {% else %}{% if not method.parameters.count == 0 %}
+    var {{ method.shortName }}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?
+    {% endif %}{% endif %}
+    {% if not method.returnTypeName.isVoid and not method.isInitializer %}var {% call methodReturnValueVariableName method %}: {{ method.returnTypeName }}!{% endif %}
 
 {% if method.isInitializer %}
     required {{ method.name }} {
@@ -30,9 +42,9 @@ class {{ type.name }}Mock: {{ type.name }} {
 {% else %}
     func {{ method.name }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
 
-        {{ method.shortName }}Called = true
+        {% call methodCalledVariableName method %} = true
         {% call methodReceivedParameters method %}
-        {% if not method.returnTypeName.isVoid %}return {{ method.shortName }}ReturnValue{% endif %}
+        {% if not method.returnTypeName.isVoid %}return {% call methodReturnValueVariableName method %}{% endif %}
     }
 {% endif %}
 {% endfor %}

--- a/Templates/AutoMockable.stencil
+++ b/Templates/AutoMockable.stencil
@@ -1,3 +1,5 @@
+import Cocoa
+
 {% for type in types.based.AutoMockable %}{% if type.kind == 'protocol' %}
 {% if not type.name == "AutoMockable" %}
 class {{ type.name }}Mock: {{ type.name }} {
@@ -13,13 +15,19 @@ class {{ type.name }}Mock: {{ type.name }} {
     {% if method.parameters.count == 1 %}var {{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }}: {{ param.typeName.unwrappedTypeName }}?{% endfor %}{% else %}{% if not method.parameters.count == 0 %}var {{ method.shortName }}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?{% endif %}{% endif %}
     {% if not method.returnTypeName.isVoid and not method.shortName == "init" %}var {{ method.shortName }}ReturnValue: {{ method.returnTypeName }}!{% endif %}
 
+    {% if not method.shortName == "init" %}
     func {{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel == nil %}_{% else %}{{ param.argumentLabel }}{% endif %}{% if not param.argumentLabel == param.name %} {{ param.name }}{% endif %}: {{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}){% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
 
-        {% if not method.shortName == "init" %}{{ method.shortName }}Called = true{% endif %}
-        {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}{% if not method.returnTypeName.isVoid %}{% endif %}
-        {% if not method.returnTypeName.isVoid and not method.shortName == "init" %}return {{ method.shortName }}ReturnValue{% endif %}{% endif %}
+    {{ method.shortName }}Called = true
+    {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}
+    {% if not method.returnTypeName.isVoid %}return {{ method.shortName }}ReturnValue{% endif %}{% endif %}
     }
+    {% else %}
+    required init({% for param in method.parameters %}{% if param.argumentLabel == nil %}_{% else %}{{ param.argumentLabel }}{% endif %}{% if not param.argumentLabel == param.name %} {{ param.name }}{% endif %}: {{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}) {
 
+        {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}{% endif %}
+    }
+    {% endif %}
 {% endfor %}
 }
 {% endif %}{% endif %}

--- a/Templates/AutoMockable.stencil
+++ b/Templates/AutoMockable.stencil
@@ -11,21 +11,17 @@ class {{ type.name }}Mock: {{ type.name }} {
     {% for method in type.allMethods %}
     //MARK: - {{ method.shortName }}
 
-    {% if not method.shortName == "init" %}var {{ method.shortName }}Called = false{% endif %}
-    {% if method.parameters.count == 1 %}var {{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }}: {{ param.typeName.unwrappedTypeName }}?{% endfor %}{% else %}{% if not method.parameters.count == 0 %}var {{ method.shortName }}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?{% endif %}{% endif %}
-    {% if not method.returnTypeName.isVoid and not method.shortName == "init" %}var {{ method.shortName }}ReturnValue: {{ method.returnTypeName }}!{% endif %}
-
-    {% if not method.shortName == "init" %}
-    func {{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel == nil %}_{% else %}{{ param.argumentLabel }}{% endif %}{% if not param.argumentLabel == param.name %} {{ param.name }}{% endif %}: {{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}){% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
-
-    {{ method.shortName }}Called = true
-    {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}
-    {% if not method.returnTypeName.isVoid %}return {{ method.shortName }}ReturnValue{% endif %}{% endif %}
-    }
-    {% else %}
+    {% if method.isInitializer %}
     required init({% for param in method.parameters %}{% if param.argumentLabel == nil %}_{% else %}{{ param.argumentLabel }}{% endif %}{% if not param.argumentLabel == param.name %} {{ param.name }}{% endif %}: {{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}) {
 
         {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}{% endif %}
+    }
+    {% else %}
+    func {{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel == nil %}_{% else %}{{ param.argumentLabel }}{% endif %}{% if not param.argumentLabel == param.name %} {{ param.name }}{% endif %}: {{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}){% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+
+        {{ method.shortName }}Called = true
+        {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}
+        {% if not method.returnTypeName.isVoid %}return {{ method.shortName }}ReturnValue{% endif %}{% endif %}
     }
     {% endif %}
 {% endfor %}

--- a/Templates/AutoMockable.stencil
+++ b/Templates/AutoMockable.stencil
@@ -1,3 +1,13 @@
+{% macro methodReceivedParameters method %}
+    {%if method.parameters.count == 1 %}
+        {{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}
+    {% else %}
+    {% if not method.parameters.count == 0 %}
+        {{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
+    {% endif %}
+    {% endif %}
+{% endmacro %}
+
 {% for type in types.based.AutoMockable %}{% if type.kind == 'protocol' %}
 {% if not type.name == "AutoMockable" %}
 class {{ type.name }}Mock: {{ type.name }} {
@@ -6,26 +16,25 @@ class {{ type.name }}Mock: {{ type.name }} {
     var {{ variable.name }}: {{ variable.typeName }}{% if not variable.isOptional %}{% if variable.isArray %} = []{% endif %}{% if variable.isDictionary %} = [:]{% endif %}{% endif %}
     {% endfor %}
 
-    {% for method in type.allMethods %}
+{% for method in type.allMethods %}
     //MARK: - {{ method.shortName }}
 
     {% if not method.isInitializer %}var {{ method.shortName }}Called = false{% endif %}
     {% if method.parameters.count == 1 %}var {{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }}: {{ param.typeName.unwrappedTypeName }}?{% endfor %}{% else %}{% if not method.parameters.count == 0 %}var {{ method.shortName }}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?{% endif %}{% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}var {{ method.shortName }}ReturnValue: {{ method.returnTypeName }}!{% endif %}
 
-    {% if method.isInitializer %}
+{% if method.isInitializer %}
     required {{ method.name }} {
-
-        {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}{% endif %}
+        {% call methodReceivedParameters method %}
     }
-    {% else %}
+{% else %}
     func {{ method.name }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
 
         {{ method.shortName }}Called = true
-        {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}
-        {% if not method.returnTypeName.isVoid %}return {{ method.shortName }}ReturnValue{% endif %}{% endif %}
+        {% call methodReceivedParameters method %}
+        {% if not method.returnTypeName.isVoid %}return {{ method.shortName }}ReturnValue{% endif %}
     }
-    {% endif %}
+{% endif %}
 {% endfor %}
 }
 {% endif %}{% endif %}

--- a/Templates/AutoMockable.stencil
+++ b/Templates/AutoMockable.stencil
@@ -11,13 +11,17 @@ class {{ type.name }}Mock: {{ type.name }} {
     {% for method in type.allMethods %}
     //MARK: - {{ method.shortName }}
 
+    {% if not method.isInitializer %}var {{ method.shortName }}Called = false{% endif %}
+    {% if method.parameters.count == 1 %}var {{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }}: {{ param.typeName.unwrappedTypeName }}?{% endfor %}{% else %}{% if not method.parameters.count == 0 %}var {{ method.shortName }}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?{% endif %}{% endif %}
+    {% if not method.returnTypeName.isVoid and not method.isInitializer %}var {{ method.shortName }}ReturnValue: {{ method.returnTypeName }}!{% endif %}
+
     {% if method.isInitializer %}
-    required init({% for param in method.parameters %}{% if param.argumentLabel == nil %}_{% else %}{{ param.argumentLabel }}{% endif %}{% if not param.argumentLabel == param.name %} {{ param.name }}{% endif %}: {{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}) {
+    required {{ method.name }} {
 
         {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}{% endif %}
     }
     {% else %}
-    func {{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel == nil %}_{% else %}{{ param.argumentLabel }}{% endif %}{% if not param.argumentLabel == param.name %} {{ param.name }}{% endif %}: {{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}){% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+    func {{ method.name }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
 
         {{ method.shortName }}Called = true
         {%if method.parameters.count == 1 %}{{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}{% else %}{% if not method.parameters.count == 0 %}{{ method.shortName }}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}

--- a/Templates/AutoMockable.stencil
+++ b/Templates/AutoMockable.stencil
@@ -1,5 +1,3 @@
-import Cocoa
-
 {% for type in types.based.AutoMockable %}{% if type.kind == 'protocol' %}
 {% if not type.name == "AutoMockable" %}
 class {{ type.name }}Mock: {{ type.name }} {


### PR DESCRIPTION
The template update fixes the incorrectly generated method for `init` methods.

For the following protocol:
```swift
protocol FolderEventsListener: AutoMockable {
    /// Designated initializer to create new instance of FolderEventsListener
    ///
    /// - Parameter folderPath: absolute folder path to watch
    /// - Parameter filter: filter for received event
    /// - Parameter fileWatcherFactory: factory to create underlying watcher
    init(folderPath: String, filter: FolderEventFilter?, fileWatcherFactory: FileWatcherFactory)
}
```

Before was:
```swift
func init(folderPath: String, filter: FolderEventFilter?, fileWatcherFactory: FileWatcherFactory) {

    initReceivedArguments = (folderPath: folderPath, filter: filter, fileWatcherFactory: fileWatcherFactory)
}
```

After:
```swift
required init(folderPath: String, filter: FolderEventFilter?, fileWatcherFactory: FileWatcherFactory) {

    initReceivedArguments = (folderPath: folderPath, filter: filter, fileWatcherFactory: fileWatcherFactory)
}
```
