### PR TITLE
Add parsing for `lazy var`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ---
 ## Master
 
+- Support for parsing lazy vars into Variable's attributes.
+
 ## 0.15.0
 
 ### New Features

--- a/SourceryRuntime/Sources/Attribute.swift
+++ b/SourceryRuntime/Sources/Attribute.swift
@@ -51,6 +51,7 @@ import Foundation
         case escaping
         case final
         case open
+        case lazy
         case `public` = "public"
         case `internal` = "internal"
         case `private` = "private"

--- a/SourceryRuntime/Sources/Variable.swift
+++ b/SourceryRuntime/Sources/Variable.swift
@@ -53,7 +53,7 @@ public typealias SourceryVariable = Variable
         return attributes[Attribute.Identifier.final.name] != nil
     }
     
-    // Whether variable is lazy or not
+    /// Whether variable is lazy or not
     public var isLazy: Bool {
         return attributes[Attribute.Identifier.lazy.name] != nil
     }

--- a/SourceryRuntime/Sources/Variable.swift
+++ b/SourceryRuntime/Sources/Variable.swift
@@ -52,6 +52,11 @@ public typealias SourceryVariable = Variable
     public var isFinal: Bool {
         return attributes[Attribute.Identifier.final.name] != nil
     }
+    
+    // Whether variable is lazy or not
+    public var isLazy: Bool {
+        return attributes[Attribute.Identifier.lazy.name] != nil
+    }
 
     /// Reference to type name where the variable is defined,
     /// nil if defined outside of any `enum`, `struct`, `class` etc

--- a/SourceryTests/Parsing/FileParser + AttributesSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AttributesSpec.swift
@@ -113,6 +113,10 @@ class FileParserAttributesSpec: QuickSpec {
                     "final": Attribute(name: "final", description: "final")
                     ]))
 
+                expect(parse("class Foo { lazy var name: String = \"Hello\" }").first?.variables.first?.attributes).to(equal([
+                    "lazy": Attribute(name: "lazy", description: "lazy")
+                    ]))
+
                 func assertSetterAccess(_ access: String, line: UInt = #line) {
                     expect(parse("public class Foo { \(access)(set) var some: Int }").first?.variables.first?.attributes, line: line).to(equal([
                         access: Attribute(name: access, arguments: ["set": NSNumber(value: true)], description: "\(access)(set)")

--- a/SourceryTests/Parsing/FileParser + VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser + VariableSpec.swift
@@ -115,10 +115,6 @@ class FileParserVariableSpec: QuickSpec {
                     expect(parse("var name: Int { didSet {} }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
                 }
 
-                it("extracts lazy property correctly") {
-                    expect(parse("lazy var name: String = \"Hello\"")).to(equal(Variable(name: "name", typeName: TypeName("String"), accessLevel: (read: .internal, write: .internal), isComputed: false, defaultValue: "Hello", attributes: ["lazy": Attribute(name: "lazy")])))
-                }
-
                 it("extracts generic property correctly") {
                     expect(parse("let name: Observable<Int>")).to(equal(Variable(name: "name", typeName: TypeName("Observable<Int>"), accessLevel: (read: .internal, write: .none), isComputed: false)))
                 }

--- a/SourceryTests/Parsing/FileParser + VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser + VariableSpec.swift
@@ -115,6 +115,10 @@ class FileParserVariableSpec: QuickSpec {
                     expect(parse("var name: Int { didSet {} }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
                 }
 
+                it("extracts lazy property correctly") {
+                    expect(parse("lazy var name: String = \"Hello\"")).to(equal(Variable(name: "name", typeName: TypeName("String"), accessLevel: (read: .internal, write: .internal), isComputed: false, defaultValue: "Hello", attributes: ["lazy": Attribute(name: "lazy")])))
+                }
+
                 it("extracts generic property correctly") {
                     expect(parse("let name: Observable<Int>")).to(equal(Variable(name: "name", typeName: TypeName("Observable<Int>"), accessLevel: (read: .internal, write: .none), isComputed: false)))
                 }


### PR DESCRIPTION
Resolves #686 
This PR tries to add support for `lazy` attribute.
