### PR TITLE
Fix running sourcery script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Internal changes
 
 - Fix link for template in docs
+- Fix running Sourcery in the example app
 
 
 ## 0.7.2

--- a/Sourcery-Example/Sourcery-Example.xcodeproj/project.pbxproj
+++ b/Sourcery-Example/Sourcery-Example.xcodeproj/project.pbxproj
@@ -209,7 +209,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Sourcery/bin/sourcery\" \"${SRCROOT}/Sourcery-Example\" \"${SRCROOT}/Templates\" \"${SRCROOT}/CodeGenerated\"";
+			shellScript = "\"${PODS_ROOT}/Sourcery/bin/sourcery\" --sources \"${SRCROOT}/Sourcery-Example\" --templates \"${SRCROOT}/Templates\" --output \"${SRCROOT}/CodeGenerated\"";
 		};
 		CF5282FB5B7BED7A23689E75 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Hey. I tried to run the sample app, but I got some errors. It seems the CLI tool has been changed, but the example app hasn't. Now everything is OK