### PR TITLE
Fixed AutoEquatable access level for == func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ---
 
+## Master
+
+### Bug fixes
+
+- Fixed AutoEquatable access level for `==` func
+
 ## 0.13.1
 
 ### New Features

--- a/Templates/Templates/AutoEquatable.stencil
+++ b/Templates/Templates/AutoEquatable.stencil
@@ -29,7 +29,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 // MARK: - {{ type.name }} AutoEquatable
 {% if not type.kind == "protocol" and not type.based.NSObject %}extension {{ type.name }}: Equatable {}{% endif %}
 {% if type.supertype.based.Equatable or type.supertype.implements.AutoEquatable %}THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable{% endif %}
-{{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
+public func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
     {% if not type.kind == "protocol" %}
     {% call compareVariables type.storedVariables %}
     {% else %}
@@ -43,7 +43,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 {% for type in types.implementing.AutoEquatable|enum %}
 // MARK: - {{ type.name }} AutoEquatable
 extension {{ type.name }}: Equatable {}
-{{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
+public func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
     switch (lhs, rhs) {
     {% for case in type.cases %}
     {% if case.hasAssociatedValue %}case (.{{ case.name }}(let lhs), .{{ case.name }}(let rhs)):{% else %}case (.{{ case.name }}, .{{ case.name }}):{% endif %}

--- a/Templates/Tests/Expected/AutoEquatable.expected
+++ b/Templates/Tests/Expected/AutoEquatable.expected
@@ -23,7 +23,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 // MARK: - AutoEquatable for classes, protocols, structs
 // MARK: - AutoEquatableClass AutoEquatable
 extension AutoEquatableClass: Equatable {}
-internal func == (lhs: AutoEquatableClass, rhs: AutoEquatableClass) -> Bool {
+public func == (lhs: AutoEquatableClass, rhs: AutoEquatableClass) -> Bool {
     guard lhs.firstName == rhs.firstName else { return false }
     guard lhs.lastName == rhs.lastName else { return false }
     guard compareArrays(lhs: lhs.parents, rhs: rhs.parents, compare: ==) else { return false }
@@ -35,17 +35,17 @@ internal func == (lhs: AutoEquatableClass, rhs: AutoEquatableClass) -> Bool {
 // MARK: - AutoEquatableClassInherited AutoEquatable
 extension AutoEquatableClassInherited: Equatable {}
 THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable
-internal func == (lhs: AutoEquatableClassInherited, rhs: AutoEquatableClassInherited) -> Bool {
+public func == (lhs: AutoEquatableClassInherited, rhs: AutoEquatableClassInherited) -> Bool {
     guard compareOptionals(lhs: lhs.middleName, rhs: rhs.middleName, compare: ==) else { return false }
     return true
 }
 // MARK: - AutoEquatableNSObject AutoEquatable
-internal func == (lhs: AutoEquatableNSObject, rhs: AutoEquatableNSObject) -> Bool {
+public func == (lhs: AutoEquatableNSObject, rhs: AutoEquatableNSObject) -> Bool {
     guard lhs.firstName == rhs.firstName else { return false }
     return true
 }
 // MARK: - AutoEquatableProtocol AutoEquatable
-internal func == (lhs: AutoEquatableProtocol, rhs: AutoEquatableProtocol) -> Bool {
+public func == (lhs: AutoEquatableProtocol, rhs: AutoEquatableProtocol) -> Bool {
     guard lhs.width == rhs.width else { return false }
     guard lhs.height == rhs.height else { return false }
     guard lhs.name == rhs.name else { return false }
@@ -53,7 +53,7 @@ internal func == (lhs: AutoEquatableProtocol, rhs: AutoEquatableProtocol) -> Boo
 }
 // MARK: - AutoEquatableStruct AutoEquatable
 extension AutoEquatableStruct: Equatable {}
-internal func == (lhs: AutoEquatableStruct, rhs: AutoEquatableStruct) -> Bool {
+public func == (lhs: AutoEquatableStruct, rhs: AutoEquatableStruct) -> Bool {
     guard lhs.firstName == rhs.firstName else { return false }
     guard lhs.lastName == rhs.lastName else { return false }
     guard compareArrays(lhs: lhs.parents, rhs: rhs.parents, compare: ==) else { return false }
@@ -66,7 +66,7 @@ internal func == (lhs: AutoEquatableStruct, rhs: AutoEquatableStruct) -> Bool {
 // MARK: - AutoEquatable for Enums
 // MARK: - AutoEquatableEnum AutoEquatable
 extension AutoEquatableEnum: Equatable {}
-internal func == (lhs: AutoEquatableEnum, rhs: AutoEquatableEnum) -> Bool {
+public func == (lhs: AutoEquatableEnum, rhs: AutoEquatableEnum) -> Bool {
     switch (lhs, rhs) {
     case (.one, .one):
         return true
@@ -81,7 +81,7 @@ internal func == (lhs: AutoEquatableEnum, rhs: AutoEquatableEnum) -> Bool {
 }
 // MARK: - AutoEquatableEnumWithOneCase AutoEquatable
 extension AutoEquatableEnumWithOneCase: Equatable {}
-internal func == (lhs: AutoEquatableEnumWithOneCase, rhs: AutoEquatableEnumWithOneCase) -> Bool {
+public func == (lhs: AutoEquatableEnumWithOneCase, rhs: AutoEquatableEnumWithOneCase) -> Bool {
     switch (lhs, rhs) {
     case (.one, .one):
         return true

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -26,7 +26,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 // MARK: - AutoEquatable for classes, protocols, structs
 // MARK: - AutoEquatableClass AutoEquatable
 extension AutoEquatableClass: Equatable {}
-internal func == (lhs: AutoEquatableClass, rhs: AutoEquatableClass) -> Bool {
+public func == (lhs: AutoEquatableClass, rhs: AutoEquatableClass) -> Bool {
     guard lhs.firstName == rhs.firstName else { return false }
     guard lhs.lastName == rhs.lastName else { return false }
     guard compareArrays(lhs: lhs.parents, rhs: rhs.parents, compare: ==) else { return false }
@@ -38,17 +38,17 @@ internal func == (lhs: AutoEquatableClass, rhs: AutoEquatableClass) -> Bool {
 // MARK: - AutoEquatableClassInherited AutoEquatable
 extension AutoEquatableClassInherited: Equatable {}
 THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable
-internal func == (lhs: AutoEquatableClassInherited, rhs: AutoEquatableClassInherited) -> Bool {
+public func == (lhs: AutoEquatableClassInherited, rhs: AutoEquatableClassInherited) -> Bool {
     guard compareOptionals(lhs: lhs.middleName, rhs: rhs.middleName, compare: ==) else { return false }
     return true
 }
 // MARK: - AutoEquatableNSObject AutoEquatable
-internal func == (lhs: AutoEquatableNSObject, rhs: AutoEquatableNSObject) -> Bool {
+public func == (lhs: AutoEquatableNSObject, rhs: AutoEquatableNSObject) -> Bool {
     guard lhs.firstName == rhs.firstName else { return false }
     return true
 }
 // MARK: - AutoEquatableProtocol AutoEquatable
-internal func == (lhs: AutoEquatableProtocol, rhs: AutoEquatableProtocol) -> Bool {
+public func == (lhs: AutoEquatableProtocol, rhs: AutoEquatableProtocol) -> Bool {
     guard lhs.width == rhs.width else { return false }
     guard lhs.height == rhs.height else { return false }
     guard lhs.name == rhs.name else { return false }
@@ -56,7 +56,7 @@ internal func == (lhs: AutoEquatableProtocol, rhs: AutoEquatableProtocol) -> Boo
 }
 // MARK: - AutoEquatableStruct AutoEquatable
 extension AutoEquatableStruct: Equatable {}
-internal func == (lhs: AutoEquatableStruct, rhs: AutoEquatableStruct) -> Bool {
+public func == (lhs: AutoEquatableStruct, rhs: AutoEquatableStruct) -> Bool {
     guard lhs.firstName == rhs.firstName else { return false }
     guard lhs.lastName == rhs.lastName else { return false }
     guard compareArrays(lhs: lhs.parents, rhs: rhs.parents, compare: ==) else { return false }
@@ -69,7 +69,7 @@ internal func == (lhs: AutoEquatableStruct, rhs: AutoEquatableStruct) -> Bool {
 // MARK: - AutoEquatable for Enums
 // MARK: - AutoEquatableEnum AutoEquatable
 extension AutoEquatableEnum: Equatable {}
-internal func == (lhs: AutoEquatableEnum, rhs: AutoEquatableEnum) -> Bool {
+public func == (lhs: AutoEquatableEnum, rhs: AutoEquatableEnum) -> Bool {
     switch (lhs, rhs) {
     case (.one, .one):
         return true
@@ -84,7 +84,7 @@ internal func == (lhs: AutoEquatableEnum, rhs: AutoEquatableEnum) -> Bool {
 }
 // MARK: - AutoEquatableEnumWithOneCase AutoEquatable
 extension AutoEquatableEnumWithOneCase: Equatable {}
-internal func == (lhs: AutoEquatableEnumWithOneCase, rhs: AutoEquatableEnumWithOneCase) -> Bool {
+public func == (lhs: AutoEquatableEnumWithOneCase, rhs: AutoEquatableEnumWithOneCase) -> Bool {
     switch (lhs, rhs) {
     case (.one, .one):
         return true


### PR DESCRIPTION
AutoEquatable is currently generating == func's with the different access levels from public (`type.accessLevel`) which doesn't match the requirement of Equatable protocol:
```
public static func == (lhs: Self, rhs: Self) -> Bool
```
and is generating building errors:
```
Method '==' must be declared public because it matches a requirement in public protocol 'Equatable'
```
This PR replace this `type.accessLevel` with `public`.