### PR TITLE
fix: get rid of (:_) for enum cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ line two
 
 ### Bug fixes
 
+- Fixed parsing associated enum cases in Xcode 10 
 - Fixed AutoEquatable access level for `==` func
 - Fixed path of generated files when linked to Xcode project
 - Fixed extraction of inline annotations in multi line comments with documentation style

--- a/Sourcery/Parsing/FileParser.swift
+++ b/Sourcery/Parsing/FileParser.swift
@@ -288,6 +288,11 @@ extension FileParser {
     fileprivate func parseTypeRequirements(_ dict: [String: SourceKitRepresentable]) -> (name: String, kind: SwiftDeclarationKind, accessibility: AccessLevel)? {
         guard let kind = (dict[SwiftDocKey.kind.rawValue] as? String).flatMap({ SwiftDeclarationKind(rawValue: $0) }),
               var name = dict[SwiftDocKey.name.rawValue] as? String else { return nil }
+
+        if case .enumelement = kind, let colon = name.index(of: "(") {
+            name = String(name[..<colon])
+        }
+
         if extract(.name, from: dict)?.hasPrefix("`") == true {
             name = "`\(name)`"
         }


### PR DESCRIPTION
Can a fix for #639 be that simple? 