### PR TITLE
Fix auto:inline for nested types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Updated `AutoMockable` to exclude generated code collisions
 - Fixed parsing of default values for variables that also have a body (e.g. for `didSet`)
 - Fixed line number display when an error occur while parsing a Swift template
+- Fixed `auto:inline` for nested types (this concerns the first time the code is inserted)
 
 ### Internal changes
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -382,7 +382,7 @@ extension Sourcery {
 
                 guard let (filePath, ranges) = parsingResult.inlineRanges.first(where: { $0.ranges[key] != nil }) else {
                     guard key.hasPrefix("auto:") else { return nil }
-                    let autoTypeName = key.trimmingPrefix("auto:").components(separatedBy: ".")[0]
+                    let autoTypeName = key.trimmingPrefix("auto:").components(separatedBy: ".").dropLast().joined(separator: ".")
                     let toInsert = "\n// sourcery:inline:\(key)\n\(generatedBody)// sourcery:end\n"
 
                     guard let definition = parsingResult.types.types.first(where: { $0.name == autoTypeName }),

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -189,7 +189,7 @@ class SourcerySpecTests: QuickSpec {
                         update(code: "class Foo {}", in: sourcePath)
 
                         update(code: "// Line One\n" +
-                            "// sourcery:inline:auto:Foo\n" +
+                            "// sourcery:inline:auto:Foo.Inlined\n" +
                             "var property = 2\n" +
                             "// Line Three\n" +
                             "// sourcery:end", in: templatePath)
@@ -197,7 +197,7 @@ class SourcerySpecTests: QuickSpec {
                         expect { try Sourcery(watcherEnabled: false, cacheDisabled: true).processFiles(.sources(Paths(include: [sourcePath])), usingTemplates: Paths(include: [templatePath]), output: outputDir) }.toNot(throwError())
 
                         let expectedResult = "class Foo {\n" +
-                            "// sourcery:inline:auto:Foo\n" +
+                            "// sourcery:inline:auto:Foo.Inlined\n" +
                             "var property = 2\n" +
                             "// Line Three\n" +
                             "// sourcery:end\n" +
@@ -211,13 +211,13 @@ class SourcerySpecTests: QuickSpec {
                         update(code: "class Foo {}\n\nclass Bar {}", in: sourcePath)
 
                         update(code: "// Line One\n" +
-                            "// sourcery:inline:auto:Bar\n" +
+                            "// sourcery:inline:auto:Bar.Inlined\n" +
                             "var property = bar\n" +
                             "// Line Three\n" +
                             "// sourcery:end" +
                             "\n" +
                             "// Line One\n" +
-                            "// sourcery:inline:auto:Foo\n" +
+                            "// sourcery:inline:auto:Foo.Inlined\n" +
                             "var property = foo\n" +
                             "// Line Three\n" +
                             "// sourcery:end", in: templatePath)
@@ -225,13 +225,13 @@ class SourcerySpecTests: QuickSpec {
                         expect { try Sourcery(watcherEnabled: false, cacheDisabled: true).processFiles(.sources(Paths(include: [sourcePath])), usingTemplates: Paths(include: [templatePath]), output: outputDir) }.toNot(throwError())
 
                         let expectedResult = "class Foo {\n" +
-                            "// sourcery:inline:auto:Foo\n" +
+                            "// sourcery:inline:auto:Foo.Inlined\n" +
                             "var property = foo\n" +
                             "// Line Three\n" +
                             "// sourcery:end\n" +
                             "}\n\n" +
                             "class Bar {\n" +
-                            "// sourcery:inline:auto:Bar\n" +
+                            "// sourcery:inline:auto:Bar.Inlined\n" +
                             "var property = bar\n" +
                             "// Line Three\n" +
                             "// sourcery:end\n" +


### PR DESCRIPTION
When using the `sourcery:inline:auto:` annotation with nested types, I have noticed that the generated code was not inserted in the correct place for the first use.

Here is an example of the use case here:
_Initial file_
```swift
struct Foo {
    struct Bar {}
}
```

_Template_
```swift
// sourcery:inline:auto:Foo.Bar.AutoInlined
let bar: Bool
// sourcery:end
```

_Expected Result_
```swift
struct Foo {
    struct Bar {
// sourcery:inline:auto:Foo.Bar.AutoInlined
let bar: Bool
// sourcery:end
}
}
```

Instead the code was not inserted in the right place.

Note that I have also fixed/changed some other tests for the `inline:auto` in 38b02c9 which were not respecting the documentation and were missing the "TemplateName" part as specified [here in the docs](https://github.com/krzysztofzablocki/Sourcery/blob/master/guides/Writing%20templates.md#automatic-inline-code-generation).