### PR TITLE
Check bundle version in rake release task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add the `lowerFirst` filter for Stencil templates.
 - Added `isRequired` property for `Method`
 - Improved parsing of closure types
+- Check if Current Project Version match version in podspec in release task
 
 ### Bug fixes
 


### PR DESCRIPTION
This PR brings the feature proposed in #285. I've decided to use a simple shell script with `xcodebuild` instead of bringing another dependency of [Xcodeproj gem](https://github.com/CocoaPods/Xcodeproj).