### PR TITLE
Do not generate file with empty content when specifying a single output file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Added support for file paths in `config` parameter
 - Improved config file validation and error reporting
 
+### Bug fixes
+
+- Fixed single file generation not skipping writing the file when there is no generated content
+
 
 ## 0.8.0
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -26,7 +26,7 @@ class Sourcery {
     fileprivate let prune: Bool
 
     fileprivate var status = ""
-    fileprivate var templatesPaths = try Paths(include: [])
+    fileprivate var templatesPaths = Paths(include: [])
     fileprivate var outputPath: Path = ""
 
     /// Creates Sourcery processor

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -570,6 +570,20 @@ class SourcerySpecTests: QuickSpec {
                         let result = try? outputFile.read(.utf8)
                         expect(result?.withoutWhitespaces).to(equal(expectedResult?.withoutWhitespaces))
                     }
+
+                    it("does not create generated file with empty content") {
+                        let templatePath = Stubs.templateDirectory + Path("Empty.stencil")
+                        update(code: "", in: templatePath)
+
+                        expect {
+                            try Sourcery(cacheDisabled: true, prune: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])),
+                                                                                        usingTemplates: Paths(include: [templatePath]),
+                                                                                        output: outputFile)
+                        }.toNot(throwError())
+
+                        let result = try? outputFile.read(.utf8)
+                        expect(result).to(beNil())
+                    }
                 }
 
                 context("given an output directory") {


### PR DESCRIPTION
When specifying a single output file, if the aggregate of generated code was empty, a file was still created.
This PR fixes this issue by preventing the file creation like what is done in the case of one generated file per template.