### PR TITLE
Allow file scope declarations (types, extensions) in swift templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Support for parsing lazy vars into Variable's attributes.
 - Updated Stencil to 0.13.1 and SwiftStencilKit to 2.7.0
 - In Swift templates CLI arguments should now be accessed via `argument` instead of `arguments`, to be consistent with Stencil and JS templates.
+- Now in swift templates you can define types, extensions and use other Swift features that require file scope, without using separate files. All templates code is now placed at the top level of the template executable code, instead of being placed inside an extension of `TemplateContext` type.
 
 ## 0.15.0
 

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -69,17 +69,12 @@ open class SwiftTemplate {
         import Foundation
         import SourceryRuntime
 
-        extension TemplateContext {
-            func generate() throws {
-                \(contents)
-            }
-        }
+        let context = ProcessInfo().context!
+        let types = context.types
+        let type = context.types.typesByName
+        let argument = context.argument
 
-        do {
-            try ProcessInfo().context!.generate()
-        } catch {
-            Log.error(error)
-        }
+        \(contents)
         """
 
         return (code, includedFiles)

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -15,11 +15,6 @@ private enum Delimiters {
     static let close = "%>"
 }
 
-private struct ProcessResult {
-    let output: String
-    let error: String
-}
-
 open class SwiftTemplate {
 
     public let sourcePath: Path
@@ -199,14 +194,13 @@ open class SwiftTemplate {
         let data = NSKeyedArchiver.archivedData(withRootObject: context)
         try serializedContextPath.write(data)
 
-        let result = try Process.runCommand(path: binaryPath.description,
-                                            arguments: [serializedContextPath.description])
-
-        if !result.error.isEmpty {
-            throw "\(sourcePath): \(result.error)"
+        do {
+            let result = try Process.runCommand(path: binaryPath.description,
+                                                arguments: [serializedContextPath.description])
+            return result
+        } catch let error as SwiftTemplateError {
+            throw "\(sourcePath): \(error.reason)"
         }
-
-        return result.output
     }
 
     func build() throws -> Path {
@@ -228,21 +222,14 @@ open class SwiftTemplate {
                 "-Xlinker", "-headerpad_max_install_names"
         ]
 
-        let compilationResult = try Process.runCommand(path: "/usr/bin/swiftc",
-                                                       arguments: arguments)
-
-        if !compilationResult.error.isEmpty {
-            throw compilationResult.error
-        }
-
-        let linkingResult = try Process.runCommand(path: "/usr/bin/install_name_tool",
-                                                   arguments: [
-                                                    "-add_rpath",
-                                                    "@executable_path/../",
-                                                    binaryFile.description])
-        if !linkingResult.error.isEmpty {
-            throw linkingResult.error
-        }
+        try Process.runCommand(path: "/usr/bin/swiftc",
+                               arguments: arguments)
+        
+        try Process.runCommand(path: "/usr/bin/install_name_tool",
+                               arguments: [
+                                "-add_rpath",
+                                "@executable_path/../",
+                                binaryFile.description])
 
         try? mainFile.delete()
 
@@ -252,16 +239,12 @@ open class SwiftTemplate {
     private func copyFramework(to path: Path) throws {
         let sourceryFramework = SwiftTemplate.frameworksPath + "SourceryRuntime.framework"
 
-        let copyFramework = try Process.runCommand(path: "/usr/bin/rsync", arguments: [
+        try Process.runCommand(path: "/usr/bin/rsync", arguments: [
             "-av",
             "--force",
             sourceryFramework.description,
             path.description
             ])
-
-        if !copyFramework.error.isEmpty {
-            throw copyFramework.error
-        }
     }
 
 }
@@ -272,6 +255,14 @@ fileprivate extension SwiftTemplate {
         return Path(Bundle(for: SwiftTemplate.self).bundlePath +  "/Versions/Current/Frameworks")
     }
 
+}
+
+struct SwiftTemplateError: Error, CustomStringConvertible {
+    let reason: String
+    
+    var description: String {
+        return reason
+    }
 }
 
 // swiftlint:disable:next force_try
@@ -290,7 +281,8 @@ private extension String {
 }
 
 private extension Process {
-    static func runCommand(path: String, arguments: [String], environment: [String: String] = [:]) throws -> ProcessResult {
+    @discardableResult
+    static func runCommand(path: String, arguments: [String], environment: [String: String] = [:]) throws -> String {
         let task = Process()
         task.launchPath = path
         task.arguments = arguments
@@ -316,14 +308,11 @@ private extension Process {
         let output = String(data: outputData, encoding: .utf8) ?? ""
         let error = String(data: errorData, encoding: .utf8) ?? ""
 
-        if task.terminationReason != .exit {
-            throw NSError(domain: NSOSStatusErrorDomain, code: -1, userInfo: [
-                "terminationReason": task.terminationReason,
-                "error": error
-                ])
+        if !errorData.isEmpty {
+            throw SwiftTemplateError(reason: error)
         }
 
-        return ProcessResult(output: output, error: error)
+        return output
     }
 }
 

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -131,7 +131,7 @@ class SwiftTemplateTests: QuickSpec {
                     }
                     .to(throwError(closure: { (error) in
                         let path = Path.cleanTemporaryDir(name: "build").parent() + "SwiftTemplate.build/main.swift"
-                        expect("\(error)").to(equal("\(path):6:19: error: expected expression in list of expressions\n        print(\"\\( )\", terminator: \"\");\n                  ^\n"))
+                        expect("\(error)").to(equal("\(path):9:11: error: expected expression in list of expressions\nprint(\"\\( )\", terminator: \"\");\n          ^\n"))
                     }))
             }
 
@@ -151,7 +151,7 @@ class SwiftTemplateTests: QuickSpec {
                     try Generator.generate(Types(types: []), template: SwiftTemplate(path: templatePath))
                     }
                     .to(throwError(closure: { (error) in
-                        expect("\(error)").to(equal("\(templatePath): Template error"))
+                        expect("\(error)").to(equal("\(templatePath): Fatal error: Index out of range\n"))
                     }))
             }
         }

--- a/SourceryTests/Stub/SwiftTemplates/Throws.swifttemplate
+++ b/SourceryTests/Stub/SwiftTemplates/Throws.swifttemplate
@@ -1,1 +1,1 @@
-<% throw "Template error" %>
+<% [String]()[1] %>


### PR DESCRIPTION
Instead of using an extension on `TemplateContext` we now simply extract its properties into global variables with the same names. This way we don't need anymore a template code to be placed in an extension of `TemplateContext` and it is still accessible in the same way. The only downside of this is that if we add any properties to the `TemplateContext` type we need to update the template, but we haven't done this for ages, so should be good enough.
Also simplified a bit error handling as there were some unneeded jumping through the hoops.
This allows defining extensions or types without including separate swift files which was added in #666 