### PR TITLE
Fix `sources` parsing and add a ConfigurationSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed inserting generated code inline automatically at wrong position
 - Fixed regression in AutoEquatable & AutoHashable template with private computed variables
+- Fixed regression in `sources` parsing in config files
 
 ### New Features
 

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		09B1DD3F1E21ADD8009228EE /* GeneratorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DF28602426F7A4C8D737 /* GeneratorSpec.swift */; };
 		09C61FA61E76109E005EA58A /* Xcode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C61FA51E76109E005EA58A /* Xcode+Extensions.swift */; };
 		09C6B0D41E11C1C500246CDF /* ClassSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C6B0D31E11C1C500246CDF /* ClassSpec.swift */; };
+		52F79EA11EE9F017006D3546 /* ConfigurationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F79EA01EE9F017006D3546 /* ConfigurationSpec.swift */; };
 		58A8D89B0B5015671E6B526C /* Pods_SourceryTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F74DA40979C0911C0573C7A /* Pods_SourceryTests.framework */; };
 		64E201AA1EAE8FBF00EAD8A2 /* SourceryRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64E201A31EAE8FBF00EAD8A2 /* SourceryRuntime.framework */; };
 		985E4D303A731C40BE326E5C /* Pods_Sourcery.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7C9B21117B6C7EB409B9D49 /* Pods_Sourcery.framework */; };
@@ -159,6 +160,7 @@
 		3825CA349BD2B2AAB9605E7F /* Pods-Sourcery.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sourcery.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sourcery/Pods-Sourcery.debug.xcconfig"; sourceTree = "<group>"; };
 		47FBEB8D5AB4DA51522B302B /* Pods-Sourcery.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sourcery.release.xcconfig"; path = "Pods/Target Support Files/Pods-Sourcery/Pods-Sourcery.release.xcconfig"; sourceTree = "<group>"; };
 		4E26A60E38FEA181642B97B4 /* Pods-SourceryTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SourceryTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SourceryTests/Pods-SourceryTests.release.xcconfig"; sourceTree = "<group>"; };
+		52F79EA01EE9F017006D3546 /* ConfigurationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationSpec.swift; sourceTree = "<group>"; };
 		64E201A31EAE8FBF00EAD8A2 /* SourceryRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SourceryRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		67BC066E18D9BE38229EEFA2 /* Pods-SourceryTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SourceryTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SourceryTests/Pods-SourceryTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6F74DA40979C0911C0573C7A /* Pods_SourceryTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourceryTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -402,6 +404,7 @@
 				E291D114F84B90258AD76A35 /* Parsing */,
 				E291DC8AFD88340E1355E531 /* Generating */,
 				CD754CA01D853F000082B512 /* Info.plist */,
+				52F79EA01EE9F017006D3546 /* ConfigurationSpec.swift */,
 				E291DF28602426F7A4C8D737 /* GeneratorSpec.swift */,
 				E291DB1241856B9CFAAA25E7 /* SourcerySpec.swift */,
 				CDE812EC1E1127FF00F1FF97 /* Sourcery+PerformanceSpec.swift */,
@@ -923,6 +926,7 @@
 				E291DA3352C0EDD1EB8DDCB3 /* FileParser + VariableSpec.swift in Sources */,
 				E291DE1CB3B72BAA22DEDEDA /* StencilTemplateSpec.swift in Sources */,
 				E291D00F3B27A346A9ACCDA4 /* Extensions.swift in Sources */,
+				52F79EA11EE9F017006D3546 /* ConfigurationSpec.swift in Sources */,
 				E291D52FDFF7CF446E239C13 /* TemplateAnnotationsParserSpec.swift in Sources */,
 				E291D5115BBE9AB32275F38F /* VerifierSpec.swift in Sources */,
 			);

--- a/Sourcery/Configuration.swift
+++ b/Sourcery/Configuration.swift
@@ -86,7 +86,7 @@ enum Source {
         } else if let project = dict["project"] as? [String: Any] {
             self = .projects([Project(dict: project, relativePath: relativePath)].flatMap({ $0 }))
         } else {
-            self = .sources(Paths(dict: dict, relativePath: relativePath))
+            self = .sources(Paths(dict: dict["sources"], relativePath: relativePath))
         }
     }
 

--- a/SourceryTests/ConfigurationSpec.swift
+++ b/SourceryTests/ConfigurationSpec.swift
@@ -1,0 +1,63 @@
+import Quick
+import Nimble
+import PathKit
+@testable import Sourcery
+
+class SourceSpecTests: QuickSpec {
+    // swiftlint:disable:next function_body_length
+    override func spec() {
+        describe("Source") {
+            let relativePath = Path("/some/path")
+
+            describe("sources paths parsing") {
+                it("include paths when provided as an array") {
+                    let config = ["sources": ["."]]
+                    let source = Source(dict: config, relativePath: relativePath)
+                    let expected = Source.sources(Paths(include: [relativePath]))
+                    expect(source).to(equal(expected))
+                }
+
+                it("include paths provided in the `include` key") {
+                    let config = ["sources": ["include": ["."]]]
+                    let source = Source(dict: config, relativePath: relativePath)
+                    let expected = Source.sources(Paths(include: [relativePath]))
+                    expect(source).to(equal(expected))
+                }
+
+                it("exclude paths provided in the `exclude` key") {
+                    let config = ["sources": ["exclude": ["."]]]
+                    let source = Source(dict: config, relativePath: relativePath)
+                    let expected = Source.sources(Paths(exclude: [relativePath]))
+                    expect(source).to(equal(expected))
+                }
+            }
+        }
+    }
+}
+
+extension Source: Equatable {
+    public static func == (lhs: Source, rhs: Source) -> Bool {
+        switch (lhs, rhs) {
+        case let (.projects(lProjects), .projects(rProjects)):
+            return lProjects == rProjects
+        case let (.sources(lPaths), .sources(rPaths)):
+            return lPaths == rPaths
+        default:
+            return false
+        }
+    }
+}
+
+extension Project: Equatable {
+    public static func == (lhs: Project, rhs: Project) -> Bool {
+        return lhs.root == rhs.root
+    }
+}
+
+extension Paths: Equatable {
+    public static func == (lhs: Paths, rhs: Paths) -> Bool {
+        return lhs.include == rhs.include
+            && lhs.exclude == rhs.exclude
+            && lhs.allPaths == rhs.allPaths
+    }
+}


### PR DESCRIPTION
I noticed that my configuration file was not working with the latest `master`.
So I tracked and found that the support for excluded paths (#347) introduced a regression in `sources` parsing in `.sourcery.yml` files.

To prevent a future regression I have added a `ConfigurationSpec` with just tests exposing the regression.
As I am not quite used to Quick/Nimble, I do not know if my tests are properly named so any feedback is welcomed 😊 