### PR TITLE
Implement forloop.counter0

### DIFF
--- a/Pods/Stencil/Sources/ForTag.swift
+++ b/Pods/Stencil/Sources/ForTag.swift
@@ -110,6 +110,7 @@ class ForNode : NodeType {
           "first": index == 0,
           "last": index == (count - 1),
           "counter": index + 1,
+          "counter0": index,
         ]
 
         return try context.push(dictionary: ["forloop": forContext]) {


### PR DESCRIPTION
Currently there is no way to directly get a zero-indexed iteration count in a for loop. Stencil solves this using [`forloop.counter0`](http://stencil.fuller.li/en/latest/builtins.html?highlight=counter0). This patch adds that functionality.