### PR TITLE
Return empty array instead of optional array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 ### New Features
 
 - Added support for subscripts
+- Return non-Optional arrays from `TypesCollection`'s `types(forKey:)` and `subscript(_ key:)` methods. Note that this is a source-breaking change for anyone who has a Swift template that does something like this:
+
+ ```swift
+<% for type in (types.implementing["SomeProtocol"] ?? []) { %>
+```
+
+ The new correct syntax would be:
+
+ ```swift
+<% for type in types.implementing["SomeProtocol"] { %>
+```
 
 ### Bug fixes 
 

--- a/SourceryRuntime/Sources/TemplateContext.swift
+++ b/SourceryRuntime/Sources/TemplateContext.swift
@@ -200,7 +200,7 @@ public class TypesCollection: NSObject, AutoJSExport {
         self.validate = validate
     }
 
-    public func types(forKey key: String) throws -> [Type]? {
+    public func types(forKey key: String) throws -> [Type] {
         if let validate = validate {
             guard let type = all.first(where: { $0.name == key }) else {
                 throw "Unknown type \(key), should be used with `based`"
@@ -221,12 +221,12 @@ public class TypesCollection: NSObject, AutoJSExport {
     }
 
     /// :nodoc:
-    public subscript(_ key: String) -> [Type]? {
+    public subscript(_ key: String) -> [Type] {
         do {
             return try types(forKey: key)
         } catch {
             Log.error(error)
-            return nil
+            return []
         }
     }
 


### PR DESCRIPTION
Related to a584ce88421a47ea096354fa3143b4c186c52519. Makes it easier to loop over types in Swift-based templates.