### PR TITLE
update Package.resolved

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -83,15 +83,6 @@
         }
       },
       {
-        "package": "SWXMLHash",
-        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-        "state": {
-          "branch": null,
-          "revision": "17d992beb3aaeda403fd35f8d5e70ab1a8124f35",
-          "version": "4.6.0"
-        }
-      },
-      {
         "package": "ShellOut",
         "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
         "state": {
@@ -155,12 +146,12 @@
         }
       },
       {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
-          "version": "0.7.0"
+          "revision": "17d992beb3aaeda403fd35f8d5e70ab1a8124f35",
+          "version": "4.6.0"
         }
       },
       {
@@ -170,6 +161,15 @@
           "branch": null,
           "revision": "eaddb983150f2eb1d308f4949b8e31d6cae4e7e9",
           "version": "4.2.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
+          "version": "0.7.0"
         }
       }
     ]


### PR DESCRIPTION
I'm no SwiftPM expert, but I wondered why on my machines the `Package.resolved` always says it's modified when I run `swift build` inside the project. The alphabetic ordering seems to have been off. 

(We use this as a binary tool dependency in a project.)