### PR TITLE
Revert: fix: use process environment when running commands (#495)

### DIFF
--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -273,7 +273,7 @@ private extension String {
 }
 
 private extension Process {
-    static func runCommand(path: String, arguments: [String], environment: [String: String] = ProcessInfo.processInfo.environment) throws -> ProcessResult {
+    static func runCommand(path: String, arguments: [String], environment: [String: String] = [:]) throws -> ProcessResult {
         let task = Process()
         task.launchPath = path
         task.arguments = arguments


### PR DESCRIPTION
Resolves #584 
This change seems to break swift templates. @krzysztofzablocki do you remember what was the reason why you changed that (#495)