### PR TITLE
Add a warning when the user is passing arguments but a yml config is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features
 
 - Added new toArray Stencil filter
+- Added a console warning when a yaml is available but any parameter between 'sources', templates', 'forceParse', 'output' are provided
 
 ### Internal changes
 

--- a/Sourcery/main.swift
+++ b/Sourcery/main.swift
@@ -149,16 +149,13 @@ func runCLI() {
                     let relativePath: Path = configPath.isDirectory ? configPath : configPath.parent()
                     configuration = try Configuration(path: yamlPath, relativePath: relativePath)
 
-                    // Doesn't consider 'configPath' cause it's related to the yaml file
-                    let hasAnyParameter = (watcherEnabled == true ||
-                        disableCache == true ||
-                        verboseLogging != true ||
-                        quiet == true ||
-                        prune == true ||
+                    // Check if the user is passing parameters
+                    // that are ignored cause read from the yaml file
+                    let hasAnyParameter = (
                         !sources.isEmpty ||
                         !templates.isEmpty ||
-                        output != "" ||
-                        !args.arguments.isEmpty)
+                        output != ""
+                    )
 
                     if hasAnyParameter {
                         Log.info("Using configuration file at '\(yamlPath)'. WARNING: Ignoring the parameters passed in the command line.")

--- a/Sourcery/main.swift
+++ b/Sourcery/main.swift
@@ -151,14 +151,14 @@ func runCLI() {
 
                     // Check if the user is passing parameters
                     // that are ignored cause read from the yaml file
-                    let hasAnyParameter = (
-                        !sources.isEmpty ||
-                        !templates.isEmpty ||
-                        !forceParse.isEmpty ||
-                        output != ""
-                    )
+                    let hasAnyYamlDuplicatedParameter = (
+                                                        !sources.isEmpty ||
+                                                        !templates.isEmpty ||
+                                                            !forceParse.isEmpty ||
+                                                            output != ""
+                                                         )
 
-                    if hasAnyParameter {
+                    if hasAnyYamlDuplicatedParameter {
                         Log.info("Using configuration file at '\(yamlPath)'. WARNING: Ignoring the parameters passed in the command line.")
                     } else {
                         Log.info("Using configuration file at '\(yamlPath)'")

--- a/Sourcery/main.swift
+++ b/Sourcery/main.swift
@@ -148,9 +148,25 @@ func runCLI() {
                 do {
                     let relativePath: Path = configPath.isDirectory ? configPath : configPath.parent()
                     configuration = try Configuration(path: yamlPath, relativePath: relativePath)
-                    Log.info("Using configuration file at '\(yamlPath)'")
+
+                    // Doesn't consider 'configPath' cause it's related to the yaml file
+                    let hasAnyParameter = (watcherEnabled == true ||
+                        disableCache == true ||
+                        verboseLogging != true ||
+                        quiet == true ||
+                        prune == true ||
+                        !sources.isEmpty ||
+                        !templates.isEmpty ||
+                        output != "" ||
+                        !args.arguments.isEmpty)
+
+                    if hasAnyParameter {
+                        Log.info("Using configuration file at '\(yamlPath)'. WARNING: Ignoring the parameters passed in the command line.")
+                    } else {
+                        Log.info("Using configuration file at '\(yamlPath)'")
+                    }
                 } catch {
-                    Log.error(error)
+                    Log.error("while reading .yml '\(yamlPath)'. '\(error)'")
                     exit(.invalidConfig)
                 }
             }

--- a/Sourcery/main.swift
+++ b/Sourcery/main.swift
@@ -154,6 +154,7 @@ func runCLI() {
                     let hasAnyParameter = (
                         !sources.isEmpty ||
                         !templates.isEmpty ||
+                        !forceParse.isEmpty ||
                         output != ""
                     )
 

--- a/Sourcery/main.swift
+++ b/Sourcery/main.swift
@@ -154,9 +154,9 @@ func runCLI() {
                     let hasAnyYamlDuplicatedParameter = (
                                                         !sources.isEmpty ||
                                                         !templates.isEmpty ||
-                                                            !forceParse.isEmpty ||
-                                                            output != ""
-                                                         )
+                                                        !forceParse.isEmpty ||
+                                                        output != ""
+                                                        )
 
                     if hasAnyYamlDuplicatedParameter {
                         Log.info("Using configuration file at '\(yamlPath)'. WARNING: Ignoring the parameters passed in the command line.")


### PR DESCRIPTION
If the user is specifing any parameter aside than config and a yml is used it shows a WARNING to avoid confusion

Related to discussion in #412 