### PR TITLE
Added ability to skip mocking of methods and variables

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -103,11 +103,11 @@ import AppKit
 
 {% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
 class {{ type.name }}Mock: {{ type.name }} {
-{% for variable in type.allVariables|!definedInExtension %}
+{% for variable in type.allVariables|!definedInExtension|!annotated:"skipMock" %}
     {% if variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
 {% endfor %}
 
-{% for method in type.allMethods|!definedInExtension %}
+{% for method in type.allMethods|!definedInExtension|!annotated:"skipMock" %}
     {% call mockMethod method %}
 {% endfor %}
 }


### PR DESCRIPTION
Added ability to skip mocking of methods and variables which can be helpful when extensions call existing methods.

Example:
```
protocol Dispatcher: AutoMockable {
    func dispatch(action: ActionType)
}

extension Dispatcher {
    //sourcery:skipMock
    func dispatch(actions: [ActionType]) {
        actions.forEach(dispatch)
    }
}
```

Since `dispatch(actions)` calls `dispatch(action)` we don't want to mock the former method, we want to test that it instead calls the latter method multiple times instead.

i.e.:
```
final class DispatcherSpec: QuickSpec {
    override func spec() {
        describe("Dispatcher") {
            var sut: DispatcherMock!
            
            beforeEach {
                sut = DispatcherMock()
            }
            
            context("dispatches") {
                it("single action") {
                    sut.dispatch(ActionTypeMock())
                    expect(sut.dispatchCalled).to(beTrue())
                    expect(sut.dispatchCallsCount).to(equal(1))
                }
                
                it("multiple actions") {
                    sut.dispatch([ActionTypeMock(), ActionTypeMock()])
                    expect(sut.dispatchCalled).to(beTrue())
                    expect(sut.dispatchCallsCount).to(equal(2))
                }
            }
        }
    }
}
```