### PR TITLE
Fix for AutoMockable template to handle methods optional return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,10 @@
 
 ## Master
 
-### New Features
-
-- Improve AutoMockable template to handle methods with optional return values
-
 ### Bug fixes
 
 - Autocases template not respecting type access level
+- Improve AutoMockable template to handle methods with optional return values
 
 ## 0.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Master
 
+### New Features
+
+- Improve AutoMockable template to handle methods with optional return values
+
 ### Bug fixes
 
 - Autocases template not respecting type access level

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -56,7 +56,7 @@ import AppKit
     var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?
     {% endif %}{% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
-    var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ method.returnTypeName }}!
+    var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ method.returnTypeName }}{% if not method.isOptionalReturnType %}!{% endif %}
     {% endif %}
     {% call methodClosureDeclaration method %}
 

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -32,7 +32,7 @@ class BasicProtocolMock: BasicProtocol {
     var loadConfigurationCalled: Bool {
         return loadConfigurationCallsCount > 0
     }
-    var loadConfigurationReturnValue: String?!
+    var loadConfigurationReturnValue: String?
     var loadConfigurationClosure: (() -> String?)?
 
     func loadConfiguration() -> String? {

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -49,7 +49,7 @@ class BasicProtocolMock: BasicProtocol {
     var loadConfigurationCalled: Bool {
         return loadConfigurationCallsCount > 0
     }
-    var loadConfigurationReturnValue: String?!
+    var loadConfigurationReturnValue: String?
     var loadConfigurationClosure: (() -> String?)?
 
     func loadConfiguration() -> String? {


### PR DESCRIPTION
This address issue: #594 

Template updated to add force unwrap for non-optional return values only.