### PR TITLE
Fix a link to `Types` documentation in Writing templates.md

### DIFF
--- a/guides/Writing templates.md
+++ b/guides/Writing templates.md
@@ -4,7 +4,7 @@ Sourcery supports templates written in Stencil, Swift and even JavaScript.
 
 Dicsovered types can be accessed in templates via global context with following properties:
 
- - `types: Types` - access collections of types, i.e. `types.implementing.AutoCoding` (`types.implementing["AutoCoding"]` in swift templates). See [Types](Classes/Types.html).
+ - `types: Types` - access collections of types, i.e. `types.implementing.AutoCoding` (`types.implementing["AutoCoding"]` in swift templates). See [Types](https://cdn.rawgit.com/krzysztofzablocki/Sourcery/master/docs/Classes/Types.html).
  - `type: [String: Type]` - access types by their names, i.e. `type.MyType` (`type["MyType"]` in swift templates)
  - `arguments: [String: NSObject]` - access additional parameters passed with `--args` command line flag or set in `.sourcery.yml` file
 


### PR DESCRIPTION
Solves #440 