### PR TITLE
Hashable template improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Master
 
+### New Features
+
+- Added support in `AutoHashable` for static variables, `[Hashable]` array and `[Hashable: Hashable]` dictionary
+
 
 ## 0.7.2
 

--- a/Templates/Templates/AutoHashable.stencil
+++ b/Templates/Templates/AutoHashable.stencil
@@ -17,8 +17,54 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
     return Int(bitPattern: lhs)
 }
 
+fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
+    guard let array = array else {
+        return 0
+    }
+    return array.reduce(5381) {
+        ($0 << 5) &+ $0 &+ $1.hashValue
+    }
+}
+
+fileprivate extension func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
+    guard let dictionary = dictionary else {
+        return 0
+    }
+    return
+}
+
+{% macro dynamicVariableHashValue variable %}
+{% if variable.isArray %}
+    hashArray({{ variable.name }}),
+{% if variable.isDictionary %}
+    hashArray({{ variable.name }}),
+{% elif not variable.isOptional %}
+    {{ variable.name }}.hashValue,
+{% else %}
+    {{ variable.name }}?.hashValue ?? 0,
+{% endif %}
+{% endmacro %}
+
+{% macro staticVariableHashValue variable %}
+
+{% endmacro %}
+
 {% macro combineVariableHashes variables %}
-        return combineHashes([{% for variable in variables where variable.readAccess != "private" and variable.readAccess != "fileprivate" %}{% if not variable.annotations.skipHashing %}{% if not variable.isOptional %}{{ variable.name }}.hashValue{% else %}{{ variable.name }}?.hashValue ?? 0{% endif %}, {% endif %}{% endfor %}0])
+        return combineHashes([{% for variable in variables where variable.readAccess != "private" and variable.readAccess != "fileprivate" %}
+    {% if not variable.annotations.skipHashing %}
+        {% if variable.isStatic %}
+        {% else %}
+            {% if variable.isArray %}
+                hashArray({{ variable.name }}),
+            {% elif not variable.isOptional %}
+                {{ variable.name }}.hashValue,
+            {% else %}
+                {{ variable.name }}?.hashValue ?? 0,
+            {% endif %}
+            {% endif %}
+            {% endif %}
+            {% endif %}{% endfor %}
+                0])
 {% endmacro %}
 
 // MARK: - AutoHashable for classes, protocols, structs

--- a/Templates/Templates/AutoHashable.stencil
+++ b/Templates/Templates/AutoHashable.stencil
@@ -17,7 +17,7 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
     return Int(bitPattern: lhs)
 }
 
-fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
+fileprivate func hashArray<T: Hashable>(_ array: [T]?) -> Int {
     guard let array = array else {
         return 0
     }
@@ -26,45 +26,51 @@ fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
     }
 }
 
-fileprivate extension func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
+fileprivate func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
     guard let dictionary = dictionary else {
         return 0
     }
-    return
+    return dictionary.reduce(5381) {
+        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
+    }
 }
 
 {% macro dynamicVariableHashValue variable %}
 {% if variable.isArray %}
-    hashArray({{ variable.name }}),
-{% if variable.isDictionary %}
-    hashArray({{ variable.name }}),
+            hashArray({{ variable.name }}),
+{% elif variable.isDictionary %}
+            hashDictionary({{ variable.name }}),
 {% elif not variable.isOptional %}
-    {{ variable.name }}.hashValue,
+            {{ variable.name }}.hashValue,
 {% else %}
-    {{ variable.name }}?.hashValue ?? 0,
+            {{ variable.name }}?.hashValue ?? 0,
 {% endif %}
 {% endmacro %}
 
 {% macro staticVariableHashValue variable %}
-
+{% if variable.isArray %}
+            hashArray(type(of: self).{{ variable.name }}),
+{% elif variable.isDictionary %}
+            hashDictionary(type(of: self).{{ variable.name }}),
+{% elif not variable.isOptional %}
+            type(of: self).{{ variable.name }}.hashValue,
+{% else %}
+            type(of: self).{{ variable.name }}?.hashValue ?? 0,
+{% endif %}
 {% endmacro %}
 
 {% macro combineVariableHashes variables %}
-        return combineHashes([{% for variable in variables where variable.readAccess != "private" and variable.readAccess != "fileprivate" %}
+        return combineHashes([
+    {% for variable in variables where variable.readAccess != "private" and variable.readAccess != "fileprivate" %}
     {% if not variable.annotations.skipHashing %}
         {% if variable.isStatic %}
+            {% call staticVariableHashValue variable %}
         {% else %}
-            {% if variable.isArray %}
-                hashArray({{ variable.name }}),
-            {% elif not variable.isOptional %}
-                {{ variable.name }}.hashValue,
-            {% else %}
-                {{ variable.name }}?.hashValue ?? 0,
-            {% endif %}
-            {% endif %}
-            {% endif %}
-            {% endif %}{% endfor %}
-                0])
+            {% call dynamicVariableHashValue variable %}
+        {% endif %}
+    {% endif %}
+    {% endfor %}
+            0])
 {% endmacro %}
 
 // MARK: - AutoHashable for classes, protocols, structs

--- a/Templates/Tests/Context/AutoHashable.swift
+++ b/Templates/Tests/Context/AutoHashable.swift
@@ -28,6 +28,9 @@ struct AutoHashableStruct: AutoHashable {
     // Fileprivate Constants
     fileprivate let phoneModel: String
 
+    // Static constant
+    static let structName: String = "AutoHashableStruct"
+
     // Internal Constants
     let firstName: String
 
@@ -40,11 +43,14 @@ struct AutoHashableStruct: AutoHashable {
         self.parents = parents
         self.laptopModel = laptopModel
         self.phoneModel = phoneModel
+        self.universityGrades = ["Math": 5, "Geometry": 3]
     }
 
     // Arrays
-    // sourcery: arrayEquality
     let parents: [Parent]
+
+    // Dictionary
+    let universityGrades: [String: Int]
 
     // Variable
     var moneyInThePocket: Double = 0
@@ -79,6 +85,9 @@ class AutoHashableClass: AutoHashable {
     // Fileprivate Constants
     fileprivate let phoneModel: String
 
+    // Static constant
+    static let className: String = "AutoHashableClass"
+
     // Internal Constants
     let firstName: String
 
@@ -91,11 +100,14 @@ class AutoHashableClass: AutoHashable {
         self.parents = parents
         self.laptopModel = laptopModel
         self.phoneModel = phoneModel
+        self.universityGrades = ["Math": 5, "Geometry": 3]
     }
 
     // Arrays
-    // sourcery: arrayEquality
     let parents: [Parent]
+
+    // Dictionary
+    let universityGrades: [String: Int]
 
     // Variable
     var moneyInThePocket: Double = 0
@@ -122,13 +134,13 @@ class AutoHashableClass: AutoHashable {
     }
 }
 
-/// Sourcery doesn't support inheritance for AutoHashable
-//class AutoHashableClassInherited: AutoHashableClass {
-//    // Optional constants
-//    let middleName: String?
-//
-//    init(middleName: String?) {
-//        self.middleName = middleName
-//        super.init(firstName: "", lastName: "", parents: [], laptopModel: "", phoneModel: "")
-//    }
-//}
+// Sourcery doesn't support inheritance for AutoHashable
+class AutoHashableClassInherited: AutoHashableClass {
+    // Optional constants
+    let middleName: String?
+
+    init(middleName: String?) {
+        self.middleName = middleName
+        super.init(firstName: "", lastName: "", parents: [], laptopModel: "", phoneModel: "")
+    }
+}

--- a/Templates/Tests/Context/AutoHashable.swift
+++ b/Templates/Tests/Context/AutoHashable.swift
@@ -20,11 +20,6 @@ enum AutoHashableEnum: AutoHashable {
     }
 }
 
-/// Sourcery should not generate a default case for enum with only one case
-enum AutoHashableEnumWithOneCase: AutoHashable {
-    case one
-}
-
 /// Sourcery should generate correct code for struct
 struct AutoHashableStruct: AutoHashable {
     // Private Constants
@@ -128,12 +123,12 @@ class AutoHashableClass: AutoHashable {
 }
 
 /// Sourcery doesn't support inheritance for AutoHashable
-class AutoHashableClassInherited: AutoHashableClass {
-    // Optional constants
-    let middleName: String?
-
-    init(middleName: String?) {
-        self.middleName = middleName
-        super.init(firstName: "", lastName: "", parents: [], laptopModel: "", phoneModel: "")
-    }
-}
+//class AutoHashableClassInherited: AutoHashableClass {
+//    // Optional constants
+//    let middleName: String?
+//
+//    init(middleName: String?) {
+//        self.middleName = middleName
+//        super.init(firstName: "", lastName: "", parents: [], laptopModel: "", phoneModel: "")
+//    }
+//}

--- a/Templates/Tests/Expected/AutoHashable.expected
+++ b/Templates/Tests/Expected/AutoHashable.expected
@@ -17,31 +17,70 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
     return Int(bitPattern: lhs)
 }
 
+fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
+    guard let array = array else {
+        return 0
+    }
+    return array.reduce(5381) {
+        ($0 << 5) &+ $0 &+ $1.hashValue
+    }
+}
+
+fileprivate extension func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
+    guard let dictionary = dictionary else {
+        return 0
+    }
+    return dictionary.reduce(5381) {
+        combineHashValues($0, combineHashValues($1.key.hash, $1.value.hash))
+    }
+}
 
 // MARK: - AutoHashable for classes, protocols, structs
 // MARK: - AutoHashableClass AutoHashable
 extension AutoHashableClass: Hashable {
     internal var hashValue: Int {
-        return combineHashes([firstName.hashValue, lastName.hashValue, parents.hashValue, moneyInThePocket.hashValue, age?.hashValue ?? 0, friends?.hashValue ?? 0, 0])
+        return combineHashes([
+            firstName.hashValue,
+            lastName.hashValue,
+            hashArray(parents),
+            hashDictionary(universityGrades),
+            moneyInThePocket.hashValue,
+            age?.hashValue ?? 0,
+            hashArray(friends),
+            0])
     }
 }
 // MARK: - AutoHashableClassInherited AutoHashable
 extension AutoHashableClassInherited: Hashable {
     THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable
     internal var hashValue: Int {
-        return combineHashes([middleName?.hashValue ?? 0, 0])
+        return combineHashes([
+            middleName?.hashValue ?? 0,
+            0])
     }
 }
 // MARK: - AutoHashableProtocol AutoHashable
 extension AutoHashableProtocol {
     internal var hashValue: Int {
-        return combineHashes([width.hashValue, height.hashValue, name.hashValue, 0])
+        return combineHashes([
+            width.hashValue,
+            height.hashValue,
+            type(of: self).name.hashValue,
+            0])
     }
 }
 // MARK: - AutoHashableStruct AutoHashable
 extension AutoHashableStruct: Hashable {
     internal var hashValue: Int {
-        return combineHashes([firstName.hashValue, lastName.hashValue, parents.hashValue, moneyInThePocket.hashValue, age?.hashValue ?? 0, friends?.hashValue ?? 0, 0])
+        return combineHashes([
+            firstName.hashValue,
+            lastName.hashValue,
+            hashArray(parents),
+            hashDictionary(universityGrades),
+            moneyInThePocket.hashValue,
+            age?.hashValue ?? 0,
+            hashArray(friends),
+            0])
     }
 }
 
@@ -57,16 +96,6 @@ extension AutoHashableEnum: Hashable {
             return combineHashes([2, data.first.hashValue, data.second.hashValue])
         case .three(let data):
             return combineHashes([3, data.hashValue])
-        }
-    }
-}
-
-// MARK: - AutoHashableEnumWithOneCase AutoHashable
-extension AutoHashableEnumWithOneCase: Hashable {
-    internal var hashValue: Int {
-        switch self {
-        case .one:
-            return 1.hashValue
         }
     }
 }

--- a/Templates/Tests/Expected/AutoHashable.expected
+++ b/Templates/Tests/Expected/AutoHashable.expected
@@ -17,7 +17,7 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
     return Int(bitPattern: lhs)
 }
 
-fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
+fileprivate func hashArray<T: Hashable>(_ array: [T]?) -> Int {
     guard let array = array else {
         return 0
     }
@@ -26,12 +26,12 @@ fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
     }
 }
 
-fileprivate extension func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
+fileprivate func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
     guard let dictionary = dictionary else {
         return 0
     }
     return dictionary.reduce(5381) {
-        combineHashValues($0, combineHashValues($1.key.hash, $1.value.hash))
+        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
     }
 }
 

--- a/Templates/Tests/Generated/AutoCases.generated.swift
+++ b/Templates/Tests/Generated/AutoCases.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.7.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.7.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -20,7 +20,7 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
     return Int(bitPattern: lhs)
 }
 
-fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
+fileprivate func hashArray<T: Hashable>(_ array: [T]?) -> Int {
     guard let array = array else {
         return 0
     }
@@ -29,12 +29,12 @@ fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
     }
 }
 
-fileprivate extension func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
+fileprivate func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
     guard let dictionary = dictionary else {
         return 0
     }
     return dictionary.reduce(5381) {
-        combineHashValues($0, combineHashValues($1.key.hash, $1.value.hash))
+        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
     }
 }
 

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -20,31 +20,50 @@ fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
     return Int(bitPattern: lhs)
 }
 
+fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
+    guard let array = array else {
+        return 0
+    }
+    return array.reduce(5381) {
+        ($0 << 5) &+ $0 &+ $1.hashValue
+    }
+}
+
 
 // MARK: - AutoHashable for classes, protocols, structs
 // MARK: - AutoHashableClass AutoHashable
 extension AutoHashableClass: Hashable {
     internal var hashValue: Int {
-        return combineHashes([firstName.hashValue, lastName.hashValue, parents.hashValue, moneyInThePocket.hashValue, age?.hashValue ?? 0, friends?.hashValue ?? 0, 0])
-    }
-}
-// MARK: - AutoHashableClassInherited AutoHashable
-extension AutoHashableClassInherited: Hashable {
-    THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable
-    internal var hashValue: Int {
-        return combineHashes([middleName?.hashValue ?? 0, 0])
+        return combineHashes([
+                firstName.hashValue,
+                lastName.hashValue,
+                hashArray(parents),
+                moneyInThePocket.hashValue,
+                age?.hashValue ?? 0,
+                hashArray(friends),
+            0])
     }
 }
 // MARK: - AutoHashableProtocol AutoHashable
 extension AutoHashableProtocol {
     internal var hashValue: Int {
-        return combineHashes([width.hashValue, height.hashValue, name.hashValue, 0])
+        return combineHashes([
+                width.hashValue,
+                height.hashValue,
+            0])
     }
 }
 // MARK: - AutoHashableStruct AutoHashable
 extension AutoHashableStruct: Hashable {
     internal var hashValue: Int {
-        return combineHashes([firstName.hashValue, lastName.hashValue, parents.hashValue, moneyInThePocket.hashValue, age?.hashValue ?? 0, friends?.hashValue ?? 0, 0])
+        return combineHashes([
+                firstName.hashValue,
+                lastName.hashValue,
+                hashArray(parents),
+                moneyInThePocket.hashValue,
+                age?.hashValue ?? 0,
+                hashArray(friends),
+            0])
     }
 }
 
@@ -60,16 +79,6 @@ extension AutoHashableEnum: Hashable {
             return combineHashes([2, data.first.hashValue, data.second.hashValue])
         case .three(let data):
             return combineHashes([3, data.hashValue])
-        }
-    }
-}
-
-// MARK: - AutoHashableEnumWithOneCase AutoHashable
-extension AutoHashableEnumWithOneCase: Hashable {
-    internal var hashValue: Int {
-        switch self {
-        case .one:
-            return 1.hashValue
         }
     }
 }

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.7.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length
@@ -29,18 +29,39 @@ fileprivate extension func hashArray<T: Hashable>(_ array: [T]?) -> Int {
     }
 }
 
+fileprivate extension func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
+    guard let dictionary = dictionary else {
+        return 0
+    }
+    return dictionary.reduce(5381) {
+        combineHashValues($0, combineHashValues($1.key.hash, $1.value.hash))
+    }
+}
+
+
+
 
 // MARK: - AutoHashable for classes, protocols, structs
 // MARK: - AutoHashableClass AutoHashable
 extension AutoHashableClass: Hashable {
     internal var hashValue: Int {
         return combineHashes([
-                firstName.hashValue,
-                lastName.hashValue,
-                hashArray(parents),
-                moneyInThePocket.hashValue,
-                age?.hashValue ?? 0,
-                hashArray(friends),
+            firstName.hashValue,
+            lastName.hashValue,
+            hashArray(parents),
+            hashDictionary(universityGrades),
+            moneyInThePocket.hashValue,
+            age?.hashValue ?? 0,
+            hashArray(friends),
+            0])
+    }
+}
+// MARK: - AutoHashableClassInherited AutoHashable
+extension AutoHashableClassInherited: Hashable {
+    THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable
+    internal var hashValue: Int {
+        return combineHashes([
+            middleName?.hashValue ?? 0,
             0])
     }
 }
@@ -48,8 +69,9 @@ extension AutoHashableClass: Hashable {
 extension AutoHashableProtocol {
     internal var hashValue: Int {
         return combineHashes([
-                width.hashValue,
-                height.hashValue,
+            width.hashValue,
+            height.hashValue,
+            type(of: self).name.hashValue,
             0])
     }
 }
@@ -57,12 +79,13 @@ extension AutoHashableProtocol {
 extension AutoHashableStruct: Hashable {
     internal var hashValue: Int {
         return combineHashes([
-                firstName.hashValue,
-                lastName.hashValue,
-                hashArray(parents),
-                moneyInThePocket.hashValue,
-                age?.hashValue ?? 0,
-                hashArray(friends),
+            firstName.hashValue,
+            lastName.hashValue,
+            hashArray(parents),
+            hashDictionary(universityGrades),
+            moneyInThePocket.hashValue,
+            age?.hashValue ?? 0,
+            hashArray(friends),
             0])
     }
 }

--- a/Templates/Tests/Generated/AutoLenses.generated.swift
+++ b/Templates/Tests/Generated/AutoLenses.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.7.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable variable_name

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.7.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length

--- a/Templates/Tests/Generated/LinuxMain.generated.swift
+++ b/Templates/Tests/Generated/LinuxMain.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.7.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest


### PR DESCRIPTION
The PR reflects the issue #355 but it extends the initial issue with the following features:
1. Support for Array<Hashable> variables
2. Support for Dictionary<Hashable, Hashable> variables
3. Support for static variables inside the protocol as for other types we use only `storedVariables`