### PR TITLE
Support includes in Swift templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support in `AutoHashable` for static variables, `[Hashable]` array and `[Hashable: Hashable]` dictionary
 - Added `definedInType` property for `Method` and `Variable`
 - Added `extensions` filter for stencil template
+- Added include support in Swift templates
 
 ### Bug fixes
 

--- a/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
+++ b/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
@@ -35,13 +35,13 @@ class SwiftTemplate: Template {
         self.code = try SwiftTemplate.parse(sourcePath: path)
     }
 
-    static func parse(sourcePath: Path) throws -> String {
+    private enum Command {
+        case output(String)
+        case controlFlow(String)
+        case outputEncoded(String)
+    }
 
-        enum Command {
-            case output(String)
-            case controlFlow(String)
-            case outputEncoded(String)
-        }
+    static func parse(sourcePath: Path) throws -> String {
 
         let templateContent = try "<%%>" + sourcePath.read()
 

--- a/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
+++ b/Sourcery/Generating/Template/Swift/SwiftTemplate.swift
@@ -116,7 +116,11 @@ class SwiftTemplate: Template {
                 guard let includedFile = match.map({ code.bridge().substring(with: $0.rangeAt(1)) }) else {
                     throw "\(sourcePath):\(currentLineNumber()) Error while parsing template. Invalid include tag format '\(code)'"
                 }
-                let includePath = Path(components: [sourcePath.parent().string, includedFile])
+                var includePath = Path(components: [sourcePath.parent().string, includedFile])
+                // The template extension may be omitted, so try to read again by adding it if a template was not found
+                if !includePath.exists, includePath.extension != "swifttemplate" {
+                    includePath = Path(includePath.string + ".swifttemplate")
+                }
                 let includedCommands = try SwiftTemplate.parseCommands(in: includePath)
                 commands.append(contentsOf: includedCommands)
             } else if code.trimPrefix("=") {

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -40,6 +40,16 @@ class SwiftTemplateTests: QuickSpec {
                     }))
             }
 
+            it("handles includes") {
+                let templatePath = Stubs.swiftTemplates + Path("Includes.swifttemplate")
+                let expectedResult = try? (Stubs.resultDirectory + Path("Basic+Other.swift")).read(.utf8)
+
+                expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: outputDir) }.toNot(throwError())
+
+                let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                expect(result).to(equal(expectedResult))
+            }
+
             it("rethrows template parsing errors") {
                 let templatePath = Stubs.swiftTemplates + Path("Invalid.swifttemplate")
                 expect {

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -70,6 +70,28 @@ class SwiftTemplateTests: QuickSpec {
                 expect(result).to(equal(expectedResult))
             }
 
+            it("throws an error when an include cycle is detected") {
+                let templatePath = Stubs.swiftTemplates + Path("IncludeCycle.swifttemplate")
+                let templateCycleDetectionLocationPath = Stubs.swiftTemplates + Path("includeCycle/Two.swifttemplate")
+                let templateInvolvedInCyclePath = Stubs.swiftTemplates + Path("includeCycle/One.swifttemplate")
+                expect {
+                    try SwiftTemplate(path: templatePath)
+                    }
+                    .to(throwError(closure: { (error) in
+                        expect("\(error)").to(equal("\(templateCycleDetectionLocationPath):1 Error: Include cycle detected for \(templateInvolvedInCyclePath). Check your include statements so that templates do not include each other."))
+                    }))
+            }
+
+            it("throws an error when an include cycle involving the root template is detected") {
+                let templatePath = Stubs.swiftTemplates + Path("SelfIncludeCycle.swifttemplate")
+                expect {
+                    try SwiftTemplate(path: templatePath)
+                    }
+                    .to(throwError(closure: { (error) in
+                        expect("\(error)").to(equal("\(templatePath):1 Error: Include cycle detected for \(templatePath). Check your include statements so that templates do not include each other."))
+                    }))
+            }
+
             it("rethrows template parsing errors") {
                 let templatePath = Stubs.swiftTemplates + Path("Invalid.swifttemplate")
                 expect {

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -50,6 +50,16 @@ class SwiftTemplateTests: QuickSpec {
                 expect(result).to(equal(expectedResult))
             }
 
+            it("handles includes from included files relatively") {
+                let templatePath = Stubs.swiftTemplates + Path("SubfolderIncludes.swifttemplate")
+                let expectedResult = try? (Stubs.resultDirectory + Path("Basic.swift")).read(.utf8)
+
+                expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: outputDir) }.toNot(throwError())
+
+                let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                expect(result).to(equal(expectedResult))
+            }
+
             it("rethrows template parsing errors") {
                 let templatePath = Stubs.swiftTemplates + Path("Invalid.swifttemplate")
                 expect {

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -50,6 +50,16 @@ class SwiftTemplateTests: QuickSpec {
                 expect(result).to(equal(expectedResult))
             }
 
+            it("handles includes without swifttemplate extension") {
+                let templatePath = Stubs.swiftTemplates + Path("IncludesNoExtension.swifttemplate")
+                let expectedResult = try? (Stubs.resultDirectory + Path("Basic+Other.swift")).read(.utf8)
+
+                expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: outputDir) }.toNot(throwError())
+
+                let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                expect(result).to(equal(expectedResult))
+            }
+
             it("handles includes from included files relatively") {
                 let templatePath = Stubs.swiftTemplates + Path("SubfolderIncludes.swifttemplate")
                 let expectedResult = try? (Stubs.resultDirectory + Path("Basic.swift")).read(.utf8)

--- a/SourceryTests/Stub/SwiftTemplates/IncludeCycle.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/IncludeCycle.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("includeCycle/One.swifttemplate") -%>

--- a/SourceryTests/Stub/SwiftTemplates/Includes.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/Includes.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("Equality.swifttemplate") -%><%- include("Other.swifttemplate") -%>

--- a/SourceryTests/Stub/SwiftTemplates/IncludesNoExtension.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/IncludesNoExtension.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("Equality") -%><%- include("Other") -%>

--- a/SourceryTests/Stub/SwiftTemplates/Other.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/Other.swifttemplate
@@ -1,0 +1,1 @@
+// Found <%= types.all.count %> types

--- a/SourceryTests/Stub/SwiftTemplates/SelfIncludeCycle.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/SelfIncludeCycle.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("SelfIncludeCycle.swifttemplate") -%>

--- a/SourceryTests/Stub/SwiftTemplates/SubfolderIncludes.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/SubfolderIncludes.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("lib/One.swifttemplate") -%>

--- a/SourceryTests/Stub/SwiftTemplates/includeCycle/One.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/includeCycle/One.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("Two.swifttemplate") -%>

--- a/SourceryTests/Stub/SwiftTemplates/includeCycle/Two.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/includeCycle/Two.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("One.swifttemplate") -%>

--- a/SourceryTests/Stub/SwiftTemplates/lib/One.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/lib/One.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("Two.swifttemplate") -%>

--- a/SourceryTests/Stub/SwiftTemplates/lib/Two.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/lib/Two.swifttemplate
@@ -1,0 +1,1 @@
+<%- include("../Equality.swifttemplate") -%>

--- a/docs/writing-templates.html
+++ b/docs/writing-templates.html
@@ -221,6 +221,7 @@ Sourcery also uses its extension <a href="https://github.com/SwiftGen/StencilSwi
 <li>Trim extra new line after control flow tag with <code>-%&gt;</code></li>
 <li>Trim <em>all</em> whitespaces before/after control flow tag with <code>&lt;%_</code> and <code>_%&gt;</code></li>
 <li>Use <code>&lt;%# %&gt;</code> for comments</li>
+<li>Use <code>&lt;%- include(&quot;relative_path_to_template.swifttemplate&quot;) %&gt;</code> to include another template. The <code>swifttemplate</code> extension can be omitted. The path is relative to the including template.</li>
 </ul>
 
 <p><strong>Example</strong>: <a href="https://github.com/krzysztofzablocki/Sourcery/blob/master/SourceryTests/Stub/SwiftTemplates/Equality.swifttemplate">Equality.swifttemplate</a></p>

--- a/guides/Writing templates.md
+++ b/guides/Writing templates.md
@@ -60,6 +60,7 @@ Swift templates syntax is very similar to EJS:
 - Trim extra new line after control flow tag with `-%>`
 - Trim _all_ whitespaces before/after control flow tag with `<%_` and `_%>`
 - Use `<%# %>` for comments
+- Use `<%- include("relative_path_to_template.swifttemplate") %>` to include another template. The `swifttemplate` extension can be omitted. The path is relative to the including template.
 
 **Example**: [Equality.swifttemplate](https://github.com/krzysztofzablocki/Sourcery/blob/master/SourceryTests/Stub/SwiftTemplates/Equality.swifttemplate)
 


### PR DESCRIPTION
This PR implements #243

It introduces the custom tag `<%- include("relative_path_to_template") %>` which will add the code from the referenced template (inspired from the EJS implementation).

The features supported by this tag:
- inclusion of templates relative to the including template
- ability to omit the `swifttemplate` extension in the tag
- include cycles detection (templates including each other) to show user friendly error instead of some stack overflow error

I hope you'll like this! 😃 

_Unrelated side note:_
When generating the docs I noticed a lot of changes across the html files. I've only added the changes related to my updates but maybe all these changes should be integrated to the repository.