### PR TITLE
fixed parsing @objc attribute and changed its attributes layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is a breaking change for template code like this:
 ```
 
 - **Breaking** @objc attribute now has a `name` argument that contains Objective-C name of attributed declaration
+- added `@objcMembers` attribute
 
 ### Bug fixes 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
 - Supports adding new templates files while in watcher mode
 - Supports adding new source files while in watcher mode
 - Added support for subscripts
-- Type collections `types.based`, `types.implementing` and `types.inheriting` now return non-optional array. If no types found, empty array will be returned. 
-This is a breaking change for template code like this:
 - You can now pass additional arguments one by one, i.e. `--args arg1=value1 --args arg2 --args arg3=value3`
+- **Breaking** Type collections `types.based`, `types.implementing` and `types.inheriting` now return non-optional array. If no types found, empty array will be returned. 
+This is a breaking change for template code like this:
 
  ```swift
 <% for type in (types.implementing["SomeProtocol"] ?? []) { %>
@@ -23,13 +23,16 @@ This is a breaking change for template code like this:
 <% for type in types.implementing["SomeProtocol"] { %>
 ```
 
+- **Breaking** @objc attribute now has a `name` argument that contains Objective-C name of attributed declaration
+
 ### Bug fixes 
 
-- Fixes FSEvents errors reported in #465 that happen on Sierra.
+- Fixes FSEvents errors reported in #465 that happen on Sierra
 - JS exceptions no more override syntax errors in JS templates 
 - Accessing unknown property on `types` now results in a better error than `undefined is not an object` in JS templates
 - Fixed issue in AutoMockable, where generated non-optional variables wouldn't meet protocol's requirements. For this purpose, underlying variable was introduced
 - Fixed `inline:auto` not inserting code if Sourcery is run with cache enabled #467
+- Fixed parsing @objc attributes on types  
 
 ## 0.10.1
 

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -888,9 +888,8 @@ extension FileParser {
                 let chars = attributeString
                 let startIndex = chars.index(openIndex, offsetBy: 1)
                 let endIndex = chars.index(chars.endIndex, offsetBy: -1)
-                let optArgumentsString = String(chars[startIndex ..< endIndex])
-                guard let argumentsString = optArgumentsString else { return nil }
-                let arguments = parseAttributeArguments(argumentsString)
+                guard let argumentsString = String(chars[startIndex ..< endIndex]) else { return nil }
+                let arguments = parseAttributeArguments(argumentsString, attribute: name)
 
                 return Attribute(name: name, arguments: arguments, description: "@\(attributeString)")
             } else {
@@ -902,11 +901,16 @@ extension FileParser {
         return attributes
     }
 
-    private func parseAttributeArguments(_ string: String) -> [String: NSObject] {
+    private func parseAttributeArguments(_ string: String, attribute: String) -> [String: NSObject] {
         var arguments = [String: NSObject]()
         string.components(separatedBy: ",", excludingDelimiterBetween: ("\"", "\""))
             .map({ $0.trimmingCharacters(in: .whitespaces) })
             .forEach { argument in
+                if attribute == "objc" {
+                    arguments["name"] = argument as NSString
+                    return
+                }
+
                 guard argument.contains("\"") else {
                     if argument != "*" {
                         arguments[argument.replacingOccurrences(of: " ", with: "_")] = NSNumber(value: true)

--- a/SourceryRuntime/Sources/Attribute.swift
+++ b/SourceryRuntime/Sources/Attribute.swift
@@ -32,6 +32,7 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case discardableResult
         case GKInspectable = "gkinspectable"
         case objc
+        case objcMembers
         case nonobjc
         case NSApplicationMain
         case NSCopying

--- a/SourceryRuntime/Sources/Attribute.swift
+++ b/SourceryRuntime/Sources/Attribute.swift
@@ -31,7 +31,7 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case available
         case discardableResult
         case GKInspectable = "gkinspectable"
-        case objc = "objc.name"
+        case objc
         case nonobjc
         case NSApplicationMain
         case NSCopying
@@ -47,7 +47,12 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case final
 
         public init?(identifier: String) {
-            self.init(rawValue: identifier.replacingOccurrences(of: "source.decl.attribute.", with: ""))
+            let identifier = identifier.replacingOccurrences(of: "source.decl.attribute.", with: "")
+            if identifier == "objc.name" {
+                self.init(rawValue: "objc")
+            } else {
+                self.init(rawValue: identifier)
+            }
         }
 
         public static func from(string: String) -> Identifier? {

--- a/SourceryTests/Parsing/FileParser + AttributesSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AttributesSpec.swift
@@ -34,6 +34,10 @@ class FileParserAttributesSpec: QuickSpec {
                 expect(parse("@objc(Bar) class Foo {}").first?.attributes).to(equal([
                     "objc": Attribute(name: "objc", arguments: ["name": "Bar" as NSString], description: "@objc(Bar)")
                     ]))
+
+                expect(parse("@objcMembers class Foo {}").first?.attributes).to(equal([
+                    "objcMembers": Attribute(name: "objcMembers", arguments: [:], description: "@objcMembers")
+                    ]))
             }
 
             context("given attribute with arguments") {

--- a/SourceryTests/Parsing/FileParser + AttributesSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AttributesSpec.swift
@@ -26,6 +26,14 @@ class FileParserAttributesSpec: QuickSpec {
                 expect(parse("final class Foo { }").first?.attributes).to(equal([
                     "final": Attribute(name: "final", description: "final")
                     ]))
+
+                expect(parse("@objc class Foo {}").first?.attributes).to(equal([
+                    "objc": Attribute(name: "objc", arguments: [:], description: "@objc")
+                    ]))
+
+                expect(parse("@objc(Bar) class Foo {}").first?.attributes).to(equal([
+                    "objc": Attribute(name: "objc", arguments: ["name": "Bar" as NSString], description: "@objc(Bar)")
+                    ]))
             }
 
             context("given attribute with arguments") {
@@ -59,7 +67,7 @@ class FileParserAttributesSpec: QuickSpec {
             it("extracts method attributes") {
                 expect(parse("class Foo { @discardableResult\n@objc(some)\nfunc some() {} }").first?.methods.first?.attributes).to(equal([
                     "discardableResult": Attribute(name: "discardableResult"),
-                    "objc": Attribute(name: "objc", arguments: ["some": NSNumber(value: true)], description: "@objc(some)")
+                    "objc": Attribute(name: "objc", arguments: ["name": "some" as NSString], description: "@objc(some)")
                     ]))
 
                 expect(parse("class Foo { @nonobjc convenience required init() {} }").first?.initializers.first?.attributes).to(equal([
@@ -86,7 +94,7 @@ class FileParserAttributesSpec: QuickSpec {
             it("extracts variable attributes") {
                 expect(parse("class Foo { @NSCopying @objc(objcName:) var name: String }").first?.variables.first?.attributes).to(equal([
                     "NSCopying": Attribute(name: "NSCopying"),
-                    "objc": Attribute(name: "objc", arguments: ["objcName:": NSNumber(value: true)], description: "@objc(objcName:)")
+                    "objc": Attribute(name: "objc", arguments: ["name": "objcName:" as NSString], description: "@objc(objcName:)")
                     ]))
 
                 expect(parse("struct Foo { mutating var some: Int }").first?.variables.first?.attributes).to(equal([


### PR DESCRIPTION
Resolves #482 
This change also contains breaking change to objc attributes layout. Before for attribute `@objc(objcName)` it would be `["objcName": true]`, now it will be `["name": "objcName"]`.
Also added new `@objcMembers` attribute