### PR TITLE
fixed dropFirst/dropLast for swift 4.1, added test for "@NSManaged"

### DIFF
--- a/SourceryRuntime/Sources/Extensions.swift
+++ b/SourceryRuntime/Sources/Extensions.swift
@@ -46,15 +46,17 @@ public extension String {
         return String(self.prefix(self.count - suffix.count))
     }
 
-    /// :nodoc:
-    func dropFirst(_ n: Int = 1) -> String {
-        return String(self.dropFirst(n))
-    }
+	/// :nodoc:
+	func dropFirst(_ n: Int = 1) -> String {
+		let substring: Substring = self.dropFirst(n)
+		return String(substring)
+	}
 
-    /// :nodoc:
-    func dropLast(_ n: Int = 1) -> String {
-        return String(self.dropLast(n))
-    }
+	/// :nodoc:
+	func dropLast(_ n: Int = 1) -> String {
+		let substring: Substring = self.dropLast(n)
+		return String(substring)
+	}
 
     /// :nodoc:
     func dropFirstAndLast(_ n: Int = 1) -> String {

--- a/SourceryTests/Parsing/FileParser + AttributesSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AttributesSpec.swift
@@ -101,6 +101,10 @@ class FileParserAttributesSpec: QuickSpec {
                     "objc": Attribute(name: "objc", arguments: ["name": "objcName:" as NSString], description: "@objc(objcName:)")
                     ]))
 
+				expect(parse("class Foo { @NSManaged var name: String }").first?.variables.first?.attributes).to(equal([
+					"NSManaged": Attribute(name: "NSManaged")
+					]))
+
                 expect(parse("struct Foo { mutating var some: Int }").first?.variables.first?.attributes).to(equal([
                     "mutating": Attribute(name: "mutating", description: "mutating")
                     ]))


### PR DESCRIPTION
PR with failing test for "@NSManaged" also to run sourcery on swift 4.1 dropFirst/dropLast must have been altered.