### PR TITLE
Add headerpad_max_install_names linker option in SwiftTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Master
 
+### Bug fixes
+
+- Fixed linker issue when using Swift templates
 
 ## 0.7.2
 

--- a/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
+++ b/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
@@ -166,7 +166,8 @@ class SwiftTemplate: Template {
                 "-module-name", "main",
                 "-target", "x86_64-apple-macosx10.10",
                 "-F", buildDir.parent().description,
-                "-o", binaryFile.description
+                "-o", binaryFile.description,
+                "-Xlinker", "-headerpad_max_install_names"
         ]
 
         let compilationResult = try Process.runCommand(path: "/usr/bin/swiftc",


### PR DESCRIPTION
While working with Swift templates I encountered the following error:

```install_name_tool: changing install names or rpaths can't be redone for: /var/folders/pw/_psd2lwx3xs2vq5dsq7s7_t80000gn/T/Sourcery.build/bin (for architecture x86_64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)```

I applied the suggested fix and it solves the issue.

You can see the error in [this Travis build](https://travis-ci.org/Liquidsoul/Sourcery-AutoJSONSerializable/builds/246797365?utm_source=email&utm_medium=notification).

You should also be able to reproduce the issue by checking out the [`sourcery-bug-demo`](https://github.com/Liquidsoul/Sourcery-AutoJSONSerializable/tree/sourcery-bug-demo) branch in my repo [`Sourcery-AutoJSONSerialization`](https://github.com/Liquidsoul/Sourcery-AutoJSONSerializable) and running `make sourcery`.