### PR TITLE
Fixed parsing protocol methods return type

### DIFF
--- a/SourceryTests/Parsing/FileParser + MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser + MethodsSpec.swift
@@ -20,7 +20,7 @@ class FileParserMethodsSpec: QuickSpec {
                 }
 
                 it("extracts methods properly") {
-                    let methods = parse("class Foo { init() throws; func bar(some: Int) throws ->Bar {}; func foo() ->  \n  Foo {}; func fooBar() rethrows {}; func fooVoid(){}; func fooInOut(some: Int, anotherSome: inout String)\n{} deinit {} }")[0].methods
+                    let methods = parse("class Foo { init() throws {}; func bar(some: Int) throws ->Bar {}; func foo() ->  \n  Foo {}; func fooBar() rethrows {}; func fooVoid(){}; func fooInOut(some: Int, anotherSome: inout String)\n{} deinit {} }")[0].methods
 
                     expect(methods[0]).to(equal(Method(name: "init()", selectorName: "init", parameters: [], returnTypeName: TypeName("Foo"), throws: true, definedInTypeName: TypeName("Foo"))))
                     expect(methods[1]).to(equal(Method(name: "bar(some: Int)", selectorName: "bar(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName("Int"))], returnTypeName: TypeName("Bar"), throws: true, definedInTypeName: TypeName("Foo"))))
@@ -216,12 +216,29 @@ class FileParserMethodsSpec: QuickSpec {
                     }
 
                     it("extracts class method properly") {
-                        let types = parse("class Foo { func foo<T: Equatable>() -> Bar?\n where \nT: Equatable { }; func fooBar<T>(bar: T) where T: Equatable { } }; class Bar {}")
+                        let types = parse("""
+                        class Foo {
+                            func foo<T: Equatable>() -> Bar?\n where \nT: Equatable {
+                            };  /// Asks a Duck to quack
+                                ///
+                                /// - Parameter times: How many times the Duck will quack
+                            func fooBar<T>(bar: T) where T: Equatable { }
+                        };
+                        class Bar {}
+                        """)
                         assertMethods(types)
                     }
 
                     it("extracts protocol method properly") {
-                        let types = parse("protocol Foo { func foo<T: Equatable>() -> Bar?\n where \nT: Equatable ; func fooBar<T>(bar: T) where T: Equatable }; class Bar {}")
+                        let types = parse("""
+                        protocol Foo {
+                            func foo<T: Equatable>() -> Bar?\n where \nT: Equatable  /// Asks a Duck to quack
+                                ///
+                                /// - Parameter times: How many times the Duck will quack
+                            func fooBar<T>(bar: T) where T: Equatable
+                        };
+                        class Bar {}
+                        """)
                         assertMethods(types)
                     }
                 }

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -12,6 +12,9 @@ protocol AutoMockable {}
 
 protocol BasicProtocol: AutoMockable {
     func loadConfiguration() -> String?
+    /// Asks a Duck to quack
+    ///
+    /// - Parameter times: How many times the Duck will quack
     func save(configuration: String)
 }
 

--- a/Templates/Tests/Generated/AutoCases.generated.swift
+++ b/Templates/Tests/Generated/AutoCases.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoLenses.generated.swift
+++ b/Templates/Tests/Generated/AutoLenses.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable variable_name

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length

--- a/Templates/Tests/Generated/LinuxMain.generated.swift
+++ b/Templates/Tests/Generated/LinuxMain.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest


### PR DESCRIPTION
Resolves #578 
I didn't check yet but I hope Swift 4.1 works better with protocol methods. For Swift 4 it just drops suffixes sometimes and we have to jump through the hoops to get the real return type.