### PR TITLE
Fix parsing of default values for variables that also have a body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed linker issue when using Swift templates
 - Updated `AutoMockable` to exclude generated code collisions
+- Fixed parsing of default values for variables that also have a body (e.g. for `didSet`)
 
 ### Internal changes
 

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -798,7 +798,7 @@ extension FileParser {
     }
 
     fileprivate func extractDefaultValue(type: String?, from source: [String: SourceKitRepresentable]) -> String? {
-        guard var nameSuffix = extract(.nameSuffix, from: source)?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+        guard var nameSuffix = extract(.nameSuffixUpToBody, from: source)?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
         if nameSuffix.trimPrefix(":") {
             nameSuffix = nameSuffix.trimmingCharacters(in: .whitespacesAndNewlines)
             guard let type = type, nameSuffix.trimPrefix(type) else { return nil }

--- a/SourceryTests/Parsing/FileParser + VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser + VariableSpec.swift
@@ -45,6 +45,9 @@ class FileParserVariableSpec: QuickSpec {
                         expect(parse("var name = { return 0 }()")?.defaultValue).to(equal("{ return 0 }()"))
                         expect(parse("var name = \t\n { return 0 }() \t\n")?.defaultValue).to(equal("{ return 0 }()"))
                         expect(parse("var name: Int = \t\n { return 0 }() \t\n")?.defaultValue).to(equal("{ return 0 }()"))
+                        expect(parse("var name: String = String() { didSet { print(0) } }")?.defaultValue).to(equal("String()"))
+                        expect(parse("var name: String = String() {\n\tdidSet { print(0) }\n}")?.defaultValue).to(equal("String()"))
+                        expect(parse("var name: String = String()\n{\n\twillSet { print(0) }\n}")?.defaultValue).to(equal("String()"))
                     }
 
                     it("extracts property with default initializer correctly") {


### PR DESCRIPTION
To extract the default value, the parser used everything after the "=". This logic breaks, if there is also a body for the variable (for example to specify `didSet` or `willSet`, which is perfectly legal, even if there is a default value):

    var name: String = "foo" {
        didSet { print(0) }
    }

In this case the parser returned `"foo" { didSet { print(0) } }` as the default value.

Also added a few test cases for this scenario.