### PR TITLE
Fix line number display of errors in Swift templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed linker issue when using Swift templates
 - Updated `AutoMockable` to exclude generated code collisions
 - Fixed parsing of default values for variables that also have a body (e.g. for `didSet`)
+- Fixed line number display when an error occur while parsing a Swift template
 
 ### Internal changes
 

--- a/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
+++ b/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
@@ -47,11 +47,11 @@ class SwiftTemplate: Template {
 
         let components = templateContent.components(separatedBy: Delimiters.open)
 
-        var sourceFile = [String]()
+        var processedComponents = [String]()
         var commands = [Command]()
 
         let currentLineNumber = {
-            return sourceFile.joined(separator: "").numberOfLineSeparators
+            return processedComponents.joined(separator: "").numberOfLineSeparators + 1
         }
 
         for component in components.suffix(from: 1) {
@@ -94,21 +94,23 @@ class SwiftTemplate: Template {
             if !encodedPart.isEmpty {
                 commands.append(.outputEncoded(encodedPart))
             }
+            processedComponents.append(component)
         }
 
+        var outputFile = [String]()
         for command in commands {
             switch command {
             case let .output(code):
-                sourceFile.append("\n  print(\"\\(" + code + ")\", terminator: \"\");")
+                outputFile.append("\n  print(\"\\(" + code + ")\", terminator: \"\");")
             case let .controlFlow(code):
-                sourceFile.append("\n \(code)")
+                outputFile.append("\n \(code)")
             case let .outputEncoded(code):
                 if !code.isEmpty {
-                    sourceFile.append(("\n  print(\"") + code.stringEncoded + "\", terminator: \"\");")
+                    outputFile.append(("\n  print(\"") + code.stringEncoded + "\", terminator: \"\");")
                 }
             }
         }
-        let contents = sourceFile.joined(separator: "")
+        let contents = outputFile.joined(separator: "")
         let code = "import Foundation\n" +
             "import SourceryRuntime\n" +
             "\n" +

--- a/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
+++ b/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
@@ -51,6 +51,7 @@ class SwiftTemplate: Template {
         var commands = [Command]()
 
         let currentLineNumber = {
+            // the following +1 is to transform a line count (starting from 0) to a line number (starting from 1)
             return processedComponents.joined(separator: "").numberOfLineSeparators + 1
         }
 

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -30,6 +30,16 @@ class SwiftTemplateTests: QuickSpec {
                 expect(result).to(equal(expectedResult))
             }
 
+            it("throws an error showing the involved line for unmatched delimiter in the template") {
+                let templatePath = Stubs.swiftTemplates + Path("InvalidTag.swifttemplate")
+                expect {
+                    try SwiftTemplate(path: templatePath)
+                    }
+                    .to(throwError(closure: { (error) in
+                        expect("\(error)").to(equal("\(templatePath):2 Error while parsing template. Unmatched <%"))
+                    }))
+            }
+
             it("rethrows template parsing errors") {
                 let templatePath = Stubs.swiftTemplates + Path("Invalid.swifttemplate")
                 expect {

--- a/SourceryTests/Stub/SwiftTemplates/InvalidTag.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/InvalidTag.swifttemplate
@@ -1,0 +1,4 @@
+<% for type in types.all {%>
+extension <%= type.name > {
+}
+<%}%>


### PR DESCRIPTION
The line number for an unmatched tag was not computed properly, it was always showing 0.
To fix this, we now keep a `processedComponents` array to keep track of the template source that was already computed. This allows to know which line we are at when we encounter an unmatched tag issue.