### PR TITLE
Don't add default clause if enum has only one case

### DIFF
--- a/Templates/AutoEquatable.stencil
+++ b/Templates/AutoEquatable.stencil
@@ -56,7 +56,7 @@ extension {{ type.name }}: Equatable {}
         {% endif %}
         {% endif %}
     {% endfor %}
-    default: return false
+    {% if type.cases.count > 1 %}default: return false {% endif %}
     }
 }
 {% endfor %}


### PR DESCRIPTION
Preventing "Default will never be executed" warnings from Xcode.

For example: 

```swift
enum Result {
    case decrypted(key: Key, refreshToken: String)
}
```

This change will output: 

```swift

extension Result: Equatable {}
public func == (lhs: Result, rhs: Result) -> Bool {
    switch (lhs, rhs) {
    case (.decrypted(let lhs), .decrypted(let rhs)): 
        if lhs.key != rhs.key { return false }
        if lhs.refreshToken != rhs.refreshToken { return false }
        return true
    }
}
```

instead of: 


```swift
extension Result: Equatable {}
public func == (lhs: Result, rhs: Result) -> Bool {
    switch (lhs, rhs) {
    case (.decrypted(let lhs), .decrypted(let rhs)): 
        if lhs.key != rhs.key { return false }
        if lhs.refreshToken != rhs.refreshToken { return false }
        return true
    default: break; // warning here
    }
}
```