### PR TITLE
Fix codecov report now showing the correct result

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@ source 'https://rubygems.org'
 gem 'cocoapods'
 gem 'cocoapods-update-if-you-dare'
 gem 'danger'
-gem 'rake'
 gem 'danger-jazzy'
+gem 'rake'
+gem 'slather'
 gem 'xcpretty'
 
 # We should do it until the jazzy release will contain https://github.com/realm/jazzy/pull/830

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       cork
       nap
       open4 (~> 1.3)
+    clamp (0.6.5)
     cocoapods (1.2.1)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.1, < 2.0)
@@ -96,6 +97,7 @@ GEM
     json (1.8.6)
     kramdown (1.13.2)
     liferaft (0.0.6)
+    mini_portile2 (2.2.0)
     minitest (5.10.2)
     molinillo (0.5.7)
     multipart-post (2.0.0)
@@ -103,6 +105,8 @@ GEM
     nanaimo (0.2.3)
     nap (1.1.0)
     netrc (0.7.8)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
@@ -115,6 +119,12 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    slather (2.4.2)
+      CFPropertyList (~> 2.2)
+      activesupport (>= 4.0.2, < 5)
+      clamp (~> 0.6)
+      nokogiri (~> 1.6)
+      xcodeproj (~> 1.4)
     sqlite3 (1.3.13)
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
@@ -142,7 +152,8 @@ DEPENDENCIES
   danger-jazzy
   jazzy!
   rake
+  slather
   xcpretty
 
 BUNDLED WITH
-   1.13.7
+   1.15.3

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ machine:
     version: 8.3
   environment:
     XCODE_WORKSPACE: Sourcery.xcworkspace
+    XCODE_PROJECT: Sourcery.xcodeproj
     XCODE_SCHEME: Sourcery
   post:
       - ln -s /Applications/Xcode-8.3.app /Applications/Xcode.app
@@ -18,4 +19,5 @@ test:
       - xcodebuild -workspace "$XCODE_WORKSPACE" -scheme "$XCODE_SCHEME" ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | tee $CIRCLE_ARTIFACTS/xcode_raw.log | xcpretty --color --report junit --output $CIRCLE_TEST_REPORTS/xcode/results.xml
       - swift build
   post:
-      - bash <(curl -s https://codecov.io/bash)
+    - bundle exec slather coverage --scheme "$XCODE_SCHEME" --workspace "$XCODE_WORKSPACE" --output-directory $CIRCLE_ARTIFACTS --binary-basename SourceryRuntime --binary-basename Sourcery --cobertura-xml Sourcery.xcodeproj
+    - bash <(curl -s https://codecov.io/bash) -f $CIRCLE_ARTIFACTS/cobertura.xml -X coveragepy -X gcov -X xcode


### PR DESCRIPTION
This is a ~_work-in-progress_~ PR to find a solution on the fact that the codecov report only shows a coverage of less that 40% while it should be more around 80%.

This adds `slather` gem and use it in `circle.yml` with the appropriate flags to report coverage of `Sourcery` and `SourceryRuntime` code.

Here is what I tried:
- ~remove `xcpretty` to see if it's related to [this codecov caveat](https://github.com/codecov/example-swift#caveats)~ this does not change the [report](https://codecov.io/gh/krzysztofzablocki/Sourcery/compare/93e5466eeefe6c4c7fb76bd3645fc8204261cdd7...2ee221efab89669d7ce53d2b2ab73421c25ebf0e)
- ~restore `circle.yml` to its state before the codecov reporting stopped~
- ~tweak codecov call~
- use slather ✅