### PR TITLE
Stored variables regression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug fixes
 
 - Fixed inserting generated code inline automatically at wrong position
-- Fixed regression in AutoEquatable & AutoHashable template with computed variables
+- Fixed regression in AutoEquatable & AutoHashable template with private computed variables
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Fixed inserting generated code inline automatically at wrong position
+- Fixed regression in AutoEquatable & AutoHashable template with computed variables
 
 ### New Features
 

--- a/Templates/Templates/AutoEquatable.stencil
+++ b/Templates/Templates/AutoEquatable.stencil
@@ -20,7 +20,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 }
 
 {% macro compareVariables variables %}
-    {% for variable in variables %}{% if not variable.annotations.skipEquality %}guard {% if not variable.isOptional %}{% if not variable.annotations.arrayEquality %}lhs.{{ variable.name }} == rhs.{{ variable.name }}{% else %}compareArrays(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %}{% else %}compareOptionals(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %} else { return false }{% endif %}
+    {% for variable in variables where variable.readAccess != "private" and variable.readAccess != "fileprivate" %}{% if not variable.annotations.skipEquality %}guard {% if not variable.isOptional %}{% if not variable.annotations.arrayEquality %}lhs.{{ variable.name }} == rhs.{{ variable.name }}{% else %}compareArrays(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %}{% else %}compareOptionals(lhs: lhs.{{ variable.name }}, rhs: rhs.{{ variable.name }}, compare: ==){% endif %} else { return false }{% endif %}
     {% endfor %}
 {% endmacro %}
 

--- a/Templates/Templates/AutoHashable.stencil
+++ b/Templates/Templates/AutoHashable.stencil
@@ -18,7 +18,7 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
 }
 
 {% macro combineVariableHashes variables %}
-        return combineHashes([{% for variable in variables %}{% if not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0])
+        return combineHashes([{% for variable in variables where variable.readAccess != "private" and variable.readAccess != "fileprivate" %}{% if not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0])
 {% endmacro %}
 
 // MARK: - AutoHashable for classes, protocols, structs

--- a/Templates/Tests/Context/AutoEquatable.swift
+++ b/Templates/Tests/Context/AutoEquatable.swift
@@ -39,14 +39,24 @@ enum AutoEquatableEnumWithOneCase: AutoEquatable {
 
 /// Sourcery should generate correct code for struct
 struct AutoEquatableStruct: AutoEquatable {
-    // Constants
-    let firstName: String
-    let lastName: String
+    // Private Constants
+    private let laptopModel: String
 
-    init(firstName: String, lastName: String, parents: [Parent]) {
+    // Fileprivate Constants
+    fileprivate let phoneModel: String
+
+    // Internal Constants
+    let firstName: String
+
+    // Public Constans
+    public let lastName: String
+
+    init(firstName: String, lastName: String, parents: [Parent], laptopModel: String, phoneModel: String) {
         self.firstName = firstName
         self.lastName = lastName
         self.parents = parents
+        self.laptopModel = laptopModel
+        self.phoneModel = phoneModel
     }
 
     // Arrays
@@ -69,7 +79,7 @@ struct AutoEquatableStruct: AutoEquatable {
 
     // Method with return value
     func greeting(for name: String) -> String {
-        return "Hi \(name)!"
+        return "Hi \(name)"
     }
 
     // Method with optional return value
@@ -80,14 +90,24 @@ struct AutoEquatableStruct: AutoEquatable {
 
 /// It should generate correct code for general class
 class AutoEquatableClass: AutoEquatable {
-    // Constants
-    let firstName: String
-    let lastName: String
+    // Private Constants
+    private let laptopModel: String
 
-    init(firstName: String, lastName: String, parents: [Parent]) {
+    // Fileprivate Constants
+    fileprivate let phoneModel: String
+
+    // Internal Constants
+    let firstName: String
+
+    // Public Constans
+    public let lastName: String
+
+    init(firstName: String, lastName: String, parents: [Parent], laptopModel: String, phoneModel: String) {
         self.firstName = firstName
         self.lastName = lastName
         self.parents = parents
+        self.laptopModel = laptopModel
+        self.phoneModel = phoneModel
     }
 
     // Arrays
@@ -126,6 +146,6 @@ class AutoEquatableClassInherited: AutoEquatableClass {
 
     init(middleName: String?) {
         self.middleName = middleName
-        super.init(firstName: "", lastName: "", parents: [])
+        super.init(firstName: "", lastName: "", parents: [], laptopModel: "", phoneModel: "")
     }
 }

--- a/Templates/Tests/Context/AutoHashable.swift
+++ b/Templates/Tests/Context/AutoHashable.swift
@@ -27,14 +27,24 @@ enum AutoHashableEnumWithOneCase: AutoHashable {
 
 /// Sourcery should generate correct code for struct
 struct AutoHashableStruct: AutoHashable {
-    // Constants
-    let firstName: String
-    let lastName: String
+    // Private Constants
+    private let laptopModel: String
 
-    init(firstName: String, lastName: String, parents: [Parent]) {
+    // Fileprivate Constants
+    fileprivate let phoneModel: String
+
+    // Internal Constants
+    let firstName: String
+
+    // Public Constans
+    public let lastName: String
+
+    init(firstName: String, lastName: String, parents: [Parent], laptopModel: String, phoneModel: String) {
         self.firstName = firstName
         self.lastName = lastName
         self.parents = parents
+        self.laptopModel = laptopModel
+        self.phoneModel = phoneModel
     }
 
     // Arrays
@@ -68,14 +78,24 @@ struct AutoHashableStruct: AutoHashable {
 
 /// It should generate correct code for general class
 class AutoHashableClass: AutoHashable {
-    // Constants
-    let firstName: String
-    let lastName: String
+    // Private Constants
+    private let laptopModel: String
 
-    init(firstName: String, lastName: String, parents: [Parent]) {
+    // Fileprivate Constants
+    fileprivate let phoneModel: String
+
+    // Internal Constants
+    let firstName: String
+
+    // Public Constans
+    public let lastName: String
+
+    init(firstName: String, lastName: String, parents: [Parent], laptopModel: String, phoneModel: String) {
         self.firstName = firstName
         self.lastName = lastName
         self.parents = parents
+        self.laptopModel = laptopModel
+        self.phoneModel = phoneModel
     }
 
     // Arrays
@@ -114,6 +134,6 @@ class AutoHashableClassInherited: AutoHashableClass {
 
     init(middleName: String?) {
         self.middleName = middleName
-        super.init(firstName: "", lastName: "", parents: [])
+        super.init(firstName: "", lastName: "", parents: [], laptopModel: "", phoneModel: "")
     }
 }

--- a/Templates/Tests/Generated/AutoCases.generated.swift
+++ b/Templates/Tests/Generated/AutoCases.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoLenses.generated.swift
+++ b/Templates/Tests/Generated/AutoLenses.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable variable_name

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length

--- a/Templates/Tests/Generated/LinuxMain.generated.swift
+++ b/Templates/Tests/Generated/LinuxMain.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest


### PR DESCRIPTION
This updates the `AutoEquatable` and `AutoHashable` templates to skip `private` and `fileprivate` variables in generated code. Referenced issue #334