### PR TITLE
Do not cut out generated content when can't find location for inline annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Support for parsing lazy vars into Variable's attributes.
 - Updated Stencil to 0.13.1 and SwiftStencilKit to 2.7.0
 - In Swift templates CLI arguments should now be accessed via `argument` instead of `arguments`, to be consistent with Stencil and JS templates.
+- Fixed missing generated code annotated with `inline` annotation when corresponding annotation in sources are missing. This generated code will be now present in `*.generated.swift` file.  
 
 ## 0.15.0
 

--- a/SourceryRuntime/Sources/Attribute.swift
+++ b/SourceryRuntime/Sources/Attribute.swift
@@ -141,22 +141,19 @@ import Foundation
         }
     }
 
-    // sourcery:inline:sourcery:.AutoCoding
+    // sourcery:inline:Attribute.AutoCoding
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
             guard let name: String = aDecoder.decode(forKey: "name") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["name"])); fatalError() }; self.name = name
             guard let arguments: [String: NSObject] = aDecoder.decode(forKey: "arguments") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["arguments"])); fatalError() }; self.arguments = arguments
             guard let _description: String = aDecoder.decode(forKey: "_description") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["_description"])); fatalError() }; self._description = _description
-
         }
 
         /// :nodoc:
         public func encode(with aCoder: NSCoder) {
-
             aCoder.encode(self.name, forKey: "name")
             aCoder.encode(self.arguments, forKey: "arguments")
             aCoder.encode(self._description, forKey: "_description")
-
         }
         // sourcery:end
 


### PR DESCRIPTION
Resolves #684 
By separating extracting annotated ranges and "cutting" then we now don't cut out ranges for which we can't find location to paste them.