### PR TITLE
Add imprort of Apple frameworks to AutoMockable; #trivial

### DIFF
--- a/Templates/AutoMockable.stencil
+++ b/Templates/AutoMockable.stencil
@@ -1,3 +1,10 @@
+import Foundation
+#if os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#elseif os(OSX)
+import AppKit
+#endif
+
 {% macro methodReceivedParameters method %}
     {%if method.parameters.count == 1 %}
         {{ method.shortName }}Received{% for param in method.parameters %}{{ param.name|upperFirst }} = {{ param.name }}{% endfor %}


### PR DESCRIPTION
In one PR about `AutoMockable` template improvements, we've decided to remove all frameworks import as we thought it's not needed. Apparently, I've faced an issue with mocking the protocol with `AppKit` components in parameters. I guess we have to return them back 😄 