### PR TITLE
option to ignore methods in extensions for auto mockable template

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -107,7 +107,7 @@ class {{ type.name }}Mock: {{ type.name }} {
     {% if variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
 {% endfor %}
 
-{% for method in type.allMethods|!definedInExtension %}
+{% for method in type.allMethods|!definedInExtension|!annotated:"ignore" %}
     {% call mockMethod method %}
 {% endfor %}
 }


### PR DESCRIPTION
Added possibility to ignore auto mockable in some methods defined|default implementation in extensions.

In some cases when we give some default implementation to protocols, for example using "when" clause this template generate duplicated methods.

Cause:
```
protocol A: AutoMockable {
   func a() -> String
   func b()
}

extension A where Self: B {
   func a() -> String { return "duplicated.method.a" }
}
```

Solution:
```
protocol A: AutoMockable {
   func a() -> String
   func b()
}

extension A where Self: B {
   // sourcery:begin: ignore
   func a() -> String { return "duplicated.method.a" }
   // sourcery:end
}
```