### PR TITLE
Add sort filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### New Features
 
+- Added new sorted Stencil filter. This can sort arrays by calling e.g. `protocol.allVariables|sorted:"name"`
 - Added new toArray Stencil filter
 - Added a console warning when a yaml is available but any parameter between 'sources', templates', 'forceParse', 'output' are provided
 

--- a/Sourcery/Generating/Template/Stencil/StencilTemplate.swift
+++ b/Sourcery/Generating/Template/Stencil/StencilTemplate.swift
@@ -62,6 +62,16 @@ final class StencilTemplate: StencilSwiftKit.StencilSwiftTemplate, Template {
         ext.registerFilter("count", filter: count)
         ext.registerFilter("toArray", filter: toArray)
 
+        ext.registerFilterWithArguments("sorted") { (array, propertyName: String) -> Any? in
+          switch array {
+            case let array as NSArray:
+              let sortDescriptor = NSSortDescriptor(key: propertyName, ascending: true, selector: #selector(NSString.caseInsensitiveCompare))
+              return array.sortedArray(using: [sortDescriptor])
+            default:
+              return nil
+          }
+        }
+
         ext.registerBoolFilter("initializer", filter: { (m: SourceryMethod) in m.isInitializer })
         ext.registerBoolFilterOr("class",
                                  filter: { (t: Type) in t is Class },

--- a/SourceryTests/Generating/StencilTemplateSpec.swift
+++ b/SourceryTests/Generating/StencilTemplateSpec.swift
@@ -12,7 +12,7 @@ class StencilTemplateSpec: QuickSpec {
 
             func generate(_ template: String) -> String {
                 let arrayAnnotations = Variable(name: "annotated", typeName: TypeName("MyClass"))
-                arrayAnnotations.annotations = ["Foo": ["Hello", "World"] as NSArray]
+                arrayAnnotations.annotations = ["Foo": ["Hello", "beautiful", "World"] as NSArray]
                 let singleAnnotation = Variable(name: "annotated", typeName: TypeName("MyClass"))
                 singleAnnotation.annotations = ["Foo": "HelloWorld" as NSString]
                 return (try? Generator.generate(Types(types: [
@@ -29,7 +29,7 @@ class StencilTemplateSpec: QuickSpec {
                 context("given array") {
                     it("doesnt modify the value") {
                         let result = generate("{% for key,value in type.MyClass.variables.2.annotations %}{{ value | toArray }}{% endfor %}")
-                        expect(result).to(equal("(\n    Hello,\n    World\n)"))
+                        expect(result).to(equal("(\n    Hello,\n    beautiful,\n    World\n)"))
                     }
                 }
 
@@ -39,6 +39,15 @@ class StencilTemplateSpec: QuickSpec {
                         expect(result).to(equal("[HelloWorld]"))
                     }
                 }
+            }
+
+            describe("sorted") {
+              context("given array") {
+                it("sorts it") {
+                  let result = generate("{% for key,value in type.MyClass.variables.2.annotations %}{{ value | sorted:\"description\" }}{% endfor %}")
+                  expect(result).to(equal("[beautiful, Hello, World]"))
+                }
+              }
             }
 
             context("given string") {


### PR DESCRIPTION
for my templates, I ran into issues, where the order of the variables was not always the same for different calls.

This filter allows to order them:

example usage:
```
    {% for variable in protocol.allVariables|sorted:"name" %}
      {{ variable.name }}: {{ variable.typeName }}{% if not forloop.last %},{% endif %}
    {% endfor %}
```