### PR TITLE
Simplify regex for annotation (#430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@
 
 ### New Features
 
-- Added new toArray Stencil fileter
+- Added new toArray Stencil filter
 
 ### Internal changes
 
 - Add release to Homebrew rake task
 - Fixed Swiftlint warnings
+- Fixed per file generation if there is long (approx. 150KB) output inside `sourcery:file` annotation
 
 ## 0.9.0
 

--- a/Sourcery/Parsing/Utils/InlineParser.swift
+++ b/Sourcery/Parsing/Utils/InlineParser.swift
@@ -10,8 +10,8 @@ internal enum TemplateAnnotationsParser {
     private static func regex(annotation: String) throws -> NSRegularExpression {
         let commentPattern = NSRegularExpression.escapedPattern(for: "//")
         let regex = try NSRegularExpression(
-            pattern: "(^\\s*?\(commentPattern)\\s*?sourcery:\(annotation):)(\\S*)\\s*?(^(?:.|\\s)*?)(^\\s*?\(commentPattern)\\s*?sourcery:end)",
-            options: [.allowCommentsAndWhitespace, .anchorsMatchLines]
+            pattern: "(^\\s*?\(commentPattern)\\s*?sourcery:\(annotation):)(\\S*)\\s*?(^.*?)(^\\s*?\(commentPattern)\\s*?sourcery:end)",
+            options: [.allowCommentsAndWhitespace, .anchorsMatchLines, .dotMatchesLineSeparators]
         )
         return regex
     }


### PR DESCRIPTION
This is a workaround for bug in NSRegularExpression that occurs for long strings and regex in regex(annotation:) method, see issue #430.