### PR TITLE
Improved inline annotations parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed detecting computed properties
 - Fixed typo in `isConvenienceInitialiser` property
 - Fixed creating cache folder when cache is disabled
+- Fixed parsing multiple enum cases annotations
 
 ### Internal changes
 

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -161,7 +161,7 @@ final class FileParser {
             }
 
             type.isGeneric = isGeneric(source: source)
-            type.annotations = parseAnnotations(from: source)
+            type.annotations = annotations.from(source)
             type.attributes = parseDeclarationAttributes(source)
             type.setSource(source)
             type.__path = path
@@ -446,7 +446,7 @@ extension FileParser {
         let writeAccessibility = setter.flatMap({ AccessLevel(rawValue: $0.replacingOccurrences(of: "source.lang.swift.accessibility.", with: "")) }) ?? .none
 
         let defaultValue = extractDefaultValue(type: maybeType, from: source)
-        let variable = Variable(name: name, typeName: typeName, accessLevel: (read: accesibility, write: writeAccessibility), isComputed: computed, isStatic: isStatic, defaultValue: defaultValue, attributes: parseDeclarationAttributes(source), annotations: parseAnnotations(from: source))
+        let variable = Variable(name: name, typeName: typeName, accessLevel: (read: accesibility, write: writeAccessibility), isComputed: computed, isStatic: isStatic, defaultValue: defaultValue, attributes: parseDeclarationAttributes(source), annotations: annotations.from(source))
         variable.setSource(source)
 
         return variable
@@ -524,7 +524,7 @@ extension FileParser {
             }
         }
 
-        let method = Method(name: fullName, selectorName: name, returnTypeName: TypeName(returnTypeName), throws: `throws`, rethrows: `rethrows`, accessLevel: accessibility, isStatic: isStatic, isClass: isClass, isFailableInitializer: isFailableInitializer, attributes: parseDeclarationAttributes(source), annotations: parseAnnotations(from: source))
+        let method = Method(name: fullName, selectorName: name, returnTypeName: TypeName(returnTypeName), throws: `throws`, rethrows: `rethrows`, accessLevel: accessibility, isStatic: isStatic, isClass: isClass, isFailableInitializer: isFailableInitializer, attributes: parseDeclarationAttributes(source), annotations: annotations.from(source))
         method.setSource(source)
 
         return method
@@ -534,21 +534,9 @@ extension FileParser {
         guard let (name, _, _) = parseTypeRequirements(source),
             let type = source[SwiftDocKey.typeName.rawValue] as? String else { return nil }
 
-        let annotations: [String: NSObject]
-        if var body = extract(.keyPrefix, from: source) {
-            if let comma = body.range(of: ",", options: [.backwards])?.upperBound {
-                body = body.substring(from: comma)
-            } else if let parenthesis = body.range(of: "(", options: [.backwards])?.upperBound {
-                body = body.substring(from: parenthesis)
-            }
-            annotations = AnnotationsParser(contents: body).all
-        } else {
-            annotations = [:]
-        }
-
         let typeName = TypeName(type, attributes: parseTypeAttributes(type))
         let defaultValue = extractDefaultValue(type: type, from: source)
-        let parameter = MethodParameter(name: name, typeName: typeName, defaultValue: defaultValue, annotations: annotations)
+        let parameter = MethodParameter(name: name, typeName: typeName, defaultValue: defaultValue, annotations: annotations.from(source))
         parameter.setSource(source)
         return parameter
     }
@@ -584,27 +572,7 @@ extension FileParser {
              Log.warning("\(logPrefix)parseEnumCase: Unknown enum case body format \(wrappedBody)")
         }
 
-        let annotations: [String: NSObject]
-        if var body = extract(.keyPrefix, from: source)?.trimmingSuffix("case") {
-            // search backwards for possible enum cases separators
-            if let semicolon = body.range(of: ";", options: [.backwards])?.upperBound {
-                body = body.substring(from: semicolon)
-            } else if let comma = body.range(of: ",", options: [.backwards])?.upperBound {
-                body = body.substring(from: comma)
-            } else if let parenthesis = body.range(of: ")", options: [.backwards])?.upperBound {
-                body = body.substring(from: parenthesis)
-            } else if let `case` = body.range(of: "case", options: [.backwards])?.upperBound {
-                body = body.substring(from: `case`)
-            } else if let brace = body.range(of: "{", options: [.backwards])?.upperBound {
-                body = body.substring(from: brace)
-            }
-
-            annotations = AnnotationsParser(contents: body).all
-        } else {
-            annotations = [:]
-        }
-
-        let enumCase = EnumCase(name: name, rawValue: rawValue, associatedValues: associatedValues, annotations: annotations)
+        let enumCase = EnumCase(name: name, rawValue: rawValue, associatedValues: associatedValues, annotations: annotations.from(source))
         enumCase.setSource(source)
         return enumCase
     }
@@ -799,41 +767,7 @@ extension FileParser {
 
 }
 
-// MARK: - Annotations
-
-extension FileParser {
-
-    func parseAnnotations(from source: [String: SourceKitRepresentable], fromKeyword: String? = nil) -> Annotations {
-        guard let prefix = extract(.keyPrefix, from: source),
-            let keyRange = Substring.key.range(for: source),
-            let keyLocation = self.contents.location(fromByteOffset: Int(keyRange.offset)),
-            let keyLine = self.contents.lineAndCharacter(forCharacterOffset: keyLocation) else {
-
-            return self.annotations.from(source)
-        }
-
-        let annotationStart: NSRange = prefix.bridge().range(of: "/*", options: [.backwards])
-        guard annotationStart.location != NSNotFound,
-            let annotationStartLine = self.contents.lineAndCharacter(forCharacterOffset: annotationStart.location),
-            annotationStartLine.line == keyLine.line else {
-
-            return self.annotations.from(source)
-        }
-
-        if let fromKeyword = fromKeyword {
-            let keywordStart = prefix.bridge().range(of: fromKeyword, options: [.backwards])
-
-            guard keywordStart.location != NSNotFound && keywordStart.location > annotationStart.location else {
-                return self.annotations.from(source)
-            }
-        }
-
-        return AnnotationsParser(contents: prefix.bridge().substring(from: annotationStart.location)).all
-    }
-
-}
-
-// MARK: - Helpres
+// MARK: - Helpers
 extension FileParser {
 
     fileprivate func extract(_ substringIdentifier: Substring, from source: [String: SourceKitRepresentable]) -> String? {

--- a/Sourcery/Parsing/Utils/AnnotationsParser.swift
+++ b/Sourcery/Parsing/Utils/AnnotationsParser.swift
@@ -104,6 +104,11 @@ internal struct AnnotationsParser {
             prefix = prefix.substring(to: commentStart.lowerBound).trimmingCharacters(in: .whitespaces)
         }
 
+        guard prefix.isEmpty else {
+            stop = true
+            return annotations
+        }
+
         // if previous line is not comment or has some trailing non-comment blocks
         // we return currently agregated annotations
         // as annotations on previous line belong to previous declaration

--- a/Sourcery/Parsing/Utils/AnnotationsParser.swift
+++ b/Sourcery/Parsing/Utils/AnnotationsParser.swift
@@ -64,7 +64,10 @@ internal struct AnnotationsParser {
             let lineInfo = contents.lineAndCharacter(forCharacterOffset: location)
             else { return [:] }
 
-        var annotations = Annotations()
+        var stop = false
+        var annotations = inlineFrom(line: lineInfo, stop: &stop)
+        guard !stop else { return annotations }
+
         for line in lines[0..<lineInfo.line-1].reversed() {
             line.annotations.forEach { annotation in
                 AnnotationsParser.append(key: annotation.key, value: annotation.value, to: &annotations)
@@ -77,16 +80,56 @@ internal struct AnnotationsParser {
         return annotations
     }
 
+    func inlineFrom(line lineInfo: (line: Int, character: Int), stop: inout Bool) -> Annotations {
+        let sourceLine = lines[lineInfo.line - 1]
+        var prefix = sourceLine.content.bridge()
+            .substring(to: max(0, lineInfo.character - 1))
+            .trimmingCharacters(in: .whitespaces)
+
+        guard !prefix.isEmpty else { return [:] }
+        var annotations = sourceLine.annotations //get block annotations for this line
+
+        // `case` is not included in the key of enum case definition, so we strip it manually
+        prefix = prefix.trimmingSuffix("case").trimmingCharacters(in: .whitespaces)
+
+        while !prefix.isEmpty {
+            guard prefix.hasSuffix("*/"), let commentStart = prefix.range(of: "/*", options: [.backwards]) else {
+                break
+            }
+
+            let comment = prefix.substring(from: commentStart.lowerBound)
+            for annotation in AnnotationsParser.parse(contents: comment)[0].annotations {
+                AnnotationsParser.append(key: annotation.key, value: annotation.value, to: &annotations)
+            }
+            prefix = prefix.substring(to: commentStart.lowerBound).trimmingCharacters(in: .whitespaces)
+        }
+
+        // if previous line is not comment or has some trailing non-comment blocks
+        // we return currently agregated annotations
+        // as annotations on previous line belong to previous declaration
+        if lineInfo.line - 2 > 0 {
+            let previousLine = lines[lineInfo.line - 2]
+            let content = previousLine.content.trimmingCharacters(in: .whitespaces)
+
+            guard previousLine.type == .comment, content.hasPrefix("//") || content.hasSuffix("*/") else {
+                stop = true
+                return annotations
+            }
+        }
+
+        return annotations
+    }
+
     private static func parse(contents: String) -> [Line] {
         var annotationsBlock: Annotations?
         return contents.lines()
-                .map { $0.content.trimmingCharacters(in: .whitespaces) }
                 .map { line in
+                    let content = line.content.trimmingCharacters(in: .whitespaces)
                     var annotations = Annotations()
-                    let isComment = line.hasPrefix("//") || line.hasPrefix("/*")
+                    let isComment = content.hasPrefix("//") || content.hasPrefix("/*")
                     var type: Line.LineType = isComment ? .comment : .other
                     if isComment {
-                        switch searchForAnnotations(commentLine: line) {
+                        switch searchForAnnotations(commentLine: content) {
                         case let .begin(items):
                             type = .blockStart
                             annotationsBlock = Annotations()
@@ -109,7 +152,7 @@ internal struct AnnotationsParser {
                         annotations[annotation.key] = annotation.value
                     }
 
-                    return Line(content: line,
+                    return Line(content: line.content,
                                 type: type,
                                 annotations: annotations)
                 }

--- a/SourceryTests/Parsing/AnnotationsParserSpec.swift
+++ b/SourceryTests/Parsing/AnnotationsParserSpec.swift
@@ -42,8 +42,11 @@ class AnnotationsParserSpec: QuickSpec {
                 }
 
                 it("extracts inline annotations") {
-                    let result = parse("/* sourcery: skipEquality */var name: Int { return 2 }")
-                    expect(result).to(equal(["skipEquality": NSNumber(value: true)]))
+                    let result = parse("//sourcery: skipDescription\n/* sourcery: skipEquality */var name: Int { return 2 }")
+                    expect(result).to(equal([
+                        "skipDescription": NSNumber(value: true),
+                        "skipEquality": NSNumber(value: true)
+                        ]))
                 }
 
                 it("extracts multi-line annotations, including numbers") {

--- a/SourceryTests/Parsing/FileParser + MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser + MethodsSpec.swift
@@ -257,23 +257,31 @@ class FileParserMethodsSpec: QuickSpec {
                 }
 
                 it("extracts parameter annotations") {
-                    expect(parse("class Foo {\n func foo(\n// sourcery: annotationA\na: Int,\n// sourcery: annotationB\nb: Int) }")).to(equal([
+                    expect(parse("class Foo {\n //sourcery: foo\nfunc foo(\n// sourcery: annotationA\na: Int,\n// sourcery: annotationB\nb: Int)\n//sourcery: bar\nfunc bar(\n// sourcery: annotationA\na: Int,\n// sourcery: annotationB\nb: Int) }")).to(equal([
                         Class(name: "Foo", methods: [
                             Method(name: "foo(a: Int,b: Int)", selectorName: "foo(a:b:)", parameters: [
                                 MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true)]),
                                 MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true)])
-                                ])
+                                ], annotations: ["foo": NSNumber(value: true)]),
+                            Method(name: "bar(a: Int,b: Int)", selectorName: "bar(a:b:)", parameters: [
+                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true)])
+                                ], annotations: ["bar": NSNumber(value: true)])
                             ])
                         ]))
                 }
 
                 it("extracts parameter inline annotations") {
-                    expect(parse("class Foo {\nfunc foo(/* sourcery: annotationA */a: Int, /* sourcery: annotationB*/b: Int) }")).to(equal([
+                    expect(parse("class Foo {\n//sourcery:begin:func\n //sourcery: foo\nfunc foo(/* sourcery: annotationA */a: Int, /* sourcery: annotationB*/b: Int)\n//sourcery: bar\nfunc bar(/* sourcery: annotationA */a: Int, /* sourcery: annotationB*/b: Int) \n//sourcery:end}")).to(equal([
                         Class(name: "Foo", methods: [
                             Method(name: "foo(a: Int, b: Int)", selectorName: "foo(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true)])
-                                ])
+                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
+                                ], annotations: ["foo": NSNumber(value: true), "func": NSNumber(value: true)]),
+                            Method(name: "bar(a: Int, b: Int)", selectorName: "bar(a:b:)", parameters: [
+                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
+                                ], annotations: ["bar": NSNumber(value: true), "func": NSNumber(value: true)])
                             ])
                         ]))
                 }

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -223,13 +223,13 @@ class FileParserSpec: QuickSpec {
                     it("extracts cases with special names") {
                         expect(parse("enum Foo { case `default`; case `for`(something: Int, else: Float, `default`: Bool) }"))
                                 .to(equal([
-                                                  Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [EnumCase(name: "`default`"), EnumCase(name: "`for`", associatedValues:
-                                                  [
-                                                          AssociatedValue(name: "something", typeName: TypeName("Int")),
-                                                          AssociatedValue(name: "else", typeName: TypeName("Float")),
-                                                          AssociatedValue(name: "`default`", typeName: TypeName("Bool"))
-                                                  ])])
-                                          ]))
+                                    Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [EnumCase(name: "`default`"), EnumCase(name: "`for`", associatedValues:
+                                        [
+                                            AssociatedValue(name: "something", typeName: TypeName("Int")),
+                                            AssociatedValue(name: "else", typeName: TypeName("Float")),
+                                            AssociatedValue(name: "`default`", typeName: TypeName("Bool"))
+                                        ])])
+                                    ]))
                     }
 
                     it("extracts multi-byte cases properly") {
@@ -239,30 +239,99 @@ class FileParserSpec: QuickSpec {
                                 ]))
                     }
 
-                    it("extracts cases with annotations properly") {
-                        expect(parse("enum Foo {\n // sourcery: annotation\ncase optionA(Int)\n case optionB }"))
+                    context("given enum cases annotations") {
+
+                        it("extracts cases with annotations properly") {
+                            expect(parse("enum Foo {\n //sourcery:begin: block\n// sourcery: first, second=\"value\"\n case optionA(/* sourcery: value */Int)\n // sourcery: third\n case optionB\n case optionC \n//sourcery:end}"))
                                 .to(equal([
-                                    Enum(name: "Foo",
-                                         cases: [
-                                            EnumCase(name: "optionA", associatedValues: [
-                                                AssociatedValue(name: nil, typeName: TypeName("Int"))
-                                                ], annotations: ["annotation": NSNumber(value: true)]),
-                                            EnumCase(name: "optionB")
+                                    Enum(name: "Foo", cases: [
+                                        EnumCase(name: "optionA", associatedValues: [
+                                            AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: ["value": NSNumber(value: true)])
+                                            ], annotations: [
+                                                "block": NSNumber(value: true),
+                                                "first": NSNumber(value: true),
+                                                "second": "value" as NSString
+                                            ]
+                                        ),
+                                        EnumCase(name: "optionB", annotations: [
+                                            "block": NSNumber(value: true),
+                                            "third": NSNumber(value: true)
+                                            ]
+                                        ),
+                                        EnumCase(name: "optionC", annotations: [
+                                            "block": NSNumber(value: true)
+                                            ])
                                         ])
                                     ]))
-                    }
+                        }
 
-                    it("extracts cases with inline annotations properly") {
-                        expect(parse("enum Foo {\n /* sourcery: annotation */case optionA(Int)\n case optionB }"))
-                            .to(equal([
-                                Enum(name: "Foo",
-                                     cases: [
+                        it("extracts cases with inline annotations properly") {
+                            expect(parse("enum Foo {\n //sourcery:begin: block\n/* sourcery: first, second = \"value\" */ case optionA(/* sourcery: associatedValue */Int)\n /* sourcery: third */ case optionB\n case optionC \n//sourcery:end\n}"))
+                                .to(equal([
+                                    Enum(name: "Foo", cases: [
+                                        EnumCase(name: "optionA", associatedValues: [
+                                            AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: [
+                                                "associatedValue": NSNumber(value: true)
+                                                ])
+                                            ], annotations: [
+                                                "block": NSNumber(value: true),
+                                                "first": NSNumber(value: true),
+                                                "second": "value" as NSString
+                                            ]),
+                                        EnumCase(name: "optionB", annotations: [
+                                            "block": NSNumber(value: true),
+                                            "third": NSNumber(value: true)
+                                            ]),
+                                        EnumCase(name: "optionC", annotations:[
+                                            "block": NSNumber(value: true)
+                                            ])
+                                        ])
+                                    ]))
+                        }
+
+                        it("extracts one line cases with inline annotations properly") {
+                            expect(parse("enum Foo {\n //sourcery:begin: block\ncase /* sourcery: first, second = \"value\" */ optionA(Int), /* sourcery: third, fourth = \"value\" */ optionB, optionC \n//sourcery:end\n}"))
+                                .to(equal([
+                                    Enum(name: "Foo", cases: [
                                         EnumCase(name: "optionA", associatedValues: [
                                             AssociatedValue(name: nil, typeName: TypeName("Int"))
-                                            ], annotations: ["annotation": NSNumber(value: true)]),
-                                        EnumCase(name: "optionB")
-                                    ])
-                                ]))
+                                            ], annotations: [
+                                                "block": NSNumber(value: true),
+                                                "first": NSNumber(value: true),
+                                                "second": "value" as NSString
+                                            ]),
+                                        EnumCase(name: "optionB", annotations: [
+                                            "block": NSNumber(value: true),
+                                            "third": NSNumber(value: true),
+                                            "fourth": "value" as NSString
+                                            ]),
+                                        EnumCase(name: "optionC", annotations: [
+                                            "block": NSNumber(value: true)
+                                            ])
+                                        ])
+                                    ]))
+                        }
+
+                        it("extracts cases with annotations and computed variables properly") {
+                            expect(parse("enum Foo {\n // sourcery: var\n var first: Int { return 0 }\n // sourcery: first, second=\"value\"\n case optionA(Int)\n // sourcery: var\n var second: Int { return 0 }\n // sourcery: third\n case optionB\n case optionC }"))
+                                .to(equal([
+                                    Enum(name: "Foo", cases: [
+                                        EnumCase(name: "optionA", associatedValues: [
+                                            AssociatedValue(name: nil, typeName: TypeName("Int"))
+                                            ], annotations: [
+                                                "first": NSNumber(value: true),
+                                                "second": "value" as NSString
+                                            ]),
+                                        EnumCase(name: "optionB", annotations: [
+                                            "third": NSNumber(value: true)
+                                            ]),
+                                        EnumCase(name: "optionC")
+                                        ], variables: [
+                                            Variable(name: "first", typeName: TypeName("Int"), accessLevel: (.internal, .none), isComputed: true, annotations: [ "var": NSNumber(value: true) ]),
+                                            Variable(name: "second", typeName: TypeName("Int"), accessLevel: (.internal, .none), isComputed: true, annotations: [ "var": NSNumber(value: true) ])
+                                        ])
+                                    ]))
+                        }
                     }
 
                     it("extracts associated value annotations properly") {


### PR DESCRIPTION
Resolves #278 and #283 . I used the same tests added in #279 with some minor additions
Everything related to annotations parsing is now moved back to `AnnotationsParser`.