### PR TITLE
Fixed documentation : Annotation filtering

### DIFF
--- a/docs/writing-templates.html
+++ b/docs/writing-templates.html
@@ -191,7 +191,7 @@ Sourcery also uses its extension <a href="https://github.com/SwiftGen/StencilSwi
 <li><code>enum</code>, <code>class</code>, <code>struct</code>, <code>protocol</code> - can be used for Type[s] as filter, can be negated with <code>!</code> prefix.</li>
 <li><code>based</code>, <code>implements</code>, <code>inherits</code> - can be used for Type[s], Variable[s], Associated value[s], can be negated with <code>!</code> prefix.</li>
 <li><code>count</code> - can be used to get count of filtered array</li>
-<li><code>annotated</code> - can be used on Type[s], Variable[s], Method[s] and Enum Case[s] to filter by annotation, e.g. <code>{% for var in variable|annotated: \&quot;skipDescription\&quot;%}</code>, can be negated with <code>!</code> prefix.</li>
+<li><code>annotated</code> - can be used on Type[s], Variable[s], Method[s] and Enum Case[s] to filter by annotation, e.g. <code>{% for var in variable|annotated:"skipDescription" %}</code>, can be negated with <code>!</code> prefix.</li>
 <li><code>public</code>, <code>open</code>, <code>internal</code>, <code>private</code>, <code>fileprivate</code> - can be used on Type[s] and Method[s] to filter by access level, can be negated with <code>!</code> prefix.</li>
 <li><code>publicGet</code>, <code>publicSet</code>, .etc - can be used on Variable[s] to filter by getter or setter access level, can be nagated with <code>!</code> prefix</li>
 </ul>

--- a/guides/Writing templates.md
+++ b/guides/Writing templates.md
@@ -41,7 +41,7 @@ Sourcery also uses its extension [StencilSwiftKit](https://github.com/SwiftGen/S
 - `enum`, `class`, `struct`, `protocol` - can be used for Type[s] as filter, can be negated with `!` prefix.
 - `based`, `implements`, `inherits` - can be used for Type[s], Variable[s], Associated value[s], can be negated with `!` prefix.
 - `count` - can be used to get count of filtered array
-- `annotated` - can be used on Type[s], Variable[s], Method[s] and Enum Case[s] to filter by annotation, e.g. `{% for var in variable|annotated: \"skipDescription\"%}`, can be negated with `!` prefix.
+- `annotated` - can be used on Type[s], Variable[s], Method[s] and Enum Case[s] to filter by annotation, e.g. `{% for var in variable|annotated:"skipDescription" %}`, can be negated with `!` prefix.
 - `public`, `open`, `internal`, `private`, `fileprivate` - can be used on Type[s] and Method[s] to filter by access level, can be negated with `!` prefix.
 - `publicGet`, `publicSet`, .etc - can be used on Variable[s] to filter by getter or setter access level, can be nagated with `!` prefix
 


### PR DESCRIPTION
I found out that the documentation is giving a wrong example of annotation filtering.
The correct format is 'varToFilter|annotated:"myAnnotation"', and it is the one used in Sourcery/Templates/Equality.stencil for example.