### PR TITLE
Exclude templates project files from release; #trivial

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -280,7 +280,6 @@ namespace :release do
     sh %Q(mkdir -p "build")
     sh %Q(mkdir -p "build/Resources")
     sh %Q(cp -r bin build/)
-    sh %Q(cp -r Templates build/)
     sh %Q(cp -r docs/docsets/Sourcery.docset build/)
     `cp LICENSE README.md CHANGELOG.md build`
     `cp Resources/daemon.gif Resources/icon-128.png build/Resources`

--- a/Rakefile
+++ b/Rakefile
@@ -280,6 +280,7 @@ namespace :release do
     sh %Q(mkdir -p "build")
     sh %Q(mkdir -p "build/Resources")
     sh %Q(cp -r bin build/)
+    sh %Q(cp -r Templates/Templates build/)
     sh %Q(cp -r docs/docsets/Sourcery.docset build/)
     `cp LICENSE README.md CHANGELOG.md build`
     `cp Resources/daemon.gif Resources/icon-128.png build/Resources`


### PR DESCRIPTION
This reflects the decision we made with @ilyapuchka in #348. As it may produce confusion for the user and it adds not much value we've decided to not include templates in the release.