### PR TITLE
Use AnyObject for class-only protocols

### DIFF
--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -8,7 +8,7 @@ import SourceKittenFramework
 import PathKit
 import SourceryRuntime
 
-protocol Parsable: class {
+protocol Parsable: AnyObject {
     var __parserData: Any? { get set }
 }
 

--- a/SourceryRuntime/Sources/Definition.swift
+++ b/SourceryRuntime/Sources/Definition.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Describes that the object is defined in a context of some `Type`
-public protocol Definition: class {
+public protocol Definition: AnyObject {
     /// Reference to type name where the object is defined, 
     /// nil if defined outside of any `enum`, `struct`, `class` etc
     var definedInTypeName: TypeName? { get }

--- a/SourceryTests/Stub/Performance-Code/Kiosk/Bid Fulfillment/FulfillmentNavigationController.swift
+++ b/SourceryTests/Stub/Performance-Code/Kiosk/Bid Fulfillment/FulfillmentNavigationController.swift
@@ -4,7 +4,7 @@ import RxSwift
 
 // We abstract this out so that we don't have network models, etc, aware of the view controller.
 // This is a "source of truth" that should be referenced in lieu of many independent variables. 
-protocol FulfillmentController: class {
+protocol FulfillmentController: AnyObject {
     var bidDetails: BidDetails { get set }
     var auctionID: String! { get set }
 }


### PR DESCRIPTION
Hi there!

I'm currently working a new SwiftLint [rule](https://github.com/realm/SwiftLint/issues/2283) which suggests using `AnyObject` instead of `class` for class-only protocols as documented by [Apple](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID281).

This PR fixes the violations raised by the new rule.