### PR TITLE
Fix aggregating annotations when no new line between inline annotations

### DIFF
--- a/Sourcery/Parsing/Utils/AnnotationsParser.swift
+++ b/Sourcery/Parsing/Utils/AnnotationsParser.swift
@@ -30,6 +30,7 @@ internal struct AnnotationsParser {
         let content: String
         let type: LineType
         let annotations: Annotations
+        let blockAnnotations: Annotations
     }
 
     private let lines: [Line]
@@ -87,7 +88,7 @@ internal struct AnnotationsParser {
             .trimmingCharacters(in: .whitespaces)
 
         guard !prefix.isEmpty else { return [:] }
-        var annotations = sourceLine.annotations //get block annotations for this line
+        var annotations = sourceLine.blockAnnotations //get block annotations for this line
 
         // `case` is not included in the key of enum case definition, so we strip it manually
         prefix = prefix.trimmingSuffix("case").trimmingCharacters(in: .whitespaces)
@@ -163,7 +164,8 @@ internal struct AnnotationsParser {
 
                     return Line(content: line.content,
                                 type: type,
-                                annotations: annotations)
+                                annotations: annotations,
+                                blockAnnotations: annotationsBlock ?? [:])
                 }
     }
 

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -267,7 +267,7 @@ class FileParserSpec: QuickSpec {
                         }
 
                         it("extracts cases with inline annotations properly") {
-                            expect(parse("enum Foo {\n //sourcery:begin: block\n/* sourcery: first, second = \"value\" */ case optionA(/* sourcery: associatedValue */Int)\n /* sourcery: third */ case optionB\n case optionC \n//sourcery:end\n}"))
+                            expect(parse("enum Foo {\n //sourcery:begin: block\n/* sourcery: first, second = \"value\" */ case optionA(/* sourcery: associatedValue */Int); /* sourcery: third */ case optionB\n case optionC \n//sourcery:end\n}"))
                                 .to(equal([
                                     Enum(name: "Foo", cases: [
                                         EnumCase(name: "optionA", associatedValues: [

--- a/guides/Writing templates.md
+++ b/guides/Writing templates.md
@@ -100,11 +100,12 @@ If you want to attribute multiple items with same attributes, you can use sectio
 
 #### Rules:
 
-- Multiple annotations can occur on the same line
-- You can add multiline annotations. Multiple annotations values with the same key are merged into array
+- Multiple annotations can occur on the same line, separated with `,`
+- You can add multiline annotations
+- Multiple annotations values with the same key are merged into array
 - You can interleave annotations with documentation
 - Sourcery scans all `sourcery:` annotations in the given comment block above the source until first non-comment/doc line
-- Using `/*` and `*/` for annotation comment you can put it on the same line with your code. This is usefull for annotating methods parameters, enum case associated values. All such annotations should be placed in one comment block. When using inline annotations for enum cases, cases must be separated with `;`
+- Using `/*` and `*/` for annotation comment you can put it on the same line with your code. This is usefull for annotating methods parameters and enum case associated values. All such annotations should be placed in one comment block. Do not mix inline and regular annotations for the same declaration (usin inline and block annotations is fine)!
 
 #### Format:
 


### PR DESCRIPTION
When there are several annotated declarations in one line that starts with inline annotation and is wrapped with block annotation we are aggregating this starting annotation for any declaration in the line instead of just using block annotations for this line. By storing block annotations separately we can distinguish between annotations added to line due to annotations block or due to inline annotation in the start of the line.