### PR TITLE
Add swiftlint autocorrect call before linting

### DIFF
--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -796,7 +796,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect\n\"${PODS_ROOT}/SwiftLint/swiftlint\" lint";
 		};
 		8E96ACE81324E260FA5DCECB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -525,7 +525,7 @@ extension FileParser {
         if let key = extract(.key, from: source),
             var line = extractLines(.key, from: source, contents: contents, trimWhitespacesAndNewlines: false),
             let range = line.range(of: key) {
-            
+
             // if parameter line ends with new line we just append everything to it so that we can read return type
             if line.trimmingCharacters(in: .whitespacesAndNewlines) != line {
                 let lines = contents.lines()
@@ -533,7 +533,7 @@ extension FileParser {
                     line += lines.suffix(from: linesRange.end).map({ $0.content }).joined()
                 }
             }
-            
+
             let lineSuffix = String(line.suffix(from: range.lowerBound))
             let components = lineSuffix.semicolonSeparated()
             if let suffix = components.first {
@@ -541,7 +541,7 @@ extension FileParser {
                     .trimmingCharacters(in: .whitespaces)
                     .trimmingPrefix(key)
                     .trimmingCharacters(in: CharacterSet(charactersIn: ")").union(.whitespacesAndNewlines))
-                
+
                 if nameSuffix.trimPrefix("->"), let openBraceIndex = nameSuffix.index(of: "{") {
                     returnTypeName = nameSuffix
                         .prefix(upTo: openBraceIndex)
@@ -564,15 +564,15 @@ extension FileParser {
         var readAccessLevel: AccessLevel = definedIn.flatMap({ AccessLevel(rawValue: $0.accessLevel) }) ?? .`internal`
         var writeAccessLevel: AccessLevel = .none
         var isFinal: Bool = false
-        
+
         let accessLevels: [AccessLevel] = [.`private`, .`fileprivate`, .`internal`, .`public`, .`open`]
         var readAllPrefixes: Bool = false
-        
+
         while !readAllPrefixes {
             var readReadAccessLevel: Bool = false
             var readWriteAccessLevel: Bool = false
             var readFinalAttribute: Bool = false
-            
+
             if let _readAccessLevel = accessLevels.first(where: { keyPrefix.trimSuffix($0.rawValue) }) {
                 readAccessLevel = _readAccessLevel
                 keyPrefix = keyPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -592,7 +592,7 @@ extension FileParser {
                 (readReadAccessLevel && readWriteAccessLevel && readFinalAttribute) ||
                 (!readReadAccessLevel && !readWriteAccessLevel && !readFinalAttribute)
         }
-        
+
         return (readAccessLevel, writeAccessLevel, isFinal)
     }
 

--- a/SourceryRuntime/Sources/Type.swift
+++ b/SourceryRuntime/Sources/Type.swift
@@ -74,11 +74,11 @@ public class Type: NSObject, SourceryModel, Annotated {
     public var allMethods: [Method] {
         return flattenAll({ $0.methods })
     }
-    
+
     /// Subscripts defined in this type only, inluding subscripts defined in its extensions,
     /// but not including subscripts inherited from superclasses (for classes only) and protocols
     public var subscripts: [Subscript]
-    
+
     // sourcery: skipEquality, skipDescription
     /// All subscripts defined for this type, including subscripts defined in extensions,
     /// in superclasses (for classes only) and protocols


### PR DESCRIPTION
This will prevent some unwanted warnings which are easily fixed automatically by swiftlint (e.g. `trailing_whitespaces`).