### PR TITLE
Fix a compile error when use 'AutoHashable'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ line two
 - Fixed AutoEquatable access level for `==` func
 - Fixed path of generated files when linked to Xcode project
 - Fixed extraction of inline annotations in multi line comments with documentation style
+- Fixed compile error when used AutoHashable in NSObject subclass.
 
 ## 0.13.1
 

--- a/Templates/Templates/AutoHashable.stencil
+++ b/Templates/Templates/AutoHashable.stencil
@@ -126,7 +126,7 @@ fileprivate func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?)
 // MARK: - {{ type.name }} AutoHashable
 extension {{ type.name }}{% if not type.kind == "protocol" and not type.based.NSObject %}: Hashable{% endif %} {
     {% if type.supertype.based.Hashable or type.supertype.implements.AutoHashable %}THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable{% endif %}
-    {{ type.accessLevel }} var hashValue: Int {
+    {{ type.accessLevel }}{% if type.based.NSObject %} override{% endif %} var hashValue: Int {
         {% if not type.kind == "protocol" %}
         {% call letCombineVariableHashes type.storedVariables %}
         {% else %}

--- a/Templates/Tests/Expected/AutoHashable.expected
+++ b/Templates/Tests/Expected/AutoHashable.expected
@@ -85,7 +85,7 @@ extension AutoHashableClassInherited: Hashable {
 }
 // MARK: - AutoHashableNSObject AutoHashable
 extension AutoHashableNSObject {
-    internal var hashValue: Int {
+    internal override var hashValue: Int {
         let firstNameHashValue = firstName.hashValue
 
         return combineHashes([


### PR DESCRIPTION
Fix compile error: "Overriding declaration requires an 'override' keyword", when used "AutoHashable" in NSObject subclass.