### PR TITLE
Improvements in AutoMockable example template

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -33,7 +33,7 @@ import AppKit
 
 {% macro extensionMethodReceivedParameters method %}
     {%if method.parameters.count == 1 %}
-        {% call swiftifyExtensionMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {{ param.name }}{% endfor %}
+        {% call swiftifyExtensionMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|capitalize }} = {{ param.name }}{% endfor %}
     {% else %}
     {% if not method.parameters.count == 0 %}
         {% call swiftifyExtensionMethodName method.selectorName %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
@@ -43,7 +43,7 @@ import AppKit
 
 {% macro methodReceivedParameters method %}
     {%if method.parameters.count == 1 %}
-        {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {{ param.name }}{% endfor %}
+        {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|capitalize }} = {{ param.name }}{% endfor %}
     {% else %}
     {% if not method.parameters.count == 0 %}
         {% call swiftifyMethodName method.selectorName %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
@@ -58,9 +58,13 @@ import AppKit
         {% call methodThrowableErrorDeclaration method %}
     {% endif %}
     {% if not method.isInitializer %}
-    var {% call swiftifyMethodName method.selectorName %}Called = false{% endif %}
+    var {% call swiftifyMethodName method.selectorName %}CallsCount = 0
+    var {% call swiftifyMethodName method.selectorName %}Called: Bool {
+        return {% call swiftifyMethodName method.selectorName %}CallsCount > 0
+    }
+    {% endif %}
     {% if method.parameters.count == 1 %}
-    var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ param.typeName.unwrappedTypeName }}?{% endfor %}
+    var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|capitalize }}: {% if param.isClosure %}({% endif %}{{ param.typeName.unwrappedTypeName }}{% if param.isClosure %}){% endif %}?{% endfor %}
     {% else %}{% if not method.parameters.count == 0 %}
     var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?
     {% endif %}{% endif %}
@@ -77,7 +81,7 @@ import AppKit
         {% if method.throws %}
         {% call methodThrowableErrorUsage method %}
         {% endif %}
-        {% call swiftifyMethodName method.selectorName %}Called = true
+        {% call swiftifyMethodName method.selectorName %}CallsCount += 1
         {% call methodReceivedParameters method %}
         {% if not method.returnTypeName.isVoid %}return {% call swiftifyMethodName method.selectorName %}ReturnValue{% endif %}
     }
@@ -91,9 +95,14 @@ import AppKit
     {% if method.throws %}
     {% call extensionMethodThrowableErrorDeclaration method %}
     {% endif %}
-    {% if not method.isInitializer %}var {% call swiftifyExtensionMethodName method.selectorName %}Called = false{% endif %}
+    {% if not method.isInitializer %}
+    var {% call swiftifyExtensionMethodName method.selectorName %}CallsCount = 0
+    var {% call swiftifyExtensionMethodName method.selectorName %}Called: Bool {
+        return {% call swiftifyExtensionMethodName method.selectorName %}CallsCount > 0
+    }
+    {% endif %}
     {% if method.parameters.count == 1 %}
-    var {% call swiftifyExtensionMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ param.typeName.unwrappedTypeName }}?{% endfor %}
+    var {% call swiftifyExtensionMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|capitalize }}: {% if param.isClosure %}({% endif %}{{ param.typeName.unwrappedTypeName }}{% if param.isClosure %}){% endif %}?{% endfor %}
     {% else %}{% if not method.parameters.count == 0 %}
     var {% call swiftifyExtensionMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?
     {% endif %}{% endif %}
@@ -110,7 +119,7 @@ import AppKit
         {% if method.throws %}
         {% call extensionMethodThrowableErrorUsage method %}
         {% endif %}
-        {% call swiftifyExtensionMethodName method.selectorName %}Called = true
+        {% call swiftifyExtensionMethodName method.selectorName %}CallsCount += 1
         {% call extensionMethodReceivedParameters method %}
         {% if not method.returnTypeName.isVoid %}return {% call swiftifyExtensionMethodName method.selectorName %}ReturnValue{% endif %}
     }

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -33,7 +33,7 @@ import AppKit
 
 {% macro extensionMethodReceivedParameters method %}
     {%if method.parameters.count == 1 %}
-        {% call swiftifyExtensionMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|capitalize }} = {{ param.name }}{% endfor %}
+        {% call swiftifyExtensionMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {{ param.name }}{% endfor %}
     {% else %}
     {% if not method.parameters.count == 0 %}
         {% call swiftifyExtensionMethodName method.selectorName %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
@@ -43,7 +43,7 @@ import AppKit
 
 {% macro methodReceivedParameters method %}
     {%if method.parameters.count == 1 %}
-        {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|capitalize }} = {{ param.name }}{% endfor %}
+        {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {{ param.name }}{% endfor %}
     {% else %}
     {% if not method.parameters.count == 0 %}
         {% call swiftifyMethodName method.selectorName %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
@@ -64,7 +64,7 @@ import AppKit
     }
     {% endif %}
     {% if method.parameters.count == 1 %}
-    var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|capitalize }}: {% if param.isClosure %}({% endif %}{{ param.typeName.unwrappedTypeName }}{% if param.isClosure %}){% endif %}?{% endfor %}
+    var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {% if param.isClosure %}({% endif %}{{ param.typeName.unwrappedTypeName }}{% if param.isClosure %}){% endif %}?{% endfor %}
     {% else %}{% if not method.parameters.count == 0 %}
     var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?
     {% endif %}{% endif %}
@@ -102,7 +102,7 @@ import AppKit
     }
     {% endif %}
     {% if method.parameters.count == 1 %}
-    var {% call swiftifyExtensionMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|capitalize }}: {% if param.isClosure %}({% endif %}{{ param.typeName.unwrappedTypeName }}{% if param.isClosure %}){% endif %}?{% endfor %}
+    var {% call swiftifyExtensionMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {% if param.isClosure %}({% endif %}{{ param.typeName.unwrappedTypeName }}{% if param.isClosure %}){% endif %}?{% endfor %}
     {% else %}{% if not method.parameters.count == 0 %}
     var {% call swiftifyExtensionMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?
     {% endif %}{% endif %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -58,3 +58,7 @@ extension ExtendableProtocol {
         print(message)
     }
 }
+
+protocol ClosureProtocol: AutoMockable {
+    func setClosure(_ closure: @escaping () -> Void)
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -10,20 +10,27 @@ class BasicProtocolMock: BasicProtocol {
 
     //MARK: - loadConfiguration
 
-    var loadConfigurationCalled = false
+    var loadConfigurationCallsCount = 0
+    var loadConfigurationCalled: Bool {
+        return loadConfigurationCallsCount > 0
+    }
     var loadConfigurationReturnValue: String?!
 
     func loadConfiguration() -> String? {
-        loadConfigurationCalled = true
+        loadConfigurationCallsCount += 1
         return loadConfigurationReturnValue
     }
+
     //MARK: - save
 
-    var saveConfigurationCalled = false
+    var saveConfigurationCallsCount = 0
+    var saveConfigurationCalled: Bool {
+        return saveConfigurationCallsCount > 0
+    }
     var saveConfigurationReceivedConfiguration: String?
 
     func save(configuration: String) {
-        saveConfigurationCalled = true
+        saveConfigurationCallsCount += 1
         saveConfigurationReceivedConfiguration = configuration
     }
 }
@@ -31,34 +38,42 @@ class CurrencyPresenterMock: CurrencyPresenter {
 
     //MARK: - showSourceCurrency
 
-    var showSourceCurrencyCalled = false
+    var showSourceCurrencyCallsCount = 0
+    var showSourceCurrencyCalled: Bool {
+        return showSourceCurrencyCallsCount > 0
+    }
     var showSourceCurrencyReceivedCurrency: String?
 
     func showSourceCurrency(_ currency: String) {
-        showSourceCurrencyCalled = true
+        showSourceCurrencyCallsCount += 1
         showSourceCurrencyReceivedCurrency = currency
     }
-
 }
 class ExtendableProtocolMock: ExtendableProtocol {
     var canReport: Bool!
 
     //MARK: - report
 
-    var reportMessageCalled = false
+    var reportMessageCallsCount = 0
+    var reportMessageCalled: Bool {
+        return reportMessageCallsCount > 0
+    }
     var reportMessageReceivedMessage: String?
 
     func report(message: String) {
-        reportMessageCalled = true
+        reportMessageCallsCount += 1
         reportMessageReceivedMessage = message
     }
     //MARK: - extension_report
 
-    var extensionReportMessageCalled = false
+    var extensionReportMessageCallsCount = 0
+    var extensionReportMessageCalled: Bool {
+        return extensionReportMessageCallsCount > 0
+    }
     var extensionReportMessageReceivedMessage: String?
 
     func report(message: String = "Test") {
-        extensionReportMessageCalled = true
+        extensionReportMessageCallsCount += 1
         extensionReportMessageReceivedMessage = message
     }
 }
@@ -73,29 +88,38 @@ class InitializationProtocolMock: InitializationProtocol {
     }
     //MARK: - start
 
-    var startCalled = false
+    var startCallsCount = 0
+    var startCalled: Bool {
+        return startCallsCount > 0
+    }
 
     func start() {
-        startCalled = true
+        startCallsCount += 1
     }
     //MARK: - stop
 
-    var stopCalled = false
+    var stopCallsCount = 0
+    var stopCalled: Bool {
+        return stopCallsCount > 0
+    }
 
     func stop() {
-        stopCalled = true
+        stopCallsCount += 1
     }
 }
 class ReservedWordsProtocolMock: ReservedWordsProtocol {
 
     //MARK: - `continue`
 
-    var continueWithCalled = false
+    var continueWithCallsCount = 0
+    var continueWithCalled: Bool {
+        return continueWithCallsCount > 0
+    }
     var continueWithReceivedMessage: String?
     var continueWithReturnValue: String!
 
     func `continue`(with message: String) -> String {
-        continueWithCalled = true
+        continueWithCallsCount += 1
         continueWithReceivedMessage = message
         return continueWithReturnValue
     }
@@ -105,20 +129,26 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
 
     //MARK: - start
 
-    var startCarOfCalled = false
+    var startCarOfCallsCount = 0
+    var startCarOfCalled: Bool {
+        return startCarOfCallsCount > 0
+    }
     var startCarOfReceivedArguments: (car: String, model: String)?
 
     func start(car: String, of model: String) {
-        startCarOfCalled = true
+        startCarOfCallsCount += 1
         startCarOfReceivedArguments = (car: car, model: model)
     }
     //MARK: - start
 
-    var startPlaneOfCalled = false
+    var startPlaneOfCallsCount = 0
+    var startPlaneOfCalled: Bool {
+        return startPlaneOfCallsCount > 0
+    }
     var startPlaneOfReceivedArguments: (plane: String, model: String)?
 
     func start(plane: String, of model: String) {
-        startPlaneOfCalled = true
+        startPlaneOfCallsCount += 1
         startPlaneOfReceivedArguments = (plane: plane, model: model)
     }
 }
@@ -127,14 +157,17 @@ class ThrowableProtocolMock: ThrowableProtocol {
     //MARK: - doOrThrow
 
     var doOrThrowThrowableError: Error?
-    var doOrThrowCalled = false
+    var doOrThrowCallsCount = 0
+    var doOrThrowCalled: Bool {
+        return doOrThrowCallsCount > 0
+    }
     var doOrThrowReturnValue: String!
 
     func doOrThrow() throws -> String {
         if let error = doOrThrowThrowableError {
             throw error
         }
-        doOrThrowCalled = true
+        doOrThrowCallsCount += 1
         return doOrThrowReturnValue
     }
 

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -34,6 +34,22 @@ class BasicProtocolMock: BasicProtocol {
         saveConfigurationReceivedConfiguration = configuration
     }
 }
+class ClosureProtocolMock: ClosureProtocol {
+
+    //MARK: - setClosure
+
+    var setClosureCallsCount = 0
+    var setClosureCalled: Bool {
+        return setClosureCallsCount > 0
+    }
+    var setClosureReceivedClosure: (() -> Void)?
+
+    func setClosure(_ closure: @escaping () -> Void) {
+        setClosureCallsCount += 1
+        setClosureReceivedClosure = closure
+    }
+
+}
 class CurrencyPresenterMock: CurrencyPresenter {
 
     //MARK: - showSourceCurrency

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -24,21 +24,27 @@ class BasicProtocolMock: BasicProtocol {
 
     //MARK: - loadConfiguration
 
-    var loadConfigurationCalled = false
+    var loadConfigurationCallsCount = 0
+    var loadConfigurationCalled: Bool {
+        return loadConfigurationCallsCount > 0
+    }
     var loadConfigurationReturnValue: String?!
 
     func loadConfiguration() -> String? {
-        loadConfigurationCalled = true
+        loadConfigurationCallsCount += 1
         return loadConfigurationReturnValue
     }
 
     //MARK: - save
 
-    var saveConfigurationCalled = false
+    var saveConfigurationCallsCount = 0
+    var saveConfigurationCalled: Bool {
+        return saveConfigurationCallsCount > 0
+    }
     var saveConfigurationReceivedConfiguration: String?
 
     func save(configuration: String) {
-        saveConfigurationCalled = true
+        saveConfigurationCallsCount += 1
         saveConfigurationReceivedConfiguration = configuration
     }
 
@@ -47,11 +53,14 @@ class CurrencyPresenterMock: CurrencyPresenter {
 
     //MARK: - showSourceCurrency
 
-    var showSourceCurrencyCalled = false
+    var showSourceCurrencyCallsCount = 0
+    var showSourceCurrencyCalled: Bool {
+        return showSourceCurrencyCallsCount > 0
+    }
     var showSourceCurrencyReceivedCurrency: String?
 
     func showSourceCurrency(_ currency: String) {
-        showSourceCurrencyCalled = true
+        showSourceCurrencyCallsCount += 1
         showSourceCurrencyReceivedCurrency = currency
     }
 
@@ -61,21 +70,27 @@ class ExtendableProtocolMock: ExtendableProtocol {
 
     //MARK: - report
 
-    var reportMessageCalled = false
+    var reportMessageCallsCount = 0
+    var reportMessageCalled: Bool {
+        return reportMessageCallsCount > 0
+    }
     var reportMessageReceivedMessage: String?
 
     func report(message: String) {
-        reportMessageCalled = true
+        reportMessageCallsCount += 1
         reportMessageReceivedMessage = message
     }
 
     //MARK: - extension_report
 
-    var extensionReportMessageCalled = false
+    var extensionReportMessageCallsCount = 0
+    var extensionReportMessageCalled: Bool {
+        return extensionReportMessageCallsCount > 0
+    }
     var extensionReportMessageReceivedMessage: String?
 
     func report(message: String = "Test") {
-        extensionReportMessageCalled = true
+        extensionReportMessageCallsCount += 1
         extensionReportMessageReceivedMessage = message
     }
 
@@ -91,18 +106,24 @@ class InitializationProtocolMock: InitializationProtocol {
     }
     //MARK: - start
 
-    var startCalled = false
+    var startCallsCount = 0
+    var startCalled: Bool {
+        return startCallsCount > 0
+    }
 
     func start() {
-        startCalled = true
+        startCallsCount += 1
     }
 
     //MARK: - stop
 
-    var stopCalled = false
+    var stopCallsCount = 0
+    var stopCalled: Bool {
+        return stopCallsCount > 0
+    }
 
     func stop() {
-        stopCalled = true
+        stopCallsCount += 1
     }
 
 }
@@ -110,12 +131,15 @@ class ReservedWordsProtocolMock: ReservedWordsProtocol {
 
     //MARK: - `continue`
 
-    var continueWithCalled = false
+    var continueWithCallsCount = 0
+    var continueWithCalled: Bool {
+        return continueWithCallsCount > 0
+    }
     var continueWithReceivedMessage: String?
     var continueWithReturnValue: String!
 
     func `continue`(with message: String) -> String {
-        continueWithCalled = true
+        continueWithCallsCount += 1
         continueWithReceivedMessage = message
         return continueWithReturnValue
     }
@@ -125,21 +149,27 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
 
     //MARK: - start
 
-    var startCarOfCalled = false
+    var startCarOfCallsCount = 0
+    var startCarOfCalled: Bool {
+        return startCarOfCallsCount > 0
+    }
     var startCarOfReceivedArguments: (car: String, model: String)?
 
     func start(car: String, of model: String) {
-        startCarOfCalled = true
+        startCarOfCallsCount += 1
         startCarOfReceivedArguments = (car: car, model: model)
     }
 
     //MARK: - start
 
-    var startPlaneOfCalled = false
+    var startPlaneOfCallsCount = 0
+    var startPlaneOfCalled: Bool {
+        return startPlaneOfCallsCount > 0
+    }
     var startPlaneOfReceivedArguments: (plane: String, model: String)?
 
     func start(plane: String, of model: String) {
-        startPlaneOfCalled = true
+        startPlaneOfCallsCount += 1
         startPlaneOfReceivedArguments = (plane: plane, model: model)
     }
 
@@ -149,14 +179,17 @@ class ThrowableProtocolMock: ThrowableProtocol {
     //MARK: - doOrThrow
 
     var doOrThrowThrowableError: Error?
-    var doOrThrowCalled = false
+    var doOrThrowCallsCount = 0
+    var doOrThrowCalled: Bool {
+        return doOrThrowCallsCount > 0
+    }
     var doOrThrowReturnValue: String!
 
     func doOrThrow() throws -> String {
         if let error = doOrThrowThrowableError {
             throw error
         }
-        doOrThrowCalled = true
+        doOrThrowCallsCount += 1
         return doOrThrowReturnValue
     }
 

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -49,6 +49,22 @@ class BasicProtocolMock: BasicProtocol {
     }
 
 }
+class ClosureProtocolMock: ClosureProtocol {
+
+    //MARK: - setClosure
+
+    var setClosureCallsCount = 0
+    var setClosureCalled: Bool {
+        return setClosureCallsCount > 0
+    }
+    var setClosureReceivedClosure: (() -> Void)?
+
+    func setClosure(_ closure: @escaping () -> Void) {
+        setClosureCallsCount += 1
+        setClosureReceivedClosure = closure
+    }
+
+}
 class CurrencyPresenterMock: CurrencyPresenter {
 
     //MARK: - showSourceCurrency


### PR DESCRIPTION
Three improvements were introduced:
1. If generated "received" variable is a closure, question mark that is applied at the end is treated as a closure's return parameter optionality marker, not as entire closure's optionality marker. It has been fixed by adding parentheses.
Example:
```
func setCompletion(_ completion @escaping () -> ()) {
...
}
```
Fragment of generated code, that is relevant for us, will look like this:
```
var setCompletionReceivedCompletion: () -> ()?
```
After fix:
```
var setCompletionReceivedCompletion: (() -> ())?
```
2. Instead of boolean marking if given mocked method was called, integer counting each call was introduced.
{methodName}Called boolean still is present, but now is a computed variable utilizing new calls count integer.
3. `upperFirstLetter` was replaced with `capitalize`. I belive this must have been a recent change to Stencil. Correct me if I'm wrong since I had not been using Sourcery for a while. `upperFirstLetter` just didn't work for me.