### PR TITLE
Fix trailing comma

### DIFF
--- a/Sourcery/Templates/Description.stencil
+++ b/Sourcery/Templates/Description.stencil
@@ -5,7 +5,8 @@
 extension {{ type.name }} {
     /// :nodoc:
     override {{ type.accessLevel }} var description: String {
-        var string = {% if type.inheritedTypes.first == "NSObject" %}"\(Swift.type(of: self)): "{% else %}super.description{% endif %}
+        var string = {% if type.inheritedTypes.first == "NSObject" %}"\(Swift.type(of: self)): "{% else %}super.description
+        string += ",\n"{% endif %}
         {% for variable in type.variables|!annotated:"skipDescription" %}string += "{{ variable.name }} = \(String(describing: self.{{ variable.name }})){% if not forloop.last %}, {% endif %}"
         {% endfor %}return string
     }

--- a/Sourcery/Templates/Description.stencil
+++ b/Sourcery/Templates/Description.stencil
@@ -6,7 +6,7 @@ extension {{ type.name }} {
     /// :nodoc:
     override {{ type.accessLevel }} var description: String {
         var string = {% if type.inheritedTypes.first == "NSObject" %}"\(Swift.type(of: self)): "{% else %}super.description
-        string += ",\n"{% endif %}
+        string += ", "{% endif %}
         {% for variable in type.variables|!annotated:"skipDescription" %}string += "{{ variable.name }} = \(String(describing: self.{{ variable.name }})){% if not forloop.last %}, {% endif %}"
         {% endfor %}return string
     }


### PR DESCRIPTION
description of `class`, `struct`, `enum` contains syntax error. I fix it.

### before (class)

```
Class: module = nil, ... , attributes = [:]kind = class, isFinal = false
```

### after (class)

```
Class: module = nil, ... , attributes = [:], kind = class, isFinal = false
```