### PR TITLE
AutoMockable with annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - EJS templates now can be used when building Sourcery with SPM
 - Added Closures to AutoMockable
 - You can now link generated files to projects using config file
+- You can now use AutoMockable with annotations
 
 ** Breaking **
 

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -101,7 +101,7 @@ import AppKit
 {% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
 {% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
 
-{% for type in types.based.AutoMockable where type|protocol and not type.name == "AutoMockable" %}
+{% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
 class {{ type.name }}Mock: {{ type.name }} {
 {% for variable in type.allVariables|!definedInExtension %}
     {% if variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
@@ -111,4 +111,4 @@ class {{ type.name }}Mock: {{ type.name }} {
     {% call mockMethod method %}
 {% endfor %}
 }
-{% endfor %}
+{% endif %}{% endfor %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -63,3 +63,8 @@ extension ExtendableProtocol {
 protocol ClosureProtocol: AutoMockable {
     func setClosure(_ closure: @escaping () -> Void)
 }
+
+/// sourcery: AutoMockable
+protocol AnnotatedProtocol {
+    func sayHelloWith(name: String)
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -6,6 +6,24 @@ import AppKit
 #endif
 
 
+class AnnotatedProtocolMock: AnnotatedProtocol {
+
+    //MARK: - sayHelloWith
+
+    var sayHelloWithNameCallsCount = 0
+    var sayHelloWithNameCalled: Bool {
+        return sayHelloWithNameCallsCount > 0
+    }
+    var sayHelloWithNameReceivedName: String?
+    var sayHelloWithNameClosure: ((String) -> Void)?
+
+    func sayHelloWith(name: String) {
+        sayHelloWithNameCallsCount += 1
+        sayHelloWithNameReceivedName = name
+        sayHelloWithNameClosure?(name)
+    }
+
+}
 class BasicProtocolMock: BasicProtocol {
 
     //MARK: - loadConfiguration

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -23,6 +23,24 @@ import AppKit
 
 
 
+class AnnotatedProtocolMock: AnnotatedProtocol {
+
+    //MARK: - sayHelloWith
+
+    var sayHelloWithNameCallsCount = 0
+    var sayHelloWithNameCalled: Bool {
+        return sayHelloWithNameCallsCount > 0
+    }
+    var sayHelloWithNameReceivedName: String?
+    var sayHelloWithNameClosure: ((String) -> Void)?
+
+    func sayHelloWith(name: String) {
+        sayHelloWithNameCallsCount += 1
+        sayHelloWithNameReceivedName = name
+        sayHelloWithNameClosure?(name)
+    }
+
+}
 class BasicProtocolMock: BasicProtocol {
 
     //MARK: - loadConfiguration


### PR DESCRIPTION
This is a backward compatible change on AutoMockable template for making it usable with annotations in addition to the current way (extending a protocol).
It allows you not having to extend a protocol in your code just because you want to use AutoMockable in testing.