### PR TITLE
Rename scheme of TemplatesTests in Rakefile; #trivial

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ task :tests do
   print_info "Running Sourcery Unit Tests"
   xcrun %Q(xcodebuild -workspace Sourcery.xcworkspace -scheme Sourcery -sdk macosx test)
   print_info "Running Sourcery Templates Tests"
-  xcrun %Q(xcodebuild -workspace Sourcery.xcworkspace -scheme Templates-Tests -sdk macosx test)
+  xcrun %Q(xcodebuild -workspace Sourcery.xcworkspace -scheme TemplatesTests -sdk macosx test)
 end
 
 desc "Delete the build/ directory"


### PR DESCRIPTION
@krzysztofzablocki that seem to be a fix for an issue from `Rakefile` that you've mentioned. Now it's shared and it also matches the one the `Rakefile` required 😄 