### PR TITLE
Use Version.swift to build Sourcery with SPM;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,22 @@
 
 ---
 
+## Master
+
+### Internal changes
+
+- Add Version.swift to represent CLI tool version
+
+
 ## 0.7.1
 
 ### Bug fixes
+
 - Fixed regression in parsing templates from config file
 - Removed meaningless `isMutating` property for `Variable`
 
 ### Internal changes
+
 - Improvements in release script
 - Updated boilerplate code to reflect latest changes
 
@@ -18,7 +27,7 @@
 ### New Features
 
 - Added `inout` flag for `MethodParameter`
-- Added parsing `mutating` and `final` attributes with convenience `isMutating` and `isFinal` properties 
+- Added parsing `mutating` and `final` attributes with convenience `isMutating` and `isFinal` properties
 - Added support for `include` Stencil tag
 - Added support for excluded paths
 

--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,7 @@ namespace :release do
   task :new => [:clean, :install_dependencies, :check_environment_variables, :check_docs, :check_ci, :tests, :update_metadata, :check_versions, :build, :tag_release, :github, :cocoapods]
 
   def podspec_update_version(version, file = 'Sourcery.podspec')
-    # The token is mainly taken from https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/helper/podspec_helper.rb
+    # The code is mainly taken from https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/helper/podspec_helper.rb
     podspec_content = File.read(file)
     version_var_name = 'version'
     version_regex = /^(?<begin>[^#]*version\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?)(?<end>['"])/i
@@ -115,6 +115,21 @@ namespace :release do
 
   def project_version(project = 'Sourcery')
     `xcodebuild -showBuildSettings -project #{project}.xcodeproj | grep CURRENT_PROJECT_VERSION | sed -E  's/(.*) = (.*)/\\2/'`.strip
+  end
+
+  def command_line_tool_update_version(version, file = 'Sourcery/Version.swift')
+    version_content = File.read(file)
+    version_regex = /(?<begin>public static let current\s*=\s*Version\(value:\s*")(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?)(?<end>"\))/i
+    version_match = version_regex.match(version_content)
+    updated_version_content = version_content.gsub(version_regex, "#{version_match[:begin]}#{version}#{version_match[:end]}")
+    File.open(file, "w") { |f| f.puts updated_version_content }
+  end
+
+  def command_line_tool_version(file = 'Sourcery/Version.swift')
+    version_content = File.read(file)
+    version_regex = /(?<begin>public static let current\s*=\s*Version\(value:\s*")(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?)(?<end>"\))/i
+    version_match = version_regex.match(version_content)
+    version_match[:value]
   end
 
   def log_result(result, label, error_msg)
@@ -231,6 +246,9 @@ namespace :release do
     # Check if Current Project Version from build settings match podspec version
     results << log_result(version == project_version, "Project version correct", "Please update Current Project Version in Build Settings to #{version}")
 
+    # Check if Command Line Tool version match podspec version
+    results << log_result(version == command_line_tool_version, "Command line tool version correct", "Please update current version in Sourcery/Version.swift to #{version}")
+
     exit 1 unless results.all?
 
     print "Release version #{version} [Y/n]? "
@@ -257,9 +275,12 @@ namespace :release do
     # Update project version
     project_update_version(new_version)
 
+    # Update command line tool version
+    command_line_tool_update_version(new_version)
+
     print "Now review and type [Y/n] to commit and push or cancel the changes. "
-    manual_commit(["CHANGELOG.md", "Sourcery.podspec", "Sourcery.xcodeproj/project.pbxproj"], "docs: update metadata for #{new_version} release")
-    git_push
+    manual_commit(["CHANGELOG.md", "Sourcery.podspec", "Sourcery.xcodeproj/project.pbxproj", "Sourcery/Version.swift"], "docs: update metadata for #{new_version} release")
+    # git_push
   end
 
   desc 'Create a tag for the project version and push to remote'

--- a/Rakefile
+++ b/Rakefile
@@ -280,7 +280,7 @@ namespace :release do
 
     print "Now review and type [Y/n] to commit and push or cancel the changes. "
     manual_commit(["CHANGELOG.md", "Sourcery.podspec", "Sourcery.xcodeproj/project.pbxproj", "Sourcery/Version.swift"], "docs: update metadata for #{new_version} release")
-    # git_push
+    git_push
   end
 
   desc 'Create a tag for the project version and push to remote'

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		52F79EA11EE9F017006D3546 /* ConfigurationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F79EA01EE9F017006D3546 /* ConfigurationSpec.swift */; };
 		58A8D89B0B5015671E6B526C /* Pods_SourceryTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F74DA40979C0911C0573C7A /* Pods_SourceryTests.framework */; };
 		64E201AA1EAE8FBF00EAD8A2 /* SourceryRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64E201A31EAE8FBF00EAD8A2 /* SourceryRuntime.framework */; };
+		6D40A8341EF3241E00E77293 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D40A8331EF3241E00E77293 /* Version.swift */; };
 		985E4D303A731C40BE326E5C /* Pods_Sourcery.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7C9B21117B6C7EB409B9D49 /* Pods_Sourcery.framework */; };
 		C894A1B01E19326C0098327C /* SwiftTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C894A1AE1E19326C0098327C /* SwiftTemplate.swift */; };
 		C894A1B31E19328E0098327C /* SwiftTemplates in Resources */ = {isa = PBXBuildFile; fileRef = C894A1B21E19328E0098327C /* SwiftTemplates */; };
@@ -163,6 +164,7 @@
 		52F79EA01EE9F017006D3546 /* ConfigurationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationSpec.swift; sourceTree = "<group>"; };
 		64E201A31EAE8FBF00EAD8A2 /* SourceryRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SourceryRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		67BC066E18D9BE38229EEFA2 /* Pods-SourceryTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SourceryTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SourceryTests/Pods-SourceryTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6D40A8331EF3241E00E77293 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		6F74DA40979C0911C0573C7A /* Pods_SourceryTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourceryTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB12F3FDE2A28AA446AA59D3 /* Pods_SourceryFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourceryFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C894A1AE1E19326C0098327C /* SwiftTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftTemplate.swift; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 				E291DB249799066B169A0F41 /* Parsing */,
 				E291DB64F90A7CCCD66B3801 /* Generating */,
 				E291DB6A95BAECDB6E978A76 /* Sourcery.swift */,
+				6D40A8331EF3241E00E77293 /* Version.swift */,
 				094415C71E78A46A00ABE04A /* Configuration.swift */,
 				CD754C951D853F000082B512 /* Info.plist */,
 				CD9C459C1DFAF76D00161C2C /* main.swift */,
@@ -877,6 +880,7 @@
 				09618B3C1E61EEE100B49D5F /* JavaScriptTemplate.swift in Sources */,
 				CD9C459D1DFAF76D00161C2C /* main.swift in Sources */,
 				C8E88CB01E20579100102D17 /* Path+Extensions.swift in Sources */,
+				6D40A8341EF3241E00E77293 /* Version.swift in Sources */,
 				E291D8C0F0FE5B3DF91025CC /* Generator.swift in Sources */,
 				094415C81E78A46A00ABE04A /* Configuration.swift in Sources */,
 				E291DCA363FD8EBF0455C712 /* Sourcery.swift in Sources */,

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -10,12 +10,7 @@ import SwiftTryCatch
 import SourceryRuntime
 
 class Sourcery {
-    public static var version: String {
-        if inUnitTests {
-            return "Major.Minor.Patch"
-        }
-        return (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "Major.Minor.Patch"
-    }
+    public static let version: String = inUnitTests ? "Major.Minor.Patch" : Version.current
     public static let generationMarker: String = "// Generated using Sourcery"
     public static let generationHeader = "\(Sourcery.generationMarker) \(Sourcery.version) — https://github.com/krzysztofzablocki/Sourcery\n"
         + "// DO NOT EDIT\n\n"

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -10,7 +10,7 @@ import SwiftTryCatch
 import SourceryRuntime
 
 class Sourcery {
-    public static let version: String = inUnitTests ? "Major.Minor.Patch" : Version.current
+    public static let version: String = inUnitTests ? "Major.Minor.Patch" : Version.current.value
     public static let generationMarker: String = "// Generated using Sourcery"
     public static let generationHeader = "\(Sourcery.generationMarker) \(Sourcery.version) — https://github.com/krzysztofzablocki/Sourcery\n"
         + "// DO NOT EDIT\n\n"

--- a/Sourcery/Version.swift
+++ b/Sourcery/Version.swift
@@ -1,0 +1,14 @@
+//
+//  Version.swift
+//  Sourcery
+//
+//  Created by Anton Domashnev on 15.06.17.
+//  Copyright © 2017 Pixle. All rights reserved.
+//
+
+import Foundation
+
+struct Version {
+    public let value: String
+    public static let current = Version(value: "0.7.1")
+}


### PR DESCRIPTION
The PR introduces the new `Version.swift` structure that represents the version for `Sourcery` command line tool. Prior approach with only `build_settings` doesn't work due to #354.
The PR also contains the update in the `Rakefile` release process to also automate the version change.