### PR TITLE
Send the codecov report "after" running the tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,13 @@ machine:
       - brew install sourcekitten
 
 test:
+  pre:
+      - rake validate_docs
+      - bundle exec danger || true
   override:
       - set -o pipefail
       - xcodebuild -workspace "$XCODE_WORKSPACE" -scheme "$XCODE_SCHEME" ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO build | xcpretty
       - xcodebuild -workspace "$XCODE_WORKSPACE" -scheme "$XCODE_SCHEME" ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | tee $CIRCLE_ARTIFACTS/xcode_raw.log | xcpretty --color --report junit --output $CIRCLE_TEST_REPORTS/xcode/results.xml
       - swift build
-  pre:
+  post:
       - bash <(curl -s https://codecov.io/bash)
-      - rake validate_docs
-      - bundle exec danger || true


### PR DESCRIPTION
While struggling to run the tests locally (I've got some dyld issues with CommonCrypto but that's not my point here), I noticed that the command sending the test report to `codecov` is done in the `pre` section of circleci. This means that the script is run **before** the tests are run.

Looking at [Codecov](https://codecov.io/gh/krzysztofzablocki/Sourcery), the code coverage status has not been updated since the 2017/05/11 which match the [circle.yml change](https://github.com/krzysztofzablocki/Sourcery/commit/6f54243ef45075f8fa7399fa35d2080568b77107#diff-29944324a3cbf9f4bd0162dfe3975d88L16).

So this PR fixes this by putting the codecov step in the `post` section and it also puts the steps in order in the circle.yml file to make the sequence of execution more explicit.

