### PR TITLE
Cache base path configurable via yaml file

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,3 +1,4 @@
 ---
 BUNDLE_DISABLE_SHARED_GEMS: "true"
+BUNDLE_PATH: "Vendor/bundle"
 BUNDLE_WITHOUT: "test:development"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features
 
 - Added support for enums in AutoCodable template
+- You can now specify the base path for the Sourcery cache directory with a `cacheBasePath` key in the yaml
 
 ## 0.13.0
 

--- a/Sourcery/Configuration.swift
+++ b/Sourcery/Configuration.swift
@@ -179,6 +179,7 @@ struct Configuration {
         case invalidSources(message: String)
         case invalidTemplates(message: String)
         case invalidOutput(message: String)
+        case invalidCacheBasePath(message: String)
         case invalidPaths(message: String)
 
         var description: String {
@@ -191,6 +192,8 @@ struct Configuration {
                 return "Invalid templates. \(message)"
             case .invalidOutput(let message):
                 return "Invalid output. \(message)"
+            case .invalidCacheBasePath(let message):
+                return "Invalid cacheBasePath. \(message)"
             case .invalidPaths(let message):
                 return "\(message)"
             }
@@ -200,6 +203,7 @@ struct Configuration {
     let source: Source
     let templates: Paths
     let output: Output
+    let cacheBasePath: Path
     let forceParse: [String]
     let args: [String: NSObject]
 
@@ -242,13 +246,22 @@ struct Configuration {
             throw Configuration.Error.invalidOutput(message: "'output' key is missing or is not a string or object.")
         }
 
+        if let cacheBasePath = dict["cacheBasePath"] as? String {
+            self.cacheBasePath = Path(cacheBasePath, relativeTo: relativePath)
+        } else if dict["cacheBasePath"] != nil {
+            throw Configuration.Error.invalidCacheBasePath(message: "'cacheBasePath' key is not a string.")
+        } else {
+            self.cacheBasePath = Path.defaultBaseCachePath
+        }
+
         self.args = dict["args"] as? [String: NSObject] ?? [:]
     }
 
-    init(sources: Paths, templates: Paths, output: Path, forceParse: [String], args: [String: NSObject]) {
+    init(sources: Paths, templates: Paths, output: Path, cacheBasePath: Path, forceParse: [String], args: [String: NSObject]) {
         self.source = .sources(sources)
         self.templates = templates
         self.output = Output(output, linkTo: nil)
+        self.cacheBasePath = cacheBasePath
         self.forceParse = forceParse
         self.args = args
     }

--- a/Sourcery/Utils/Path+Extensions.swift
+++ b/Sourcery/Utils/Path+Extensions.swift
@@ -20,9 +20,19 @@ extension Path {
         return Path(tempDirURL.path)
     }
 
-    static func cachesDir(sourcePath: Path, createIfMissing: Bool = true) -> Path {
-        var paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true) as [String]
-        let path = Path(paths[0]) + "Sourcery" + sourcePath.lastComponent
+    /// - returns: The `.cachesDirectory` search path in the user domain, as a `Path`.
+    static var defaultBaseCachePath: Path {
+        let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true) as [String]
+        let path = paths[0]
+        return Path(path)
+    }
+
+    /// - parameter _basePath: The value of the `--cachePath` command line parameter, if any.
+    /// - note: This function does not consider the `--disableCache` command line parameter.
+    ///         It is considered programmer error to call this function when `--disableCache` is specified.
+    static func cachesDir(sourcePath: Path, basePath _basePath: Path?, createIfMissing: Bool = true) -> Path {
+        let basePath = _basePath ?? defaultBaseCachePath
+        let path = basePath + "Sourcery" + sourcePath.lastComponent
         if !path.exists && createIfMissing {
             // swiftlint:disable:next force_try
             try! FileManager.default.createDirectory(at: path.url, withIntermediateDirectories: true, attributes: nil)

--- a/Sourcery/main.swift
+++ b/Sourcery/main.swift
@@ -118,6 +118,7 @@ func runCLI() {
                 configuration = Configuration(sources: Paths(include: sources, exclude: excludeSources) ,
                                               templates: Paths(include: templates, exclude: excludeTemplates),
                                               output: output.string.isEmpty ? "." : output,
+                                              cacheBasePath: Path.defaultBaseCachePath,
                                               forceParse: forceParse,
                                               args: arguments)
             } else {
@@ -157,6 +158,7 @@ func runCLI() {
             let sourcery = Sourcery(verbose: verboseLogging,
                                     watcherEnabled: watcherEnabled,
                                     cacheDisabled: disableCache,
+                                    cacheBasePath: configuration.cacheBasePath,
                                     prune: prune,
                                     arguments: configuration.args)
             if let keepAlive = try sourcery.processFiles(

--- a/SourceryTests/ConfigurationSpec.swift
+++ b/SourceryTests/ConfigurationSpec.swift
@@ -109,6 +109,11 @@ class ConfigurationSpec: QuickSpec {
                     expect(configError(config)).to(equal("Invalid output. 'output' key is missing or is not a string or object."))
                 }
 
+                it("throws error on invalid cacheBasePath format") {
+                    let config: [String: Any] = ["sources": ["."], "templates": ["."], "output": ".", "cacheBasePath": ["."]]
+                    expect(configError(config)).to(equal("Invalid cacheBasePath. 'cacheBasePath' key is not a string."))
+                }
+
             }
 
         }
@@ -159,6 +164,17 @@ class ConfigurationSpec: QuickSpec {
                     let templates = try? Configuration(dict: config, relativePath: relativePath).templates
                     let expected = Paths(include: [relativePath], exclude: [relativePath + "excludedPath"])
                     expect(templates).to(equal(expected))
+                }
+            }
+        }
+
+        describe("Cache Base Path") {
+            context("provided with cacheBasePath") {
+                it("has the correct cacheBasePath") {
+                    let config: [String: Any] = ["sources": ["."], "templates": ["."], "output": ".", "cacheBasePath": "test-base-path"]
+                    let cacheBasePath = try? Configuration(dict: config, relativePath: relativePath).cacheBasePath
+                    let expected = Path("test-base-path", relativeTo: relativePath)
+                    expect(cacheBasePath).to(equal(expected))
                 }
             }
         }

--- a/Templates/Tests/Generated/AutoCases.generated.swift
+++ b/Templates/Tests/Generated/AutoCases.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.12.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoCodable.generated.swift
+++ b/Templates/Tests/Generated/AutoCodable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.12.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.12.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.12.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoLenses.generated.swift
+++ b/Templates/Tests/Generated/AutoLenses.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.12.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable variable_name

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.12.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length

--- a/Templates/Tests/Generated/LinuxMain.generated.swift
+++ b/Templates/Tests/Generated/LinuxMain.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.12.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest


### PR DESCRIPTION
I have added support for a `cacheBasePath` key to the yaml file. This path will be used in place of `~/Library/Caches` (which is still computed using `NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)`) when computing the `cachesPath` for the `loadOrParse` function.

I have extracted the logic for calculating the default so that the default value can be placed in the `Configuration` when there is no yaml file.