### PR TITLE
Update Autohashable for Swift 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - In Swift templates CLI arguments should now be accessed via `argument` instead of `arguments`, to be consistent with Stencil and JS templates.
 - Now in swift templates you can define types, extensions and use other Swift features that require file scope, without using separate files. All templates code is now placed at the top level of the template executable code, instead of being placed inside an extension of `TemplateContext` type.
 - Fixed missing generated code annotated with `inline` annotation when corresponding annotation in sources are missing. This generated code will be now present in `*.generated.swift` file.  
+- Updated AutoHashable template to use Swift 4.2's `hash(into:)` method from `Hashable`, and enable support for inheritance.
 
 ## 0.15.0
 

--- a/Templates/Templates/AutoHashable.stencil
+++ b/Templates/Templates/AutoHashable.stencil
@@ -1,138 +1,19 @@
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-
-fileprivate func combineHashes(_ hashes: [Int]) -> Int {
-    return hashes.reduce(0, combineHashValues)
-}
-
-fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
-    #if arch(x86_64) || arch(arm64)
-        let magic: UInt = 0x9e3779b97f4a7c15
-    #elseif arch(i386) || arch(arm)
-        let magic: UInt = 0x9e3779b9
-    #endif
-    var lhs = UInt(bitPattern: initial)
-    let rhs = UInt(bitPattern: other)
-    lhs ^= rhs &+ magic &+ (lhs << 6) &+ (lhs >> 2)
-    return Int(bitPattern: lhs)
-}
-
-fileprivate func hashArray<T: Hashable>(_ array: [T]?) -> Int {
-    guard let array = array else {
-        return 0
-    }
-    return array.reduce(5381) {
-        ($0 << 5) &+ $0 &+ $1.hashValue
-    }
-}
-
-#if swift(>=4.0)
-fileprivate func hashDictionary<T, U: Hashable>(_ dictionary: [T: U]?) -> Int {
-    guard let dictionary = dictionary else {
-        return 0
-    }
-    return dictionary.reduce(5381) {
-        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
-    }
-}
-#else
-fileprivate func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
-    guard let dictionary = dictionary else {
-        return 0
-    }
-    return dictionary.reduce(5381) {
-        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
-    }
-}
-#endif
-
-{% macro letDynamicVariableHashValue variable %}
-{% if variable.isArray %}
-        let {{ variable.name }}HashValue = hashArray({{ variable.name }})
-{% elif variable.isDictionary %}
-        let {{ variable.name }}HashValue = hashDictionary({{ variable.name }})
-{% elif not variable.isOptional %}
-        let {{ variable.name }}HashValue = {{ variable.name }}.hashValue
-{% else %}
-        let {{ variable.name }}HashValue = {{ variable.name }}?.hashValue ?? 0
-{% endif %}
-{% endmacro %}
-
-{% macro dynamicVariableHashValue variable %}
-{% if variable.isArray %}
-            {{ variable.name }}HashValue,
-{% elif variable.isDictionary %}
-            {{ variable.name }}HashValue,
-{% elif not variable.isOptional %}
-            {{ variable.name }}HashValue,
-{% else %}
-            {{ variable.name }}HashValue,
-{% endif %}
-{% endmacro %}
-
-{% macro letStaticVariableHashValue variable %}
-  {% if variable.isArray %}
-        let {{ variable.name }}HashValue = hashArray(type(of: self).{{ variable.name }})
-{% elif variable.isDictionary %}
-        let {{ variable.name }}HashValue = hashDictionary(type(of: self).{{ variable.name }})
-{% elif not variable.isOptional %}
-        let type(of: self).{{ variable.name }}HashValue = type(of: self).{{ variable.name }}.hashValue
-{% else %}
-        let type(of: self).{{ variable.name }}HashValue = type(of: self).{{ variable.name }}?.hashValue ?? 0
-{% endif %}
-{% endmacro %}
-
-{% macro staticVariableHashValue variable %}
-{% if variable.isArray %}
-            {{ variable.name }}HashValue,
-{% elif variable.isDictionary %}
-            {{ variable.name }}HashValue,
-{% elif not variable.isOptional %}
-            {{ variable.name }}HashValue,
-{% else %}
-            {{ variable.name }}HashValue,
-{% endif %}
-{% endmacro %}
-
+// swiftlint:disable all
 
 {% macro combineVariableHashes variables %}
-        return combineHashes([
-    {% for variable in variables where variable.readAccess != "private" and variable.readAccess != "fileprivate" %}
-    {% if not variable.annotations.skipHashing %}
-        {% if variable.isStatic %}
-            {% call staticVariableHashValue variable %}
-        {% else %}
-            {% call dynamicVariableHashValue variable %}
-        {% endif %}
-    {% endif %}
-    {% endfor %}
-            0])
-{% endmacro %}
-
-{% macro letCombineVariableHashes variables %}
 {% for variable in variables where variable.readAccess != "private" and variable.readAccess != "fileprivate" %}
-  {% if not variable.annotations.skipHashing %}
-    {% if variable.isStatic %}
-      {% call letStaticVariableHashValue variable %}
-    {% else %}
-      {% call letDynamicVariableHashValue variable %}
-    {% endif %}
-  {% endif %}
+{% if not variable.annotations.skipHashing %}
+        {% if variable.isStatic %}type(of: self).{% endif %}{{ variable.name }}.hash(into: &hasher)
+{% endif %}
 {% endfor %}
 {% endmacro %}
 
 // MARK: - AutoHashable for classes, protocols, structs
-{% for type in types.implementing.AutoHashable %}{% if not type.kind == "enum" %}
+{% for type in types.types|!enum where type.implements.AutoHashable or type|annotated:"AutoHashable" %}
 // MARK: - {{ type.name }} AutoHashable
 extension {{ type.name }}{% if not type.kind == "protocol" and not type.based.NSObject %}: Hashable{% endif %} {
-    {% if type.supertype.based.Hashable or type.supertype.implements.AutoHashable %}THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable{% endif %}
-    {{ type.accessLevel }}{% if type.based.NSObject %} override{% endif %} var hashValue: Int {
-        {% if not type.kind == "protocol" %}
-        {% call letCombineVariableHashes type.storedVariables %}
-        {% else %}
-        {% call letCombineVariableHashes type.allVariables %}
-        {% endif %}
-
+{% if type.supertype.based.Hashable or type.supertype.implements.AutoHashable %}#error Inheritance is not supported for AutoHashable{% endif %}
+    {{ type.accessLevel }}{% if type.based.NSObject %} override{% endif %} func hash(into hasher: inout Hasher) {
         {% if not type.kind == "protocol" %}
         {% call combineVariableHashes type.storedVariables %}
         {% else %}
@@ -140,28 +21,30 @@ extension {{ type.name }}{% if not type.kind == "protocol" and not type.based.NS
         {% endif %}
     }
 }
-{% endif %}{% endfor %}
+{% endfor %}
 
 // MARK: - AutoHashable for Enums
-{% for type in types.implementing.AutoHashable|enum %}
+{% for type in types.enums where type.implements.AutoHashable or type|annotated:"AutoHashable" %}
 
 // MARK: - {{ type.name }} AutoHashable
 extension {{ type.name }}: Hashable {
-    {{ type.accessLevel }} var hashValue: Int {
+    {{ type.accessLevel }} func hash(into hasher: inout Hasher) {
         switch self {
         {% for case in type.cases %}
         {% if case.hasAssociatedValue %}case .{{ case.name }}(let data):{% else %}case .{{ case.name }}:{% endif %}
-            {% ifnot case.hasAssociatedValue %}
-            {% if type.computedVariables.count == 0 %}
-            return {{ forloop.counter }}.hashValue
-            {% else %}
-            return combineHashes([{{ forloop.counter }}, {% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}])
+            {{ forloop.counter }}.hash(into: &hasher)
+            {% if type.computedVariables.count > 0 %}
+            {% for variable in type.computedVariables %}
+            {% if not variable.annotations.skipHashing %}{{ variable.name }}.hash(into: &hasher)
             {% endif %}
-            {% else %}
+            {% endfor %}
+            {% endif %}
+            {% if case.hasAssociatedValue %}
             {% if case.associatedValues.count == 1 %}
-            return combineHashes([{{ forloop.counter }}, data.hashValue])
+            data.hash(into: &hasher)
             {% else %}
-            return combineHashes([{{ forloop.counter }}, {% for associated in case.associatedValues %}data.{{ associated.externalName }}.hashValue{% if not forloop.last %}, {% endif %}{% endfor %}{% for variable in type.computedVariables %}{% if variable.annotations.includeInHashing %}, {{ variable.name }}.hashValue{% endif %}{% endfor %}])
+            {% for associated in case.associatedValues %}data.{{ associated.externalName }}.hash(into: &hasher)
+            {% endfor %}
             {% endif %}
             {% endif %}
             {% endfor %}

--- a/Templates/Templates/AutoHashable.stencil
+++ b/Templates/Templates/AutoHashable.stencil
@@ -12,8 +12,10 @@
 {% for type in types.types|!enum where type.implements.AutoHashable or type|annotated:"AutoHashable" %}
 // MARK: - {{ type.name }} AutoHashable
 extension {{ type.name }}{% if not type.kind == "protocol" and not type.based.NSObject %}: Hashable{% endif %} {
-{% if type.supertype.based.Hashable or type.supertype.implements.AutoHashable %}#error Inheritance is not supported for AutoHashable{% endif %}
-    {{ type.accessLevel }}{% if type.based.NSObject %} override{% endif %} func hash(into hasher: inout Hasher) {
+    {{ type.accessLevel }}{% if type.based.NSObject or type.supertype.implements.AutoHashable or type.supertype|annotated:"AutoHashable" or type.supertype.based.Hashable %} override{% endif %} func hash(into hasher: inout Hasher) {
+        {% if type.based.NSObject or type.supertype.implements.AutoHashable or type.supertype|annotated:"AutoHashable" or type.supertype.based.Hashable %}
+        super.hash(into: hasher)
+        {% endif %}
         {% if not type.kind == "protocol" %}
         {% call combineVariableHashes type.storedVariables %}
         {% else %}

--- a/Templates/Tests/Context/AutoHashable.swift
+++ b/Templates/Tests/Context/AutoHashable.swift
@@ -134,7 +134,6 @@ class AutoHashableClass: AutoHashable {
     }
 }
 
-// Sourcery doesn't support inheritance for AutoHashable
 class AutoHashableClassInherited: AutoHashableClass {
     // Optional constants
     let middleName: String?
@@ -145,11 +144,85 @@ class AutoHashableClassInherited: AutoHashableClass {
     }
 }
 
+class AutoHashableClassInheritedInherited: AutoHashableClassInherited {
+    // Optional constants
+    let prefix: String?
+
+    init(prefix: String?) {
+        self.prefix = prefix
+        super.init(middleName: "")
+    }
+}
+
+class NonHashableClass {
+    let firstName: String
+
+    init(firstName: String) {
+        self.firstName = firstName
+    }
+}
+
+// Should not add super call
+class AutoHashableClassFromNonHashableInherited: NonHashableClass, AutoHashable {
+    let lastName: String?
+
+    init(lastName: String?) {
+        self.lastName = lastName
+        super.init(firstName: "")
+    }
+}
+
+// Should add super call
+class AutoHashableClassFromNonHashableInheritedInherited: AutoHashableClassFromNonHashableInherited {
+    let prefix: String?
+
+    init(prefix: String?) {
+        self.prefix = prefix
+        super.init(lastName: "")
+    }
+}
+
+class HashableClass: Hashable {
+    let firstName: String
+
+    init(firstName: String) {
+        self.firstName = firstName
+    }
+
+    static func == (lhs: HashableClass, rhs: HashableClass) -> Bool {
+        return lhs.firstName == rhs.firstName
+    }
+
+    func hash(into hasher: inout Hasher) {
+        self.firstName.hash(into: &hasher)
+    }
+}
+
+// Should add super
+class AutoHashableFromHashableInherited: HashableClass, AutoHashable {
+    let lastName: String?
+
+    init(lastName: String?) {
+        self.lastName = lastName
+        super.init(firstName: "")
+    }
+}
+
 /// Should not add Hashable conformance
 class AutoHashableNSObject: NSObject, AutoHashable {
     let firstName: String
 
     init(firstName: String) {
         self.firstName = firstName
+    }
+}
+
+// Should add super call
+class AutoHashableNSObjectInherited: AutoHashableNSObject {
+    let lastName: String
+
+    init(lastName: String) {
+        self.lastName = lastName
+            super.init(firstName: "")
     }
 }

--- a/Templates/Tests/Context/AutoHashable.swift
+++ b/Templates/Tests/Context/AutoHashable.swift
@@ -223,6 +223,6 @@ class AutoHashableNSObjectInherited: AutoHashableNSObject {
 
     init(lastName: String) {
         self.lastName = lastName
-            super.init(firstName: "")
+        super.init(firstName: "")
     }
 }

--- a/Templates/Tests/Expected/AutoHashable.expected
+++ b/Templates/Tests/Expected/AutoHashable.expected
@@ -14,17 +14,52 @@ extension AutoHashableClass: Hashable {
         friends.hash(into: &hasher)
     }
 }
+// MARK: - AutoHashableClassFromNonHashableInherited AutoHashable
+extension AutoHashableClassFromNonHashableInherited: Hashable {
+    internal func hash(into hasher: inout Hasher) {
+        lastName.hash(into: &hasher)
+    }
+}
+// MARK: - AutoHashableClassFromNonHashableInheritedInherited AutoHashable
+extension AutoHashableClassFromNonHashableInheritedInherited: Hashable {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
+        prefix.hash(into: &hasher)
+    }
+}
 // MARK: - AutoHashableClassInherited AutoHashable
 extension AutoHashableClassInherited: Hashable {
-#error Inheritance is not supported for AutoHashable
-    internal func hash(into hasher: inout Hasher) {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
         middleName.hash(into: &hasher)
+    }
+}
+// MARK: - AutoHashableClassInheritedInherited AutoHashable
+extension AutoHashableClassInheritedInherited: Hashable {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
+        prefix.hash(into: &hasher)
+    }
+}
+// MARK: - AutoHashableFromHashableInherited AutoHashable
+extension AutoHashableFromHashableInherited: Hashable {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
+        lastName.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableNSObject AutoHashable
 extension AutoHashableNSObject {
     internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
         firstName.hash(into: &hasher)
+    }
+}
+// MARK: - AutoHashableNSObjectInherited AutoHashable
+extension AutoHashableNSObjectInherited {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
+        lastName.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableProtocol AutoHashable

--- a/Templates/Tests/Expected/AutoHashable.expected
+++ b/Templates/Tests/Expected/AutoHashable.expected
@@ -1,132 +1,50 @@
-// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
-// DO NOT EDIT
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-
-fileprivate func combineHashes(_ hashes: [Int]) -> Int {
-    return hashes.reduce(0, combineHashValues)
-}
-
-fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
-    #if arch(x86_64) || arch(arm64)
-        let magic: UInt = 0x9e3779b97f4a7c15
-    #elseif arch(i386) || arch(arm)
-        let magic: UInt = 0x9e3779b9
-    #endif
-    var lhs = UInt(bitPattern: initial)
-    let rhs = UInt(bitPattern: other)
-    lhs ^= rhs &+ magic &+ (lhs << 6) &+ (lhs >> 2)
-    return Int(bitPattern: lhs)
-}
-
-fileprivate func hashArray<T: Hashable>(_ array: [T]?) -> Int {
-    guard let array = array else {
-        return 0
-    }
-    return array.reduce(5381) {
-        ($0 << 5) &+ $0 &+ $1.hashValue
-    }
-}
-
-#if swift(>=4.0)
-fileprivate func hashDictionary<T, U: Hashable>(_ dictionary: [T: U]?) -> Int {
-    guard let dictionary = dictionary else {
-        return 0
-    }
-    return dictionary.reduce(5381) {
-        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
-    }
-}
-#else
-fileprivate func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
-    guard let dictionary = dictionary else {
-        return 0
-    }
-    return dictionary.reduce(5381) {
-        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
-    }
-}
-#endif
+// swiftlint:disable all
 
 // MARK: - AutoHashable for classes, protocols, structs
 // MARK: - AutoHashableClass AutoHashable
 extension AutoHashableClass: Hashable {
-    internal var hashValue: Int {
-        let firstNameHashValue = firstName.hashValue
-        let lastNameHashValue = lastName.hashValue
-        let parentsHashValue = hashArray(parents)
-        let universityGradesHashValue = hashDictionary(universityGrades)
-        let moneyInThePocketHashValue = moneyInThePocket.hashValue
-        let ageHashValue = age?.hashValue ?? 0
-        let friendsHashValue = hashArray(friends)
-
-        return combineHashes([
-            firstNameHashValue,
-            lastNameHashValue,
-            parentsHashValue,
-            universityGradesHashValue,
-            moneyInThePocketHashValue,
-            ageHashValue,
-            friendsHashValue,
-            0])
+    internal func hash(into hasher: inout Hasher) {
+        firstName.hash(into: &hasher)
+        lastName.hash(into: &hasher)
+        parents.hash(into: &hasher)
+        universityGrades.hash(into: &hasher)
+        moneyInThePocket.hash(into: &hasher)
+        age.hash(into: &hasher)
+        friends.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableClassInherited AutoHashable
 extension AutoHashableClassInherited: Hashable {
-    THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable
-    internal var hashValue: Int {
-        let middleNameHashValue = middleName?.hashValue ?? 0
-
-        return combineHashes([
-            middleNameHashValue,
-            0])
+#error Inheritance is not supported for AutoHashable
+    internal func hash(into hasher: inout Hasher) {
+        middleName.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableNSObject AutoHashable
 extension AutoHashableNSObject {
-    internal override var hashValue: Int {
-        let firstNameHashValue = firstName.hashValue
-
-        return combineHashes([
-            firstNameHashValue,
-            0])
+    internal override func hash(into hasher: inout Hasher) {
+        firstName.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableProtocol AutoHashable
 extension AutoHashableProtocol {
-    internal var hashValue: Int {
-        let widthHashValue = width.hashValue
-        let heightHashValue = height.hashValue
-        let type(of: self).nameHashValue = type(of: self).name.hashValue
-
-        return combineHashes([
-            widthHashValue,
-            heightHashValue,
-            nameHashValue,
-            0])
+    internal func hash(into hasher: inout Hasher) {
+        width.hash(into: &hasher)
+        height.hash(into: &hasher)
+        type(of: self).name.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableStruct AutoHashable
 extension AutoHashableStruct: Hashable {
-    internal var hashValue: Int {
-        let firstNameHashValue = firstName.hashValue
-        let lastNameHashValue = lastName.hashValue
-        let parentsHashValue = hashArray(parents)
-        let universityGradesHashValue = hashDictionary(universityGrades)
-        let moneyInThePocketHashValue = moneyInThePocket.hashValue
-        let ageHashValue = age?.hashValue ?? 0
-        let friendsHashValue = hashArray(friends)
-
-        return combineHashes([
-            firstNameHashValue,
-            lastNameHashValue,
-            parentsHashValue,
-            universityGradesHashValue,
-            moneyInThePocketHashValue,
-            ageHashValue,
-            friendsHashValue,
-            0])
+    internal func hash(into hasher: inout Hasher) {
+        firstName.hash(into: &hasher)
+        lastName.hash(into: &hasher)
+        parents.hash(into: &hasher)
+        universityGrades.hash(into: &hasher)
+        moneyInThePocket.hash(into: &hasher)
+        age.hash(into: &hasher)
+        friends.hash(into: &hasher)
     }
 }
 
@@ -134,14 +52,17 @@ extension AutoHashableStruct: Hashable {
 
 // MARK: - AutoHashableEnum AutoHashable
 extension AutoHashableEnum: Hashable {
-    internal var hashValue: Int {
+    internal func hash(into hasher: inout Hasher) {
         switch self {
         case .one:
-            return 1.hashValue
+            1.hash(into: &hasher)
         case .two(let data):
-            return combineHashes([2, data.first.hashValue, data.second.hashValue])
+            2.hash(into: &hasher)
+            data.first.hash(into: &hasher)
+            data.second.hash(into: &hasher)
         case .three(let data):
-            return combineHashes([3, data.hashValue])
+            3.hash(into: &hasher)
+            data.hash(into: &hasher)
         }
     }
 }

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -17,17 +17,52 @@ extension AutoHashableClass: Hashable {
         friends.hash(into: &hasher)
     }
 }
+// MARK: - AutoHashableClassFromNonHashableInherited AutoHashable
+extension AutoHashableClassFromNonHashableInherited: Hashable {
+    internal func hash(into hasher: inout Hasher) {
+        lastName.hash(into: &hasher)
+    }
+}
+// MARK: - AutoHashableClassFromNonHashableInheritedInherited AutoHashable
+extension AutoHashableClassFromNonHashableInheritedInherited: Hashable {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
+        prefix.hash(into: &hasher)
+    }
+}
 // MARK: - AutoHashableClassInherited AutoHashable
 extension AutoHashableClassInherited: Hashable {
-#error Inheritance is not supported for AutoHashable
-    internal func hash(into hasher: inout Hasher) {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
         middleName.hash(into: &hasher)
+    }
+}
+// MARK: - AutoHashableClassInheritedInherited AutoHashable
+extension AutoHashableClassInheritedInherited: Hashable {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
+        prefix.hash(into: &hasher)
+    }
+}
+// MARK: - AutoHashableFromHashableInherited AutoHashable
+extension AutoHashableFromHashableInherited: Hashable {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
+        lastName.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableNSObject AutoHashable
 extension AutoHashableNSObject {
     internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
         firstName.hash(into: &hasher)
+    }
+}
+// MARK: - AutoHashableNSObjectInherited AutoHashable
+extension AutoHashableNSObjectInherited {
+    internal override func hash(into hasher: inout Hasher) {
+        super.hash(into: hasher)
+        lastName.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableProtocol AutoHashable

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -1,139 +1,53 @@
 // Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-
-fileprivate func combineHashes(_ hashes: [Int]) -> Int {
-    return hashes.reduce(0, combineHashValues)
-}
-
-fileprivate func combineHashValues(_ initial: Int, _ other: Int) -> Int {
-    #if arch(x86_64) || arch(arm64)
-        let magic: UInt = 0x9e3779b97f4a7c15
-    #elseif arch(i386) || arch(arm)
-        let magic: UInt = 0x9e3779b9
-    #endif
-    var lhs = UInt(bitPattern: initial)
-    let rhs = UInt(bitPattern: other)
-    lhs ^= rhs &+ magic &+ (lhs << 6) &+ (lhs >> 2)
-    return Int(bitPattern: lhs)
-}
-
-fileprivate func hashArray<T: Hashable>(_ array: [T]?) -> Int {
-    guard let array = array else {
-        return 0
-    }
-    return array.reduce(5381) {
-        ($0 << 5) &+ $0 &+ $1.hashValue
-    }
-}
-
-#if swift(>=4.0)
-fileprivate func hashDictionary<T, U: Hashable>(_ dictionary: [T: U]?) -> Int {
-    guard let dictionary = dictionary else {
-        return 0
-    }
-    return dictionary.reduce(5381) {
-        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
-    }
-}
-#else
-fileprivate func hashDictionary<T: Hashable, U: Hashable>(_ dictionary: [T: U]?) -> Int {
-    guard let dictionary = dictionary else {
-        return 0
-    }
-    return dictionary.reduce(5381) {
-        combineHashValues($0, combineHashValues($1.key.hashValue, $1.value.hashValue))
-    }
-}
-#endif
-
-
-
-
-
-
+// swiftlint:disable all
 
 
 // MARK: - AutoHashable for classes, protocols, structs
 // MARK: - AutoHashableClass AutoHashable
 extension AutoHashableClass: Hashable {
-    internal var hashValue: Int {
-        let firstNameHashValue = firstName.hashValue
-        let lastNameHashValue = lastName.hashValue
-        let parentsHashValue = hashArray(parents)
-        let universityGradesHashValue = hashDictionary(universityGrades)
-        let moneyInThePocketHashValue = moneyInThePocket.hashValue
-        let ageHashValue = age?.hashValue ?? 0
-        let friendsHashValue = hashArray(friends)
-
-        return combineHashes([
-            firstNameHashValue,
-            lastNameHashValue,
-            parentsHashValue,
-            universityGradesHashValue,
-            moneyInThePocketHashValue,
-            ageHashValue,
-            friendsHashValue,
-            0])
+    internal func hash(into hasher: inout Hasher) {
+        firstName.hash(into: &hasher)
+        lastName.hash(into: &hasher)
+        parents.hash(into: &hasher)
+        universityGrades.hash(into: &hasher)
+        moneyInThePocket.hash(into: &hasher)
+        age.hash(into: &hasher)
+        friends.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableClassInherited AutoHashable
 extension AutoHashableClassInherited: Hashable {
-    THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoHashable
-    internal var hashValue: Int {
-        let middleNameHashValue = middleName?.hashValue ?? 0
-
-        return combineHashes([
-            middleNameHashValue,
-            0])
+#error Inheritance is not supported for AutoHashable
+    internal func hash(into hasher: inout Hasher) {
+        middleName.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableNSObject AutoHashable
 extension AutoHashableNSObject {
-    internal override var hashValue: Int {
-        let firstNameHashValue = firstName.hashValue
-
-        return combineHashes([
-            firstNameHashValue,
-            0])
+    internal override func hash(into hasher: inout Hasher) {
+        firstName.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableProtocol AutoHashable
 extension AutoHashableProtocol {
-    internal var hashValue: Int {
-        let widthHashValue = width.hashValue
-        let heightHashValue = height.hashValue
-        let type(of: self).nameHashValue = type(of: self).name.hashValue
-
-        return combineHashes([
-            widthHashValue,
-            heightHashValue,
-            nameHashValue,
-            0])
+    internal func hash(into hasher: inout Hasher) {
+        width.hash(into: &hasher)
+        height.hash(into: &hasher)
+        type(of: self).name.hash(into: &hasher)
     }
 }
 // MARK: - AutoHashableStruct AutoHashable
 extension AutoHashableStruct: Hashable {
-    internal var hashValue: Int {
-        let firstNameHashValue = firstName.hashValue
-        let lastNameHashValue = lastName.hashValue
-        let parentsHashValue = hashArray(parents)
-        let universityGradesHashValue = hashDictionary(universityGrades)
-        let moneyInThePocketHashValue = moneyInThePocket.hashValue
-        let ageHashValue = age?.hashValue ?? 0
-        let friendsHashValue = hashArray(friends)
-
-        return combineHashes([
-            firstNameHashValue,
-            lastNameHashValue,
-            parentsHashValue,
-            universityGradesHashValue,
-            moneyInThePocketHashValue,
-            ageHashValue,
-            friendsHashValue,
-            0])
+    internal func hash(into hasher: inout Hasher) {
+        firstName.hash(into: &hasher)
+        lastName.hash(into: &hasher)
+        parents.hash(into: &hasher)
+        universityGrades.hash(into: &hasher)
+        moneyInThePocket.hash(into: &hasher)
+        age.hash(into: &hasher)
+        friends.hash(into: &hasher)
     }
 }
 
@@ -141,14 +55,17 @@ extension AutoHashableStruct: Hashable {
 
 // MARK: - AutoHashableEnum AutoHashable
 extension AutoHashableEnum: Hashable {
-    internal var hashValue: Int {
+    internal func hash(into hasher: inout Hasher) {
         switch self {
         case .one:
-            return 1.hashValue
+            1.hash(into: &hasher)
         case .two(let data):
-            return combineHashes([2, data.first.hashValue, data.second.hashValue])
+            2.hash(into: &hasher)
+            data.first.hash(into: &hasher)
+            data.second.hash(into: &hasher)
         case .three(let data):
-            return combineHashes([3, data.hashValue])
+            3.hash(into: &hasher)
+            data.hash(into: &hasher)
         }
     }
 }


### PR DESCRIPTION
This PR updates the `AutoHashable` template so it uses the Swift 4.2 new `hash(into:)`'s method, rather than calculating a `hashValue`. Thanks to optional conformance defined of `Hashable` for `Optional` and `Collection`, this simplifies the template a bit. The annotation `skipHashing` allowing tweak which variable are excluded is still supported.
I've tried to keep the original structure the same, and just changed the implementation itself.

I've also included a commit to tentatively support inheritance for classes and `Hashable` - I'm not sure why it wasn't supported in the first place, so I'd definitely like another pair of eye to look at this.

This PR also makes a minor update that allows to use annotations to implement `AutoHashable` conformance.

This updated template has been in use in a production project for some time and no issues have been found with it so far. I would like it to have a first round of review before more extensive testing.

As a side note, since this doesn't touch the code but rather a template, I decided creating a PR directly is fine.