### PR TITLE
Remove clutter from releases

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,7 +110,8 @@ end
 desc "Validate docs"
 task :validate_docs do
   print_info "Checking docs are up to date"
-  sh "sourcekitten doc --module-name SourceryRuntime > docs.json && bundle exec jazzy --skip-undocumented --no-download-badge && rm docs.json"
+  sh "sourcekitten doc --module-name SourceryRuntime -- -workspace Sourcery.xcworkspace -scheme Sourcery-Release -derivedDataPath #{BUILD_DIR}tmp/ > docs.json && bundle exec jazzy --skip-undocumented --no-download-badge && rm docs.json"
+  sh "rm -fr #{BUILD_DIR}tmp/"
 end
 
 ## [ Release ] ##########################################################

--- a/Rakefile
+++ b/Rakefile
@@ -110,8 +110,9 @@ end
 desc "Validate docs"
 task :validate_docs do
   print_info "Checking docs are up to date"
-  sh "sourcekitten doc --module-name SourceryRuntime -- -workspace Sourcery.xcworkspace -scheme Sourcery-Release -derivedDataPath #{BUILD_DIR}tmp/ > docs.json && bundle exec jazzy --skip-undocumented --no-download-badge && rm docs.json"
-  sh "rm -fr #{BUILD_DIR}tmp/"
+  temp_build_dir = "#{BUILD_DIR}tmp/"
+  sh "sourcekitten doc --module-name SourceryRuntime -- -workspace Sourcery.xcworkspace -scheme Sourcery-Release -derivedDataPath #{temp_build_dir} > docs.json && bundle exec jazzy --skip-undocumented --no-download-badge && rm docs.json"
+  sh "rm -fr #{temp_build_dir}"
 end
 
 ## [ Release ] ##########################################################


### PR DESCRIPTION
In zip versions, I noticed that some unrelated `Release` and `Sourcery.build` folders were present.
This is because of the `:validate_docs` step which was writing them in the `build/` during the process while the `:clean` step trashing `build/` had already been done.
To prevent this, we now specify the derivedDataPath like in the `:build` step and remove it after the process is done.

I noticed that after fixing #400.
This will reduce the zip file by several MB (almost 4MB for the `0.8.0` release)!
You can see this because I've updated the 0.8.0 with an uncluttered zip and kept the initial invalid release containing a 0.7.2 build.