### PR TITLE
Fix swifttemplate rsync call failing sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Updated `AutoMockable` to exclude generated code collisions
 - Fixed parsing of default values for variables that also have a body (e.g. for `didSet`)
 - Fixed line number display when an error occur while parsing a Swift template
+- Fixed `rsync` issue on `SourceryRuntime.framework` when using Swift templates
 
 ### Internal changes
 

--- a/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
+++ b/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
@@ -199,7 +199,10 @@ class SwiftTemplate: Template {
         let sourceryFramework = SwiftTemplate.frameworksPath + "SourceryRuntime.framework"
 
         let copyFramework = try Process.runCommand(path: "/usr/bin/rsync", arguments: [
-            "-av", sourceryFramework.description, path.description
+            "-av",
+            "--force",
+            sourceryFramework.description,
+            path.description
             ])
 
         if !copyFramework.error.isEmpty {


### PR DESCRIPTION
From time to time, I have this kind of error while working with swifttemplates:
```
error: rsync: delete_file: rmdir "/var/folders/pw/_psd2lwx3xs2vq5dsq7s7_t80000gn/T/SourceryRuntime.framework/Headers" failed: Directory not empty (66)
rsync: delete_file: rmdir "/var/folders/pw/_psd2lwx3xs2vq5dsq7s7_t80000gn/T/SourceryRuntime.framework/Modules" failed: Directory not empty (66)
rsync: delete_file: rmdir "/var/folders/pw/_psd2lwx3xs2vq5dsq7s7_t80000gn/T/SourceryRuntime.framework/Resources" failed: Directory not empty (66)
rsync: delete_file: rmdir "/var/folders/pw/_psd2lwx3xs2vq5dsq7s7_t80000gn/T/SourceryRuntime.framework/Versions/Current" failed: Directory not empty (66)
rsync error: some files could not be transferred (code 23) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-51/rsync/main.c(996) [sender=2.6.9]
```

And this cannot be solved until I have deleted the framework in this folder.
To work around this problem, I have added the `--force` option in `rsync` which seems to fix the issue.

I think this issue happens when the SourceryRuntime framework changes. So it can happen a lot when you are working on Sourcery but should happen less frequently in the classic use case where only version updates changes it.