### PR TITLE
Internal release process updates;

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gem 'cocoapods'
 gem 'cocoapods-update-if-you-dare'
 gem 'danger'
 gem 'rake'
-gem 'jazzy'
 gem 'danger-jazzy'
 gem 'xcpretty'
+
+# We should do it until the jazzy release will contain https://github.com/realm/jazzy/pull/830
+# See related sourcery issue https://github.com/krzysztofzablocki/Sourcery/issues/359
+gem 'jazzy', :git=>'https://github.com/realm/jazzy.git', :branch=>'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/realm/jazzy.git
+  revision: 5c1ccb7ac23a9bb9b33516d0baa8995c95510958
+  branch: master
+  specs:
+    jazzy (0.8.2)
+      cocoapods (~> 1.0)
+      mustache (~> 0.99)
+      open4
+      redcarpet (~> 3.2)
+      rouge (~> 1.5)
+      sass (~> 3.4)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -78,15 +93,6 @@ GEM
     gh_inspector (1.0.3)
     git (1.3.0)
     i18n (0.8.1)
-    jazzy (0.8.2)
-      cocoapods (~> 1.0)
-      mustache (~> 0.99)
-      open4
-      redcarpet (~> 3.2)
-      rouge (~> 1.5)
-      sass (~> 3.4)
-      sqlite3 (~> 1.3)
-      xcinvoke (~> 0.3.0)
     json (1.8.6)
     kramdown (1.13.2)
     liferaft (0.0.6)
@@ -105,7 +111,7 @@ GEM
     redcarpet (3.4.0)
     rouge (1.11.1)
     ruby-macho (1.1.0)
-    sass (3.4.23)
+    sass (3.4.24)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -134,7 +140,7 @@ DEPENDENCIES
   cocoapods-update-if-you-dare
   danger
   danger-jazzy
-  jazzy
+  jazzy!
   rake
   xcpretty
 

--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,7 @@ end
 
 namespace :release do
   desc 'Create a new release on GitHub, CocoaPods and Homebrew'
-  task :new => [:clean, :install_dependencies, :check_environment_variables, :check_docs, :check_ci, :build, :tests, :update_metadata, :check_versions, :tag_release, :github, :cocoapods]
+  task :new => [:clean, :install_dependencies, :check_environment_variables, :check_docs, :check_ci, :tests, :update_metadata, :check_versions, :build, :tag_release, :github, :cocoapods]
 
   def podspec_update_version(version, file = 'Sourcery.podspec')
     # The token is mainly taken from https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/helper/podspec_helper.rb


### PR DESCRIPTION
This PR is associated with #359 and #354 and it contains two changes:
1. Now the `update_metadata` task happens before `build` the `Sourcery` binary for release. 
2. `jazzy` dependency is loaded from `master` branch in order to [load badge using curl](https://github.com/realm/jazzy/pull/830)