### PR TITLE
Add support for including `.swift` files in Swift templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### New Features
 
+- You can now include entire Swift files in Swift templates
 - You can now use AutoEquatable with annotations
 - Content from multiple file annotations will now be concatenated instead of writing only the latest generated content.
 

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -52,6 +52,16 @@ class SwiftTemplateTests: QuickSpec {
                 expect(result).to(equal(expectedResult))
             }
 
+            it("handles file includes") {
+                let templatePath = Stubs.swiftTemplates + Path("IncludeFile.swifttemplate")
+                let expectedResult = try? (Stubs.resultDirectory + Path("Basic.swift")).read(.utf8)
+
+                expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output) }.toNot(throwError())
+
+                let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                expect(result).to(equal(expectedResult))
+            }
+
             it("handles includes without swifttemplate extension") {
                 let templatePath = Stubs.swiftTemplates + Path("IncludesNoExtension.swifttemplate")
                 let expectedResult = try? (Stubs.resultDirectory + Path("Basic+Other.swift")).read(.utf8)
@@ -62,8 +72,28 @@ class SwiftTemplateTests: QuickSpec {
                 expect(result).to(equal(expectedResult))
             }
 
+            it("handles file includes without swift extension") {
+                let templatePath = Stubs.swiftTemplates + Path("IncludeFileNoExtension.swifttemplate")
+                let expectedResult = try? (Stubs.resultDirectory + Path("Basic.swift")).read(.utf8)
+
+                expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output) }.toNot(throwError())
+
+                let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                expect(result).to(equal(expectedResult))
+            }
+
             it("handles includes from included files relatively") {
                 let templatePath = Stubs.swiftTemplates + Path("SubfolderIncludes.swifttemplate")
+                let expectedResult = try? (Stubs.resultDirectory + Path("Basic.swift")).read(.utf8)
+
+                expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output) }.toNot(throwError())
+
+                let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                expect(result).to(equal(expectedResult))
+            }
+
+            it("handles file includes from included files relatively") {
+                let templatePath = Stubs.swiftTemplates + Path("SubfolderFileIncludes.swifttemplate")
                 let expectedResult = try? (Stubs.resultDirectory + Path("Basic.swift")).read(.utf8)
 
                 expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output) }.toNot(throwError())

--- a/SourceryTests/Stub/SwiftTemplates/Equality.swift
+++ b/SourceryTests/Stub/SwiftTemplates/Equality.swift
@@ -1,0 +1,41 @@
+import SourceryRuntime
+
+enum EqualityGenerator {
+    static func generate(for types: Types) -> String {
+        return types.classes.map { $0.generateEquality() }.joined(separator: "\n")
+    }
+}
+
+extension Class {
+    func generateEquality() -> String {
+        let propertyComparisons = variables.map { $0.generateEquality() }.joined(separator: "\n    ")
+
+        return """
+        extension \(name): Equatable {}
+        \(hasAnnotations())
+        func == (lhs: \(name), rhs: \(name)) -> Bool {
+            \(propertyComparisons)
+        
+            return true
+        }
+        
+        """
+    }
+
+    func hasAnnotations() -> String {
+        guard annotations["showComment"] != nil else {
+            return ""
+        }
+        return """
+
+        // \(name) has Annotations
+        
+        """
+    }
+}
+
+extension Variable {
+    func generateEquality() -> String {
+        return "if lhs.\(name) != rhs.\(name) { return false }"
+    }
+}

--- a/SourceryTests/Stub/SwiftTemplates/IncludeFile.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/IncludeFile.swifttemplate
@@ -1,0 +1,1 @@
+<%- includeFile("Equality.swift") -%><%= EqualityGenerator.generate(for: types) %>

--- a/SourceryTests/Stub/SwiftTemplates/IncludeFileNoExtension.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/IncludeFileNoExtension.swifttemplate
@@ -1,0 +1,1 @@
+<%- includeFile("Equality") -%><%= EqualityGenerator.generate(for: types) %>

--- a/SourceryTests/Stub/SwiftTemplates/SubfolderFileIncludes.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/SubfolderFileIncludes.swifttemplate
@@ -1,0 +1,1 @@
+<%- includeFile("lib/Equality.swift") -%><%= EqualityGenerator.generate(for: types) %>

--- a/SourceryTests/Stub/SwiftTemplates/lib/Equality.swift
+++ b/SourceryTests/Stub/SwiftTemplates/lib/Equality.swift
@@ -1,0 +1,41 @@
+import SourceryRuntime
+
+enum EqualityGenerator {
+    static func generate(for types: Types) -> String {
+        return types.classes.map { $0.generateEquality() }.joined(separator: "\n")
+    }
+}
+
+extension Class {
+    func generateEquality() -> String {
+        let propertyComparisons = variables.map { $0.generateEquality() }.joined(separator: "\n    ")
+
+        return """
+        extension \(name): Equatable {}
+        \(hasAnnotations())
+        func == (lhs: \(name), rhs: \(name)) -> Bool {
+            \(propertyComparisons)
+
+            return true
+        }
+
+        """
+    }
+
+    func hasAnnotations() -> String {
+        guard annotations["showComment"] != nil else {
+            return ""
+        }
+        return """
+
+        // \(name) has Annotations
+
+        """
+    }
+}
+
+extension Variable {
+    func generateEquality() -> String {
+        return "if lhs.\(name) != rhs.\(name) { return false }"
+    }
+}


### PR DESCRIPTION
There are a number of Swift language features that are not currently supported by Swift templates.  Most notable are extensions and protocols which are not available because Swift template code does not currently live at the top level scope of the Swift file that is compiled.  The use of files and `private`  `fileprivate` access control to structure the code in larger templates is also not available.  Lifting these restrictions will significantly improve support for writing sophisticated templates using the full power of Swift.

This PR adds support for the full scope of Swift language features by allowing Swift templates to include entire `.swift` files.  The paths to these files are passed to the compiler along with the path to `main.swift`.  Usage is very simple:

In the `.swifttemplate` file:
```
<%- includeFile("Template.swift") -%><%= Generator.generate(for: types) %>
```

In `Template.swift`:
```swift
import SourceryRuntime

enum Generator {
    static func generate(for types: Types) -> String {
        // ...
    }
}

private extension Typed {
    // ...
}
```

Note: this PR overlaps significantly with the changes proposed by https://github.com/krzysztofzablocki/Sourcery/pull/663.