### PR TITLE
Add filter toArray;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Master
 
+### New Features
+
+- Added new toArray Stencil fileter
+
 ### Internal changes
 
 - Add release to Homebrew rake task

--- a/Pods/Target Support Files/libCommonCrypto/libCommonCrypto.modulemap
+++ b/Pods/Target Support Files/libCommonCrypto/libCommonCrypto.modulemap
@@ -2,7 +2,7 @@ framework module CommonCrypto {
   umbrella header "CommonCrypto.h"
 
   module CommonDigest [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonDigest.h"
+    header "/Applications/Xcode_9.0.0_fb.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonDigest.h"
     export *
   }
 

--- a/Pods/Target Support Files/libCommonCrypto/libCommonCrypto.modulemap
+++ b/Pods/Target Support Files/libCommonCrypto/libCommonCrypto.modulemap
@@ -2,7 +2,7 @@ framework module CommonCrypto {
   umbrella header "CommonCrypto.h"
 
   module CommonDigest [system] {
-    header "/Applications/Xcode_9.0.0_fb.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonDigest.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonDigest.h"
     export *
   }
 

--- a/Sourcery/Generating/Template/Stencil/StencilTemplate.swift
+++ b/Sourcery/Generating/Template/Stencil/StencilTemplate.swift
@@ -60,6 +60,7 @@ final class StencilTemplate: StencilSwiftKit.StencilSwiftTemplate, Template {
         ext.registerBoolFilter("protocol", filter: { (t: Type) in t is SourceryProtocol })
 
         ext.registerFilter("count", filter: count)
+        ext.registerFilter("toArray", filter: toArray)
 
         ext.registerBoolFilter("initializer", filter: { (m: SourceryMethod) in m.isInitializer })
         ext.registerBoolFilterOr("class",
@@ -198,6 +199,17 @@ extension Stencil.Extension {
         registerBoolFilter("!\(accessLevel.rawValue)Set", filter: { (v: SourceryVariable) in v.writeAccess != accessLevel.rawValue && v.writeAccess != AccessLevel.none.rawValue })
     }
 
+}
+
+private func toArray(_ value: Any?) -> Any? {
+    switch value {
+    case let array as NSArray:
+        return array
+    case .some(let something):
+        return [something]
+    default:
+        return nil
+    }
 }
 
 private func count(_ value: Any?) -> Any? {

--- a/SourceryTests/Generating/StencilTemplateSpec.swift
+++ b/SourceryTests/Generating/StencilTemplateSpec.swift
@@ -11,12 +11,34 @@ class StencilTemplateSpec: QuickSpec {
         describe("StencilTemplate") {
 
             func generate(_ template: String) -> String {
+                let arrayAnnotations = Variable(name: "annotated", typeName: TypeName("MyClass"))
+                arrayAnnotations.annotations = ["Foo": ["Hello", "World"] as NSArray]
+                let singleAnnotation = Variable(name: "annotated", typeName: TypeName("MyClass"))
+                singleAnnotation.annotations = ["Foo": "HelloWorld" as NSString]
                 return (try? Generator.generate(Types(types: [
                     Class(name: "MyClass", variables: [
                         Variable(name: "lowerFirst", typeName: TypeName("myClass")),
-                        Variable(name: "upperFirst", typeName: TypeName("MyClass"))
-                        ])
+                        Variable(name: "upperFirst", typeName: TypeName("MyClass")),
+                        arrayAnnotations,
+                        singleAnnotation
+                        ]),
                     ]), template: StencilTemplate(templateString: template))) ?? ""
+            }
+            
+            describe("toArray") {
+                context("given array") {
+                    it("doesnt modify the value") {
+                        let result = generate("{% for key,value in type.MyClass.variables.2.annotations %}{{ value | toArray }}{% endfor %}")
+                        expect(result).to(equal("(\n    Hello,\n    World\n)"))
+                    }
+                }
+                
+                context("given something") {
+                    it("transforms it into array") {
+                        let result = generate("{% for key,value in type.MyClass.variables.3.annotations %}{{ value | toArray }}{% endfor %}")
+                        expect(result).to(equal("[HelloWorld]"))
+                    }
+                }
             }
 
             context("given string") {


### PR DESCRIPTION
The PR adds new filter `toArray`. The purpose of the filter is to fix the problem from #302.
With the new filter the problem that was mentioned can be solved by doing:
```
{% for type in types.protocols|annotated:"TypeErase" %}
{% for key,value in type.annotations %}
{% for values in value | toArray %}
Do something witht the annotation value
{% endfor %}
{% endfor %}
{% endfor %}
```

The logic of the filter is:
1. If value is already array - do not modify value
2. If value is not array - convert it into array with one value