### PR TITLE
fixed creating output folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ This is a breaking change for template code like this:
 - Fixed resolving actual type name for generics with inner types
 - Fixed parsing nested types from extensions
 - Fixed removing back ticks in types names
+- Fixed creating output folder if it does not exist
 
 ## 0.10.1
 

--- a/Sourcery.xcworkspace/xcshareddata/xcschemes/Sourcery.xcscheme
+++ b/Sourcery.xcworkspace/xcshareddata/xcschemes/Sourcery.xcscheme
@@ -122,7 +122,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "/Users/ilyapuchka/dev/Sourcery/SourceryRuntime/Sources"
+            argument = "$SRCROOT/SourceryRuntime/Sources"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
@@ -130,7 +130,15 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "/Users/ilyapuchka/dev/Sourcery/Sourcery/Templates"
+            argument = "$SRCROOT/Sourcery/Templates"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--output"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "$SRCROOT/SourceryRuntime/Sources"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Sourcery/Configuration.swift
+++ b/Sourcery/Configuration.swift
@@ -144,6 +144,13 @@ struct Output {
     let path: Path
     let linkTo: LinkTo?
 
+    var isDirectory: Bool {
+        guard path.exists else {
+            return path.lastComponentWithoutExtension == path.lastComponent || path.string.hasSuffix("/")
+        }
+        return path.isDirectory
+    }
+
     init(dict: [String: Any], relativePath: Path) throws {
         guard let path = dict["path"] as? String else {
             throw Configuration.Error.invalidOutput(message: "No path provided.")

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -354,7 +354,7 @@ extension Sourcery {
         Log.info("Generating code...")
         status = ""
 
-        if output.path.isDirectory {
+        if output.isDirectory {
             try allTemplates.forEach { template in
                 let result = try generate(template, forParsingResult: parsingResult, outputPath: output.path)
                 let outputPath = output.path + generatedPath(for: template.sourcePath)


### PR DESCRIPTION
We were considering non-existent folders as files, so in this case all generated content was written to the file without extension, instead of creating folder and writing output into separate files in it.