### PR TITLE
Codable enums improvement

### DIFF
--- a/Templates/CodableContextTests/CodableContextTests.swift
+++ b/Templates/CodableContextTests/CodableContextTests.swift
@@ -35,6 +35,22 @@ class CodableContextTests: QuickSpec {
                     expect(decoded).to(equal(value))
                 }
 
+                it("can't use value with unnamed associated values") {
+                    let value = AssociatedValuesEnum.unnamedCase(0, "a")
+                    let encoded = "{\"type\" : \"unnamedCase\"}".data(using: .utf8)!
+
+                    expect { try encoder.encode(value) }.to(throwError())
+                    expect { try decoder.decode(AssociatedValuesEnum.self, from: encoded) }.to(throwError())
+                }
+
+                it("can't use value with mixed associated values") {
+                    let value = AssociatedValuesEnum.mixCase(0, name: "a")
+                    let encoded = "{\"type\" : \"mixCase\"}".data(using: .utf8)!
+
+                    expect { try encoder.encode(value) }.to(throwError())
+                    expect { try decoder.decode(AssociatedValuesEnum.self, from: encoded) }.to(throwError())
+                }
+
                 it("codes value without associated values") {
                     let value = AssociatedValuesEnum.anotherCase
 
@@ -87,6 +103,14 @@ class CodableContextTests: QuickSpec {
 
                     let decoded = try! decoder.decode(AssociatedValuesEnumNoCaseKey.self, from: encoded)
                     expect(decoded).to(equal(value))
+                }
+
+                it("can't use value with mixed associated values") {
+                    let value = AssociatedValuesEnumNoCaseKey.mixCase(0, name: "a")
+                    let encoded = "{\"type\" : \"mixCase\"}".data(using: .utf8)!
+
+                    expect { try encoder.encode(value) }.to(throwError())
+                    expect { try decoder.decode(AssociatedValuesEnumNoCaseKey.self, from: encoded) }.to(throwError())
                 }
 
                 it("codes value without assoicated values") {

--- a/Templates/CodableContextTests/CodableContextTests.swift
+++ b/Templates/CodableContextTests/CodableContextTests.swift
@@ -71,6 +71,24 @@ class CodableContextTests: QuickSpec {
                     expect(decoded).to(equal(value))
                 }
 
+                it("codes value with unnamed associated values") {
+                    let value = AssociatedValuesEnumNoCaseKey.unnamedCase(0, "a")
+
+                    let encoded = try! encoder.encode(value)
+                    expect(String(data: encoded, encoding: .utf8)).to(equal("""
+                    {
+                      "unnamedCase" : [
+                        0,
+                        "a"
+                      ]
+                    }
+                    """
+                    ))
+
+                    let decoded = try! decoder.decode(AssociatedValuesEnumNoCaseKey.self, from: encoded)
+                    expect(decoded).to(equal(value))
+                }
+
                 it("codes value without assoicated values") {
                     let value = AssociatedValuesEnumNoCaseKey.anotherCase
 

--- a/Templates/Templates.xcodeproj/project.pbxproj
+++ b/Templates/Templates.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		328D9E935602E7E23C76D3C3 /* Pods_CodableContextTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 433370DB5CFA428C5E58DD79 /* Pods_CodableContextTests.framework */; };
 		636D78572081781E00160CC4 /* AutoCodable.swifttemplate in Resources */ = {isa = PBXBuildFile; fileRef = 636D78472080251800160CC4 /* AutoCodable.swifttemplate */; };
-		636D786D2083B91A00160CC4 /* AutoCodable.expected in Resources */ = {isa = PBXBuildFile; fileRef = 636D786B2083B8D700160CC4 /* AutoCodable.expected */; };
 		63A4F4D120964FB3000F8CDF /* CodableContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A4F4CF20964FB3000F8CDF /* CodableContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63A4F4D520964FBE000F8CDF /* AutoCodable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636D784C208169E100160CC4 /* AutoCodable.generated.swift */; };
 		63A4F4D620964FC5000F8CDF /* AutoCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636D78492080256500160CC4 /* AutoCodable.swift */; };
@@ -42,6 +41,7 @@
 		6D6645CB1ECC22A3004C1948 /* LinuxMain.generated.swift in Resources */ = {isa = PBXBuildFile; fileRef = 6D342C9B1EBA3156006EEBEC /* LinuxMain.generated.swift */; };
 		6D6C19261FC4CE7900CD2A34 /* Decorator.swifttemplate in Resources */ = {isa = PBXBuildFile; fileRef = 6D6C19251FC4CE7900CD2A34 /* Decorator.swifttemplate */; };
 		6DC27BD81EC6592700B73CAF /* AutoHashable.expected in Resources */ = {isa = PBXBuildFile; fileRef = 6DC27BD71EC6592700B73CAF /* AutoHashable.expected */; };
+		B50435DF2157222E00F120DF /* AutoCodable.expected in Resources */ = {isa = PBXBuildFile; fileRef = 636D786B2083B8D700160CC4 /* AutoCodable.expected */; };
 		C03FD2E6F7645376C192094D /* Pods_TemplatesTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26AD1250F60484521E03C14A /* Pods_TemplatesTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -329,8 +329,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6D6A24B61EB79E8900C1FB1A /* Build configuration list for PBXNativeTarget "TemplatesTests" */;
 			buildPhases = (
-				D775B999DCC76F43E995E441 /* [CP] Check Pods Manifest.lock */,
 				6D342C951EBA1881006EEBEC /* Sourcery */,
+				D775B999DCC76F43E995E441 /* [CP] Check Pods Manifest.lock */,
 				6D6A24A61EB79E8900C1FB1A /* Sources */,
 				6D6A24A71EB79E8900C1FB1A /* Frameworks */,
 				6D6A24A81EB79E8900C1FB1A /* Resources */,
@@ -410,7 +410,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				636D786D2083B91A00160CC4 /* AutoCodable.expected in Resources */,
 				6D4D84481EC667630005932D /* AutoEquatable.generated.swift in Resources */,
 				6D6645C61ECC1CAA004C1948 /* AutoMockable.generated.swift in Resources */,
 				6D6645C31ECC1824004C1948 /* AutoMockable.expected in Resources */,
@@ -419,6 +418,7 @@
 				6D130B7B1ECACD0F00E9642A /* AutoLenses.expected in Resources */,
 				6D342C841EBA13DF006EEBEC /* AutoEquatable.stencil in Resources */,
 				6D6C19261FC4CE7900CD2A34 /* Decorator.swifttemplate in Resources */,
+				B50435DF2157222E00F120DF /* AutoCodable.expected in Resources */,
 				6D342C891EBA13DF006EEBEC /* LinuxMain.stencil in Resources */,
 				6D130B7C1ECACEB800E9642A /* AutoLenses.generated.swift in Resources */,
 				6D342C871EBA13DF006EEBEC /* AutoMockable.stencil in Resources */,
@@ -469,7 +469,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${BUILD_DIR}/Debug/Sourcery.app/Contents/MacOS/Sourcery\" --sources \"${SRCROOT}/Tests/Context\" --templates \"${SRCROOT}/Templates\" --output \"${SRCROOT}/Tests/Generated\" --disableCache --verbose";
+			shellScript = "\"${BUILD_DIR}/Debug/Sourcery.app/Contents/MacOS/Sourcery\" --sources \"${SRCROOT}/Tests/Context\" --templates \"${SRCROOT}/Templates\" --output \"${SRCROOT}/Tests/Generated\" --disableCache --verbose\n";
 		};
 		7139144942C834B5880D5184 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Templates/Templates.xcodeproj/xcshareddata/xcschemes/TemplatesTests.xcscheme
+++ b/Templates/Templates.xcodeproj/xcshareddata/xcschemes/TemplatesTests.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:../Sourcery.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6D6A24A91EB79E8900C1FB1A"
+               BuildableName = "TemplatesTests.xctest"
+               BlueprintName = "TemplatesTests"
+               ReferencedContainer = "container:Templates.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Templates/Templates/AutoCodable.swifttemplate
+++ b/Templates/Templates/AutoCodable.swifttemplate
@@ -85,11 +85,16 @@ func codingKeysFor(_ type: Type) -> (generated: [String], all: [String]) {
             }
         }
     } else if let enumType = type as? Enum {
-        let casesKeys: [String]
+        var casesKeys: [String] = enumType.cases.map({ $0.name })
         if enumType.hasAssociatedValues {
-            casesKeys = enumType.cases.map({ $0.name }) + enumType.cases.flatMap({ $0.associatedValues }).flatMap({ $0.localName })
-        } else {
-            casesKeys = enumType.cases.map({ $0.name })
+            enumType.cases
+                .flatMap({ $0.associatedValues })
+                .compactMap({ $0.localName })
+                .forEach({
+                    if !casesKeys.contains($0) {
+                        casesKeys.append($0)
+                    }
+                })
         }
         if let codingKeysType = type.containedType["CodingKeys"] as? Enum {
             allCodingKeys = codingKeysType.cases.map({ $0.name })
@@ -150,23 +155,31 @@ extension <%= type.name %> {
         switch enumCase {
         <%_ for enumCase in enumType.cases { -%>
         case CodingKeys.<%= enumCase.name %>.rawValue:
-            <%_ for associatedValue in enumCase.associatedValues where associatedValue.localName != nil { -%>
-            let <%= associatedValue.localName! %> = try container.decode(<%= associatedValue.typeName %>.self, forKey: .<%= associatedValue.localName! %>)
-            <%_ } -%>
             <%_ if enumCase.associatedValues.isEmpty { -%>
             self = .<%= enumCase.name %>
-            <%_ } else { -%>
+            <%_ } else if enumCase.associatedValues.filter({ $0.localName == nil }).count == enumCase.associatedValues.count { -%>
+            // Enum cases with unnamed associated values can't be decoded
+            throw DecodingError.dataCorruptedError(forKey: .enumCaseKey, in: container, debugDescription: "Can't decode '\(enumCase)'")
+            <%_ } else if enumCase.associatedValues.filter({ $0.localName != nil }).count == enumCase.associatedValues.count { -%>
+            <%_ for associatedValue in enumCase.associatedValues { -%>
+            let <%= associatedValue.localName! %> = try container.decode(<%= associatedValue.typeName %>.self, forKey: .<%= associatedValue.localName! %>)
+            <%_ } -%>
             self = .<%= enumCase.name %>(<% -%>
                 <%_ %><%= enumCase.associatedValues.map({ "\($0.localName!): \($0.localName!)" }).joined(separator: ", ") %>)
+            <%_ } else { -%>
+            // Enum cases with mixed named and unnamed associated values can't be decoded
+            throw DecodingError.dataCorruptedError(forKey: .enumCaseKey, in: container, debugDescription: "Can't decode '\(enumCase)'")
             <%_ } -%>
         <%_ } -%>
-        default: throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unknown enum case '\(enumCase)'"))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .enumCaseKey, in: container, debugDescription: "Unknown enum case '\(enumCase)'")
         }
         <%_ } else { -%>
         <%_ for enumCase in enumType.cases { -%>
         if container.allKeys.contains(.<%= enumCase.name %>), try container.decodeNil(forKey: .<%= enumCase.name %>) == false {
             <%_ if enumCase.associatedValues.isEmpty { -%>
             self = .<%= enumCase.name %>
+            return
             <%_ } else if enumCase.associatedValues.filter({ $0.localName == nil }).count == enumCase.associatedValues.count { -%>
             var associatedValues = try container.nestedUnkeyedContainer(forKey: .<%= enumCase.name %>)
             <%_ for (index, associatedValue) in enumCase.associatedValues.enumerated() { -%>
@@ -174,15 +187,19 @@ extension <%= type.name %> {
             <%_ } -%>
             self = .<%= enumCase.name %>(<% -%>
             <%_ %><%= enumCase.associatedValues.indices.map({ "associatedValue\($0)" }).joined(separator: ", ") %>)
-            <%_ } else { -%>
+            return
+            <%_ } else if enumCase.associatedValues.filter({ $0.localName != nil }).count == enumCase.associatedValues.count { -%>
             let associatedValues = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .<%= enumCase.name %>)
-            <%_ for associatedValue in enumCase.associatedValues where associatedValue.localName != nil { -%>
+            <%_ for associatedValue in enumCase.associatedValues { -%>
             let <%= associatedValue.localName! %> = try associatedValues.decode(<%= associatedValue.typeName %>.self, forKey: .<%= associatedValue.localName! %>)
             <%_ } -%>
             self = .<%= enumCase.name %>(<% -%>
             <%_ %><%= enumCase.associatedValues.map({ "\($0.localName!): \($0.localName!)" }).joined(separator: ", ") %>)
-            <%_ } -%>
             return
+            <%_ } else { -%>
+            // Enum cases with mixed named and unnamed associated values can't be decoded
+            throw DecodingError.dataCorruptedError(forKey: .<%= enumCase.name %>, in: container, debugDescription: "Can't decode `.<%= enumCase.name %>`")
+            <%_ } -%>
         }
         <%_ } -%>
         throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unknown enum case"))
@@ -232,12 +249,20 @@ extension <%= type.name %> {
         <%_ if enumCase.associatedValues.isEmpty { -%>
         case .<%= enumCase.name %>:
             try container.encode(CodingKeys.<%= enumCase.name %>.rawValue, forKey: .enumCaseKey)
-        <%_ } else { -%>
-        case let .<%= enumCase.name %>(<%= enumCase.associatedValues.map({ "\($0.localName ?? "_")" }).joined(separator: ", ") %>):
+        <%_ } else if enumCase.associatedValues.filter({ $0.localName == nil }).count == enumCase.associatedValues.count { -%>
+        case .<%= enumCase.name %>:
+            // Enum cases with unnamed associated values can't be encoded
+            throw EncodingError.invalidValue(self, .init(codingPath: encoder.codingPath, debugDescription: "Can't encode '\(self)'"))
+        <%_ } else if enumCase.associatedValues.filter({ $0.localName != nil }).count == enumCase.associatedValues.count { -%>
+        case let .<%= enumCase.name %>(<%= enumCase.associatedValues.map({ "\($0.localName!)" }).joined(separator: ", ") %>):
             try container.encode(CodingKeys.<%= enumCase.name %>.rawValue, forKey: .enumCaseKey)
-            <%_ for accociatedValue in enumCase.associatedValues where accociatedValue.localName != nil { -%>
+            <%_ for accociatedValue in enumCase.associatedValues { -%>
             try container.encode(<%= accociatedValue.localName! %>, forKey: .<%= accociatedValue.localName! %>)
             <%_ } -%>
+        <%_ } else { -%>
+        case .<%= enumCase.name %>:
+            // Enum cases with mixed named and unnamed associated values can't be encoded
+            throw EncodingError.invalidValue(self, .init(codingPath: encoder.codingPath, debugDescription: "Can't encode '\(self)'"))
         <%_ } -%>
         <%_ } -%>
         }
@@ -253,12 +278,16 @@ extension <%= type.name %> {
             <%_ for (index, associatedValue) in enumCase.associatedValues.enumerated() { -%>
             try associatedValues.encode(associatedValue<%= index %>)
         <%_ } -%>
-        <%_ } else { -%>
+        <%_ } else if enumCase.associatedValues.filter({ $0.localName != nil }).count == enumCase.associatedValues.count { -%>
         case let .<%= enumCase.name %>(<%= enumCase.associatedValues.map({ "\($0.localName!)" }).joined(separator: ", ") %>):
             var associatedValues = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .<%= enumCase.name %>)
-            <%_ for accociatedValue in enumCase.associatedValues where accociatedValue.localName != nil { -%>
+            <%_ for accociatedValue in enumCase.associatedValues { -%>
             try associatedValues.encode(<%= accociatedValue.localName! %>, forKey: .<%= accociatedValue.localName! %>)
         <%_ } -%>
+        <%_ } else { -%>
+        case .<%= enumCase.name %>:
+            // Enum cases with mixed named and unnamed associated values can't be encoded
+            throw EncodingError.invalidValue(self, .init(codingPath: encoder.codingPath, debugDescription: "Can't encode '\(self)'"))
         <%_ } -%>
         <%_ } -%>
         }

--- a/Templates/Templates/AutoCodable.swifttemplate
+++ b/Templates/Templates/AutoCodable.swifttemplate
@@ -167,6 +167,13 @@ extension <%= type.name %> {
         if container.allKeys.contains(.<%= enumCase.name %>), try container.decodeNil(forKey: .<%= enumCase.name %>) == false {
             <%_ if enumCase.associatedValues.isEmpty { -%>
             self = .<%= enumCase.name %>
+            <%_ } else if enumCase.associatedValues.filter({ $0.localName == nil }).count == enumCase.associatedValues.count { -%>
+            var associatedValues = try container.nestedUnkeyedContainer(forKey: .<%= enumCase.name %>)
+            <%_ for (index, associatedValue) in enumCase.associatedValues.enumerated() { -%>
+            let associatedValue<%= index %> = try associatedValues.decode(<%= associatedValue.typeName %>.self)
+            <%_ } -%>
+            self = .<%= enumCase.name %>(<% -%>
+            <%_ %><%= enumCase.associatedValues.indices.map({ "associatedValue\($0)" }).joined(separator: ", ") %>)
             <%_ } else { -%>
             let associatedValues = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .<%= enumCase.name %>)
             <%_ for associatedValue in enumCase.associatedValues where associatedValue.localName != nil { -%>
@@ -240,8 +247,14 @@ extension <%= type.name %> {
         <%_ if enumCase.associatedValues.isEmpty { -%>
         case .<%= enumCase.name %>:
             _ = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .<%= enumCase.name %>)
+        <%_ } else if enumCase.associatedValues.filter({ $0.localName == nil }).count == enumCase.associatedValues.count { -%>
+        case let .<%= enumCase.name %>(<%= enumCase.associatedValues.indices.map({ "associatedValue\($0)" }).joined(separator: ", ") %>):
+            var associatedValues = container.nestedUnkeyedContainer(forKey: .<%= enumCase.name %>)
+            <%_ for (index, associatedValue) in enumCase.associatedValues.enumerated() { -%>
+            try associatedValues.encode(associatedValue<%= index %>)
+        <%_ } -%>
         <%_ } else { -%>
-        case let .<%= enumCase.name %>(<%= enumCase.associatedValues.map({ "\($0.localName ?? "_")" }).joined(separator: ", ") %>):
+        case let .<%= enumCase.name %>(<%= enumCase.associatedValues.map({ "\($0.localName!)" }).joined(separator: ", ") %>):
             var associatedValues = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .<%= enumCase.name %>)
             <%_ for accociatedValue in enumCase.associatedValues where accociatedValue.localName != nil { -%>
             try associatedValues.encode(<%= accociatedValue.localName! %>, forKey: .<%= accociatedValue.localName! %>)

--- a/Templates/Tests/Context/AutoCodable.swift
+++ b/Templates/Tests/Context/AutoCodable.swift
@@ -149,5 +149,6 @@ enum AssociatedValuesEnum: AutoCodable, Equatable {
 
 enum AssociatedValuesEnumNoCaseKey: AutoCodable, Equatable {
     case someCase(id: Int, name: String)
+    case unnamedCase(Int, String)
     case anotherCase
 }

--- a/Templates/Tests/Context/AutoCodable.swift
+++ b/Templates/Tests/Context/AutoCodable.swift
@@ -133,6 +133,8 @@ enum SimpleEnum: AutoCodable {
 
 enum AssociatedValuesEnum: AutoCodable, Equatable {
     case someCase(id: Int, name: String)
+    case unnamedCase(Int, String)
+    case mixCase(Int, name: String)
     case anotherCase
 
     enum CodingKeys: String, CodingKey {
@@ -140,6 +142,8 @@ enum AssociatedValuesEnum: AutoCodable, Equatable {
 
 // sourcery:inline:auto:AssociatedValuesEnum.CodingKeys.AutoCodable
         case someCase
+        case unnamedCase
+        case mixCase
         case anotherCase
         case id
         case name
@@ -150,5 +154,6 @@ enum AssociatedValuesEnum: AutoCodable, Equatable {
 enum AssociatedValuesEnumNoCaseKey: AutoCodable, Equatable {
     case someCase(id: Int, name: String)
     case unnamedCase(Int, String)
+    case mixCase(Int, name: String)
     case anotherCase
 }

--- a/Templates/Tests/Expected/AutoCodable.expected
+++ b/Templates/Tests/Expected/AutoCodable.expected
@@ -39,6 +39,7 @@ extension AssociatedValuesEnumNoCaseKey {
 
     enum CodingKeys: String, CodingKey {
         case someCase
+        case unnamedCase
         case anotherCase
         case id
         case name
@@ -52,6 +53,13 @@ extension AssociatedValuesEnumNoCaseKey {
             let id = try associatedValues.decode(Int.self, forKey: .id)
             let name = try associatedValues.decode(String.self, forKey: .name)
             self = .someCase(id: id, name: name)
+            return
+        }
+        if container.allKeys.contains(.unnamedCase), try container.decodeNil(forKey: .unnamedCase) == false {
+            var associatedValues = try container.nestedUnkeyedContainer(forKey: .unnamedCase)
+            let associatedValue0 = try associatedValues.decode(Int.self)
+            let associatedValue1 = try associatedValues.decode(String.self)
+            self = .unnamedCase(associatedValue0, associatedValue1)
             return
         }
         if container.allKeys.contains(.anotherCase), try container.decodeNil(forKey: .anotherCase) == false {
@@ -69,6 +77,10 @@ extension AssociatedValuesEnumNoCaseKey {
             var associatedValues = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .someCase)
             try associatedValues.encode(id, forKey: .id)
             try associatedValues.encode(name, forKey: .name)
+        case let .unnamedCase(associatedValue0, associatedValue1):
+            var associatedValues = container.nestedUnkeyedContainer(forKey: .unnamedCase)
+            try associatedValues.encode(associatedValue0)
+            try associatedValues.encode(associatedValue1)
         case .anotherCase:
             _ = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .anotherCase)
         }

--- a/Templates/Tests/Generated/AutoCodable.generated.swift
+++ b/Templates/Tests/Generated/AutoCodable.generated.swift
@@ -39,6 +39,7 @@ extension AssociatedValuesEnumNoCaseKey {
 
     enum CodingKeys: String, CodingKey {
         case someCase
+        case unnamedCase
         case anotherCase
         case id
         case name
@@ -52,6 +53,13 @@ extension AssociatedValuesEnumNoCaseKey {
             let id = try associatedValues.decode(Int.self, forKey: .id)
             let name = try associatedValues.decode(String.self, forKey: .name)
             self = .someCase(id: id, name: name)
+            return
+        }
+        if container.allKeys.contains(.unnamedCase), try container.decodeNil(forKey: .unnamedCase) == false {
+            var associatedValues = try container.nestedUnkeyedContainer(forKey: .unnamedCase)
+            let associatedValue0 = try associatedValues.decode(Int.self)
+            let associatedValue1 = try associatedValues.decode(String.self)
+            self = .unnamedCase(associatedValue0, associatedValue1)
             return
         }
         if container.allKeys.contains(.anotherCase), try container.decodeNil(forKey: .anotherCase) == false {
@@ -69,6 +77,10 @@ extension AssociatedValuesEnumNoCaseKey {
             var associatedValues = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .someCase)
             try associatedValues.encode(id, forKey: .id)
             try associatedValues.encode(name, forKey: .name)
+        case let .unnamedCase(associatedValue0, associatedValue1):
+            var associatedValues = container.nestedUnkeyedContainer(forKey: .unnamedCase)
+            try associatedValues.encode(associatedValue0)
+            try associatedValues.encode(associatedValue1)
         case .anotherCase:
             _ = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .anotherCase)
         }

--- a/guides/Codable.md
+++ b/guides/Codable.md
@@ -204,7 +204,7 @@ enum SimpleEnum {
 
 #### Enums with assoicated values
 
-In such enums all associated values should be named. Template supports two different representations of such enums in JSON format.
+Template supports two different representations of such enums in JSON format.
 
 ```swift
 enum SimpleEnum {
@@ -213,7 +213,7 @@ enum SimpleEnum {
 }
 ```
 
-For such enum template will generate code that will successfully decode from/encode to JSON of following forms:
+If you define a coding key named `enumCaseKey` then the template will genearaet code that will encode/decode enum in/from following format:
 
 ```json
 {
@@ -222,8 +222,9 @@ For such enum template will generate code that will successfully decode from/enc
   "name": "Jhon"
 }
 ```
+All enum cases associated values must be named.
 
-or
+If you don't define `enumCaseKey` then the template will generate code that will encode/decode enum in/from following format:
 
 ```json
 {
@@ -234,5 +235,16 @@ or
 }
 ```
 
-To make template generate code for the first form you need to define a special coding key named `enumCaseKey`. If this key is not defined, template will generate code for the second form.
-You can use all other customisation methods described for structs as well for enums.
+Associated values of each enum case must be either all named or all unnamed.
+For cases with unnamed associated values JSON format will use array instead of dictionary for associated values, in the same order in which they are defined:
+
+```json
+{
+  "someCase": [
+    1,
+    "Jhon"
+  ]
+}
+```
+
+You can use all other customisation methods described for structs to decode/encode enum case associated values individually. 


### PR DESCRIPTION
Allow enums with unnamed associated values and don't allow mixing them (as it results in not fully decodable/encodable values)