### PR TITLE
Fix func signature for void return throws

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -77,7 +77,7 @@ import AppKit
         {% call methodReceivedParameters method %}
     }
 {% else %}
-    func {{ method.name }}{% if not method.returnTypeName.isVoid %} {% if method.throws %}throws {% endif %}-> {{ method.returnTypeName }}{% endif %} {
+    func {{ method.name }}{% if not method.returnTypeName.isVoid %} {% if method.throws %}throws {% endif %}-> {{ method.returnTypeName }}{% else %}{% if method.throws %} throws{% endif %}{% endif %} {
         {% if method.throws %}
         {% call methodThrowableErrorUsage method %}
         {% endif %}


### PR DESCRIPTION
AutoMockable wasn't generating valid code for requirements that were void return throwing.  This PR adds an else for void returning methods and checks if throwing and adds throws if needed.  I have testing this in my project is now generating code that compiles