### PR TITLE
Use all variables for autoequatalbe template for protocols; #trivial

### DIFF
--- a/Templates/AutoEquatable.stencil
+++ b/Templates/AutoEquatable.stencil
@@ -33,7 +33,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
     {% if not type.kind == "protocol" %}
     {% call compareVariables type.storedVariables %}
     {% else %}
-    {% call compareVariables type.computedVariables %}
+    {% call compareVariables type.allVariables %}
     {% endif %}
     return true
 }

--- a/Templates/AutoHashable.stencil
+++ b/Templates/AutoHashable.stencil
@@ -29,7 +29,7 @@ extension {{ type.name }}{% if not type.kind == "protocol" %}: Hashable{% endif 
         {% if not type.kind == "protocol" %}
         {% call combineVariableHashes type.storedVariables %}
         {% else %}
-        {% call combineVariableHashes type.computedVariables %}
+        {% call combineVariableHashes type.allVariables %}
         {% endif %}
     }
 }


### PR DESCRIPTION
This fixes the issue #297.
@ilyapuchka we've discussed to filter static variables in generated code for protocols, but we don't need to filter them 😄 
For example:
```
protocol Foo {
  var one: Int { get }
  static var name: String { get }
}
```

We actually need to compare `name` in the `==` function. @ilyapuchka do you agree?