### PR TITLE
Make AutoEquatable template react to origin access level

### DIFF
--- a/Templates/Templates/AutoEquatable.stencil
+++ b/Templates/Templates/AutoEquatable.stencil
@@ -29,7 +29,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 // MARK: - {{ type.name }} AutoEquatable
 {% if not type.kind == "protocol" and not type.based.NSObject %}extension {{ type.name }}: Equatable {}{% endif %}
 {% if type.supertype.based.Equatable or type.supertype.implements.AutoEquatable or type.supertype|annotated:"AutoEquatable" %}THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable{% endif %}
-public func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
+{{type.accessLevel}} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
     {% if not type.kind == "protocol" %}
     {% call compareVariables type.storedVariables %}
     {% else %}
@@ -43,7 +43,7 @@ public func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
 {% for type in types.enums where type.implements.AutoEquatable or type|annotated:"AutoEquatable" %}
 // MARK: - {{ type.name }} AutoEquatable
 extension {{ type.name }}: Equatable {}
-public func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
+{{type.accessLevel}} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
     switch (lhs, rhs) {
     {% for case in type.cases %}
     {% if case.hasAssociatedValue %}case (.{{ case.name }}(let lhs), .{{ case.name }}(let rhs)):{% else %}case (.{{ case.name }}, .{{ case.name }}):{% endif %}


### PR DESCRIPTION
Making an internal class auto-equatable resulted in compile errors before, because the access level public was hard-coded to the template and access levels would not match.