### PR TITLE
Fix the creation of a symbolic link to bin/sourcery

### DIFF
--- a/bin/sourcery
+++ b/bin/sourcery
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # This file serves just as a link
 
-parent_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null && pwd )"
 
-"${parent_path}"/Sourcery.app/Contents/MacOS/Sourcery "$@"
+"${DIR}"/Sourcery.app/Contents/MacOS/Sourcery "$@"


### PR DESCRIPTION
**Problem**
Creating a symbolic link to `bin/sourcery` fails to execute as it will resolve the path to Sourcery.app using the path of the link instead of the path of the script file.

**Example**
1. download the latest binary release of Sourcery and unzip it (e.g. `~/Downloads/Sourcery/`)
2. go elsewhere on you drive (e.g. `cd ~`)
3. create a symbolic link using `ln` (e.g. `ln -s Downloads/Sourcery/bin/sourcery sourcery`)
4. running `./sourcery` fails with a `No such file or directory` error on `Sourcery.app`

**Solution**
This fixes the path resolution using the code from this [gist](https://gist.github.com/TheMengzor/968e5ea87e99d9c41782).
It will resolve the links until it finds the real path of the `bin/sourcery` file.