### PR TITLE
Allowed string filters to be applied to TypeName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `extensions` filter for stencil template
 - Added include support in Swift templates
 - Swift templates now can throw errors. You can also throw just string literals.
+- Added support for TypeName in string filters (except filters from StencilSwiftKit).
 
 ### Bug fixes
 

--- a/Sourcery/Parsing/Composer.swift
+++ b/Sourcery/Parsing/Composer.swift
@@ -143,7 +143,7 @@ struct Composer {
 
     private func resolveVariableTypes(_ variable: Variable, of type: Type, resolve: TypeResolver) {
         variable.type = resolve(variable.typeName, type)
-        
+
         /// The actual `definedInType` is assigned in `uniqueTypes` but we still
         /// need to resolve the type to correctly parse typealiases
         /// @see https://github.com/krzysztofzablocki/Sourcery/pull/374

--- a/SourceryTests/Generating/StencilTemplateSpec.swift
+++ b/SourceryTests/Generating/StencilTemplateSpec.swift
@@ -11,44 +11,113 @@ class StencilTemplateSpec: QuickSpec {
         describe("StencilTemplate") {
 
             func generate(_ template: String) -> String {
-                return (try? Generator.generate(Types(types: []), template: StencilTemplate(templateString: template))) ?? ""
+                return (try? Generator.generate(Types(types: [
+                    Class(name: "MyClass", variables: [
+                        Variable(name: "lowerFirst", typeName: TypeName("myClass")),
+                        Variable(name: "upperFirst", typeName: TypeName("MyClass"))
+                        ])
+                    ]), template: StencilTemplate(templateString: template))) ?? ""
             }
 
-            it("generates uppercase") {
-                expect(generate("{{\"helloWorld\" | upperFirst }}")).to(equal("HelloWorld"))
+            context("given string") {
+                it("generates upperFirst") {
+                    expect(generate("{{\"helloWorld\" | upperFirst }}")).to(equal("HelloWorld"))
+                }
+
+                it("generates lowerFirst") {
+                    expect(generate("{{\"HelloWorld\" | lowerFirst }}")).to(equal("helloWorld"))
+                }
+
+                it("generates uppercase") {
+                    expect(generate("{{ \"HelloWorld\" | uppercase }}")).to(equal("HELLOWORLD"))
+                }
+
+                it("generates lowercase") {
+                    expect(generate("{{ \"HelloWorld\" | lowercase }}")).to(equal("helloworld"))
+                }
+
+                it("generates capitalise") {
+                    expect(generate("{{ \"helloWorld\" | capitalise }}")).to(equal("Helloworld"))
+                }
+
+                it("checks for string in name") {
+                    expect(generate("{{ \"FooBar\" | contains:\"oo\" }}")).to(equal("true"))
+                    expect(generate("{{ \"FooBar\" | contains:\"xx\" }}")).to(equal("false"))
+                    expect(generate("{{ \"FooBar\" | !contains:\"oo\" }}")).to(equal("false"))
+                    expect(generate("{{ \"FooBar\" | !contains:\"xx\" }}")).to(equal("true"))
+                }
+
+                it("checks for string in prefix") {
+                    expect(generate("{{ \"FooBar\" | hasPrefix:\"Foo\" }}")).to(equal("true"))
+                    expect(generate("{{ \"FooBar\" | hasPrefix:\"Bar\" }}")).to(equal("false"))
+                    expect(generate("{{ \"FooBar\" | !hasPrefix:\"Foo\" }}")).to(equal("false"))
+                    expect(generate("{{ \"FooBar\" | !hasPrefix:\"Bar\" }}")).to(equal("true"))
+                }
+
+                it("checks for string in suffix") {
+                    expect(generate("{{ \"FooBar\" | hasSuffix:\"Bar\" }}")).to(equal("true"))
+                    expect(generate("{{ \"FooBar\" | hasSuffix:\"Foo\" }}")).to(equal("false"))
+                    expect(generate("{{ \"FooBar\" | !hasSuffix:\"Bar\" }}")).to(equal("false"))
+                    expect(generate("{{ \"FooBar\" | !hasSuffix:\"Foo\" }}")).to(equal("true"))
+                }
+
+                it("removes instances of a substring") {
+                    expect(generate("{{\"helloWorld\" | replace:\"he\",\"bo\" | replace:\"llo\",\"la\" }}")).to(equal("bolaWorld"))
+                    expect(generate("{{\"helloWorldhelloWorld\" | replace:\"hello\",\"hola\" }}")).to(equal("holaWorldholaWorld"))
+                    expect(generate("{{\"helloWorld\" | replace:\"hello\",\"\" }}")).to(equal("World"))
+                    expect(generate("{{\"helloWorld\" | replace:\"foo\",\"bar\" }}")).to(equal("helloWorld"))
+                }
             }
 
-            it("generates lowercase") {
-                expect(generate("{{\"HelloWorld\" | lowerFirst }}")).to(equal("helloWorld"))
-            }
+            context("given TypeName") {
+                it("generates upperFirst") {
+                    expect(generate("{{ type.MyClass.variables.0.typeName | upperFirst }}")).to(equal("MyClass"))
+                }
 
-            it("checks for string in name") {
-                expect(generate("{{ \"FooBar\" | contains:\"oo\" }}")).to(equal("true"))
-                expect(generate("{{ \"FooBar\" | contains:\"xx\" }}")).to(equal("false"))
-                expect(generate("{{ \"FooBar\" | !contains:\"oo\" }}")).to(equal("false"))
-                expect(generate("{{ \"FooBar\" | !contains:\"xx\" }}")).to(equal("true"))
-            }
+                it("generates lowerFirst") {
+                    expect(generate("{{ type.MyClass.variables.1.typeName | lowerFirst }}")).to(equal("myClass"))
+                }
 
-            it("checks for string in prefix") {
-                expect(generate("{{ \"FooBar\" | hasPrefix:\"Foo\" }}")).to(equal("true"))
-                expect(generate("{{ \"FooBar\" | hasPrefix:\"Bar\" }}")).to(equal("false"))
-                expect(generate("{{ \"FooBar\" | !hasPrefix:\"Foo\" }}")).to(equal("false"))
-                expect(generate("{{ \"FooBar\" | !hasPrefix:\"Bar\" }}")).to(equal("true"))
-            }
+                it("generates uppercase") {
+                    expect(generate("{{ type.MyClass.variables.0.typeName | uppercase }}")).to(equal("MYCLASS"))
+                }
 
-            it("checks for string in suffix") {
-                expect(generate("{{ \"FooBar\" | hasSuffix:\"Bar\" }}")).to(equal("true"))
-                expect(generate("{{ \"FooBar\" | hasSuffix:\"Foo\" }}")).to(equal("false"))
-                expect(generate("{{ \"FooBar\" | !hasSuffix:\"Bar\" }}")).to(equal("false"))
-                expect(generate("{{ \"FooBar\" | !hasSuffix:\"Foo\" }}")).to(equal("true"))
-            }
+                it("generates lowercase") {
+                    expect(generate("{{ type.MyClass.variables.1.typeName | lowercase }}")).to(equal("myclass"))
+                }
 
-            it("removes instances of a substring") {
-                expect(generate("{{\"helloWorld\" | replace:\"he\",\"bo\" | replace:\"llo\",\"la\" }}")).to(equal("bolaWorld"))
-                expect(generate("{{\"helloWorld\" | replace:\"hello\",\"hola\" }}")).to(equal("holaWorld"))
-                expect(generate("{{\"helloWorldhelloWorld\" | replace:\"hello\",\"hola\" }}")).to(equal("holaWorldholaWorld"))
-                expect(generate("{{\"helloWorld\" | replace:\"hello\",\"\" }}")).to(equal("World"))
-                expect(generate("{{\"helloWorld\" | replace:\"foo\",\"bar\" }}")).to(equal("helloWorld"))
+                it("generates capitalise") {
+                    expect(generate("{{ type.MyClass.variables.1.typeName | capitalise }}")).to(equal("Myclass"))
+                }
+
+                it("checks for string in name") {
+                    expect(generate("{{ type.MyClass.variables.0.typeName | contains:\"my\" }}")).to(equal("true"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | contains:\"xx\" }}")).to(equal("false"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | !contains:\"my\" }}")).to(equal("false"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | !contains:\"xx\" }}")).to(equal("true"))
+                }
+
+                it("checks for string in prefix") {
+                    expect(generate("{{ type.MyClass.variables.0.typeName | hasPrefix:\"my\" }}")).to(equal("true"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | hasPrefix:\"My\" }}")).to(equal("false"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | !hasPrefix:\"my\" }}")).to(equal("false"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | !hasPrefix:\"My\" }}")).to(equal("true"))
+                }
+
+                it("checks for string in suffix") {
+                    expect(generate("{{ type.MyClass.variables.0.typeName | hasSuffix:\"Class\" }}")).to(equal("true"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | hasSuffix:\"class\" }}")).to(equal("false"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | !hasSuffix:\"Class\" }}")).to(equal("false"))
+                    expect(generate("{{ type.MyClass.variables.0.typeName | !hasSuffix:\"class\" }}")).to(equal("true"))
+                }
+
+                it("removes instances of a substring") {
+                    expect(generate("{{type.MyClass.variables.0.typeName | replace:\"my\",\"My\" | replace:\"Class\",\"Struct\" }}")).to(equal("MyStruct"))
+                    expect(generate("{{type.MyClass.variables.0.typeName | replace:\"s\",\"z\" }}")).to(equal("myClazz"))
+                    expect(generate("{{type.MyClass.variables.0.typeName | replace:\"my\",\"\" }}")).to(equal("Class"))
+                    expect(generate("{{type.MyClass.variables.0.typeName | replace:\"foo\",\"bar\" }}")).to(equal("myClass"))
+                }
+
             }
 
             it("rethrows template parsing errors") {


### PR DESCRIPTION
Resolves #391 and other common complaints that string filters do not work when applied to type name.

Unfortunately StencilSwiftKit filters only support `Strings`, so either we need to reimplement them in Sourcery or suggest to expand those filters on `CustomStringConvertible` types.