### PR TITLE
Fix extraction of inline annotations in comments like /** sourcery: skipDescription */

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed AutoEquatable access level for `==` func
 - Fixed path of generated files when linked to Xcode project
+- Fixed  extraction of inline annotations in comments like /** sourcery: skipDescription */
 
 ## 0.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed AutoEquatable access level for `==` func
 - Fixed path of generated files when linked to Xcode project
-- Fixed  extraction of inline annotations in comments like /** sourcery: skipDescription */
+- Fixed extraction of inline annotations in multi line comments with documentation style
 
 ## 0.13.1
 

--- a/Sourcery/Parsing/Utils/AnnotationsParser.swift
+++ b/Sourcery/Parsing/Utils/AnnotationsParser.swift
@@ -182,7 +182,7 @@ internal struct AnnotationsParser {
     }
 
     private static func searchForAnnotations(commentLine: String) -> AnnotationType {
-        let comment = commentLine.trimmingPrefix("///").trimmingPrefix("//").trimmingPrefix("/*").stripped()
+        let comment = commentLine.trimmingPrefix("///").trimmingPrefix("//").trimmingPrefix("/**").trimmingPrefix("/*").stripped()
 
         guard comment.hasPrefix("sourcery:") else { return .annotations([:]) }
 

--- a/SourceryTests/Parsing/AnnotationsParserSpec.swift
+++ b/SourceryTests/Parsing/AnnotationsParserSpec.swift
@@ -42,10 +42,11 @@ class AnnotationsParserSpec: QuickSpec {
                 }
 
                 it("extracts inline annotations") {
-                    let result = parse("//sourcery: skipDescription\n/* sourcery: skipEquality */var name: Int { return 2 }")
+                    let result = parse("//sourcery: skipDescription\n/* sourcery: skipEquality */\n/** sourcery: skipCoding */var name: Int { return 2 }")
                     expect(result).to(equal([
                         "skipDescription": NSNumber(value: true),
-                        "skipEquality": NSNumber(value: true)
+                        "skipEquality": NSNumber(value: true),
+                        "skipCoding": NSNumber(value: true)
                         ]))
                 }
 


### PR DESCRIPTION
Hi, I have a project that was using an old version of Sourcery, 0.10.1.

In that version, Sourcery was able to extract annotations from comments with the following format:
```
/** sourcery: skipDescription */
```

Today I updated Sourcery and it started failing parsing this type of comments.

So I fixed and added a test case to it.

EDIT:Supporting this type of comment is important to me, because I use a tool that generates code with this kind of comments, that contains annotations for Sourcery.