### PR TITLE
Fix inline annotations parsing when access level is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed typo in `isConvenienceInitialiser` property
 - Fixed creating cache folder when cache is disabled
 - Fixed parsing multiple enum cases annotations
+- Fixed parsing inline annotations when there is an access level or attribute
 
 ### Internal changes
 

--- a/Sourcery/Models/AccessLevel.swift
+++ b/Sourcery/Models/AccessLevel.swift
@@ -30,16 +30,4 @@ enum AccessLevel: String {
             return ""
         }
     }
-
-    static var all: [AccessLevel] {
-        return [
-            .internal,
-            .private,
-            .fileprivate,
-            .public,
-            .open,
-            .none
-        ]
-    }
-
 }

--- a/Sourcery/Models/AccessLevel.swift
+++ b/Sourcery/Models/AccessLevel.swift
@@ -30,4 +30,16 @@ enum AccessLevel: String {
             return ""
         }
     }
+
+    static var all: [AccessLevel] {
+        return [
+            .internal,
+            .private,
+            .fileprivate,
+            .public,
+            .open,
+            .none
+        ]
+    }
+
 }

--- a/Sourcery/Parsing/Utils/AnnotationsParser.swift
+++ b/Sourcery/Parsing/Utils/AnnotationsParser.swift
@@ -92,19 +92,14 @@ internal struct AnnotationsParser {
         // `case` is not included in the key of enum case definition, so we strip it manually
         prefix = prefix.trimmingSuffix("case").trimmingCharacters(in: .whitespaces)
 
-        // Strips the access level if any
-        if let accessLevel = AccessLevel.all
-            .map({ $0.rawValue })
-            .filter({ prefix.hasSuffix($0) })
-            .first {
-
-            prefix = prefix.trimmingSuffix(accessLevel).trimmingCharacters(in: .whitespaces)
-        }
+        var inlineCommentFound = false
 
         while !prefix.isEmpty {
             guard prefix.hasSuffix("*/"), let commentStart = prefix.range(of: "/*", options: [.backwards]) else {
                 break
             }
+
+            inlineCommentFound = true
 
             let comment = prefix.substring(from: commentStart.lowerBound)
             for annotation in AnnotationsParser.parse(contents: comment)[0].annotations {
@@ -113,7 +108,7 @@ internal struct AnnotationsParser {
             prefix = prefix.substring(to: commentStart.lowerBound).trimmingCharacters(in: .whitespaces)
         }
 
-        guard prefix.isEmpty else {
+        if inlineCommentFound && !prefix.isEmpty {
             stop = true
             return annotations
         }

--- a/Sourcery/Parsing/Utils/AnnotationsParser.swift
+++ b/Sourcery/Parsing/Utils/AnnotationsParser.swift
@@ -92,6 +92,15 @@ internal struct AnnotationsParser {
         // `case` is not included in the key of enum case definition, so we strip it manually
         prefix = prefix.trimmingSuffix("case").trimmingCharacters(in: .whitespaces)
 
+        // Strips the access level if any
+        if let accessLevel = AccessLevel.all
+            .map({ $0.rawValue })
+            .filter({ prefix.hasSuffix($0) })
+            .first {
+
+            prefix = prefix.trimmingSuffix(accessLevel).trimmingCharacters(in: .whitespaces)
+        }
+
         while !prefix.isEmpty {
             guard prefix.hasSuffix("*/"), let commentStart = prefix.range(of: "/*", options: [.backwards]) else {
                 break

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -113,11 +113,11 @@ class FileParserSpec: QuickSpec {
                     }
 
                     it("extracts annotations correctly") {
-                        let expectedType = Class(name: "Foo", accessLevel: .internal, isExtension: false, variables: [], inheritedTypes: ["TestProtocol"])
+                        let expectedType = Class(name: "Foo", accessLevel: .public, isExtension: false, variables: [], inheritedTypes: ["TestProtocol"])
                         expectedType.annotations["firstLine"] = NSNumber(value: true)
                         expectedType.annotations["thirdLine"] = NSNumber(value: 4543)
 
-                        expect(parse("// sourcery: thirdLine = 4543\n/// comment\n// sourcery: firstLine\n class Foo: TestProtocol { }"))
+                        expect(parse("// sourcery: thirdLine = 4543\n/// comment\n// sourcery: firstLine\npublic class Foo: TestProtocol { }"))
                                 .to(equal([expectedType]))
                     }
                 }


### PR DESCRIPTION
It appears that an inline annotation followed by the access level won't parse right.

For example :
```
// sourcery: anAnnotation
class Foo {}
```
works well, annotation 'anAnnotation' is parsed, whereas :
```
// sourcery: anAnnotation
internal class Foo {}
```
won't parse any annotation.

The bug was introduced with inline annotations improvements, #282.