### PR TITLE
Internal boilerplate code update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Fix link for template in docs
 - Fix running Sourcery in the example app
+- Add step to update internal boilerplate code during the release
 
 
 ## 0.7.2

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,10 +28,11 @@ It will perform the following steps:
 1. Install Bundler and CocoaPods dependencies;
 2. Check if the docs are up-to-date or not;
 3. Check if the master branch is green on [CI](https://circleci.com/gh/krzysztofzablocki/Sourcery);
-4. Run tests;
-5. Ask for the new release version and updates metadata for it;
-6. Create a new release on [GitHub](https://github.com/krzysztofzablocki/Sourcery/releases);
-7. Push new release to [CocoaPods Trunk](https://guides.cocoapods.org/making/getting-setup-with-trunk.html);
-8. Prepare a new development iteration
+3. Update internal boilerplate code;
+5. Run tests;
+6. Ask for the new release version and updates metadata for it;
+7. Create a new release on [GitHub](https://github.com/krzysztofzablocki/Sourcery/releases);
+8. Push new release to [CocoaPods Trunk](https://guides.cocoapods.org/making/getting-setup-with-trunk.html);
+9. Prepare a new development iteration
 
 Some tasks require manual approvement, please pay attention to the automatic changes before confirming them.

--- a/Rakefile
+++ b/Rakefile
@@ -78,7 +78,6 @@ end
 
 ## [ Code Generated ] ################################################
 
-desc "Run sourcery on Sourcery itself"
 task :run_sourcery do
   print_info "Generating internal boilerplate code"
   sh "bin/sourcery --sources './Sources/' --templates './Sourcery/Templates/' --output './SourceryRuntime/Sources/'"

--- a/Rakefile
+++ b/Rakefile
@@ -64,6 +64,7 @@ end
 
 desc "Delete the build/ directory"
 task :clean do
+  print_info "Cleaning build folder"
   sh %Q(rm -fr build)
 end
 
@@ -73,6 +74,30 @@ task :build do
   sh %Q(rm -fr bin/Sourcery.app)
   `mv #{BUILD_DIR}tmp/Build/Products/Release/Sourcery.app bin/`
   sh %Q(rm -fr #{BUILD_DIR}tmp/)
+end
+
+## [ Code Generated ] ################################################
+
+desc "Run sourcery on Sourcery itself"
+task :run_sourcery do
+  print_info "Generating internal boilerplate code"
+  sh "bin/sourcery --sources './Sources/' --templates './Sourcery/Templates/' --output './SourceryRuntime/Sources/'"
+end
+
+desc "Update internal boilerplate code"
+task :generate_internal_boilerplate_code => [:build, :run_sourcery, :clean] do
+  generated_files = [
+    "SourceryRuntime/Sources/Coding.generated.swift",
+    "SourceryRuntime/Sources/Description.generated.swift",
+    "SourceryRuntime/Sources/Diffable.generated.swift",
+    "SourceryRuntime/Sources/Equality.generated.swift",
+    "SourceryRuntime/Sources/JSExport.generated.swift",
+    "SourceryRuntime/Sources/Typed.generated.swift",
+    "SourceryTests/Models/TypedSpec.generated.swift"
+  ]
+  print_info "Now review and type [Y/n] to commit and push or cancel the changes."
+  print "Updated files:\n#{generated_files.join("\n")}\n"
+  manual_commit(generated_files, "update internal boilerplate code.")
 end
 
 ## [ Docs ] ##########################################################

--- a/Rakefile
+++ b/Rakefile
@@ -117,7 +117,7 @@ end
 
 namespace :release do
   desc 'Create a new release on GitHub, CocoaPods and Homebrew'
-  task :new => [:clean, :install_dependencies, :check_environment_variables, :check_docs, :check_ci, :tests, :update_metadata, :check_versions, :build, :tag_release, :github, :cocoapods]
+  task :new => [:clean, :install_dependencies, :check_environment_variables, :check_docs, :check_ci, :generate_internal_boilerplate_code, :tests, :update_metadata, :check_versions, :build, :tag_release, :github, :cocoapods]
 
   def podspec_update_version(version, file = 'Sourcery.podspec')
     # The code is mainly taken from https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/helper/podspec_helper.rb


### PR DESCRIPTION
The PR adds additional `Rake::Task` to update internal code generated by Sourcery that we use in Sourcery 😄. It fixes the PR #358.