### PR TITLE
Add EnumsDefaults template

### DIFF
--- a/Templates/Templates.xcodeproj/project.pbxproj
+++ b/Templates/Templates.xcodeproj/project.pbxproj
@@ -43,6 +43,11 @@
 		6DC27BD81EC6592700B73CAF /* AutoHashable.expected in Resources */ = {isa = PBXBuildFile; fileRef = 6DC27BD71EC6592700B73CAF /* AutoHashable.expected */; };
 		B50435DF2157222E00F120DF /* AutoCodable.expected in Resources */ = {isa = PBXBuildFile; fileRef = 636D786B2083B8D700160CC4 /* AutoCodable.expected */; };
 		C03FD2E6F7645376C192094D /* Pods_TemplatesTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26AD1250F60484521E03C14A /* Pods_TemplatesTests.framework */; };
+		DFBDBE68218CC9DC009AD3D2 /* EnumsDefaults.swifttemplate in Resources */ = {isa = PBXBuildFile; fileRef = DFBDBE67218CC9DC009AD3D2 /* EnumsDefaults.swifttemplate */; };
+		DFBDBE6A218CC9EC009AD3D2 /* EnumsDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBDBE69218CC9EC009AD3D2 /* EnumsDefaults.swift */; };
+		DFBDBE6C218CCAC6009AD3D2 /* EnumsDefaults.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBDBE6B218CCAC6009AD3D2 /* EnumsDefaults.generated.swift */; };
+		DFBDBE6E218CCC7E009AD3D2 /* EnumsDefaults.expected in Resources */ = {isa = PBXBuildFile; fileRef = DFBDBE6D218CCC7E009AD3D2 /* EnumsDefaults.expected */; };
+		DFBDBE70218CCD60009AD3D2 /* EnumsDefaults.generated.swift in Resources */ = {isa = PBXBuildFile; fileRef = DFBDBE6B218CCAC6009AD3D2 /* EnumsDefaults.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -112,6 +117,10 @@
 		8BC863822106BD763A8B145B /* Pods-TemplatesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TemplatesTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-TemplatesTests/Pods-TemplatesTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A4E640041AB8FBF997174F87 /* Pods-CodableContextTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CodableContextTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-CodableContextTests/Pods-CodableContextTests.debug.xcconfig"; sourceTree = "<group>"; };
 		AD6C4A9866B1F8FDB6B02DA5 /* Pods-TemplatesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TemplatesTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-TemplatesTests/Pods-TemplatesTests.release.xcconfig"; sourceTree = "<group>"; };
+		DFBDBE67218CC9DC009AD3D2 /* EnumsDefaults.swifttemplate */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EnumsDefaults.swifttemplate; sourceTree = "<group>"; };
+		DFBDBE69218CC9EC009AD3D2 /* EnumsDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumsDefaults.swift; sourceTree = "<group>"; };
+		DFBDBE6B218CCAC6009AD3D2 /* EnumsDefaults.generated.swift */ = {isa = PBXFileReference; explicitFileType = text; fileEncoding = 4; path = EnumsDefaults.generated.swift; sourceTree = "<group>"; };
+		DFBDBE6D218CCC7E009AD3D2 /* EnumsDefaults.expected */ = {isa = PBXFileReference; lastKnownFileType = text; path = EnumsDefaults.expected; sourceTree = "<group>"; };
 		E0F526BDFB067A8F16ACE2F6 /* Pods-CodableContextTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CodableContextTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-CodableContextTests/Pods-CodableContextTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -183,6 +192,7 @@
 				6D6645C41ECC184A004C1948 /* AutoMockable.swift */,
 				6D6645C91ECC219C004C1948 /* LinuxMain.swift */,
 				636D78492080256500160CC4 /* AutoCodable.swift */,
+				DFBDBE69218CC9EC009AD3D2 /* EnumsDefaults.swift */,
 			);
 			path = Context;
 			sourceTree = "<group>";
@@ -197,6 +207,7 @@
 				6D6645C21ECC1824004C1948 /* AutoMockable.expected */,
 				6D6645C71ECC2187004C1948 /* LinuxMain.expected */,
 				636D786B2083B8D700160CC4 /* AutoCodable.expected */,
+				DFBDBE6D218CCC7E009AD3D2 /* EnumsDefaults.expected */,
 			);
 			path = Expected;
 			sourceTree = "<group>";
@@ -211,6 +222,7 @@
 				6D342C9A1EBA3156006EEBEC /* AutoLenses.generated.swift */,
 				6D342C9B1EBA3156006EEBEC /* LinuxMain.generated.swift */,
 				636D784C208169E100160CC4 /* AutoCodable.generated.swift */,
+				DFBDBE6B218CCAC6009AD3D2 /* EnumsDefaults.generated.swift */,
 			);
 			path = Generated;
 			sourceTree = "<group>";
@@ -249,6 +261,7 @@
 				6D342C801EBA13DF006EEBEC /* AutoMockable.stencil */,
 				6D342C821EBA13DF006EEBEC /* LinuxMain.stencil */,
 				636D78472080251800160CC4 /* AutoCodable.swifttemplate */,
+				DFBDBE67218CC9DC009AD3D2 /* EnumsDefaults.swifttemplate */,
 			);
 			path = Templates;
 			sourceTree = "<group>";
@@ -410,6 +423,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DFBDBE70218CCD60009AD3D2 /* EnumsDefaults.generated.swift in Resources */,
 				6D4D84481EC667630005932D /* AutoEquatable.generated.swift in Resources */,
 				6D6645C61ECC1CAA004C1948 /* AutoMockable.generated.swift in Resources */,
 				6D6645C31ECC1824004C1948 /* AutoMockable.expected in Resources */,
@@ -422,12 +436,14 @@
 				6D342C891EBA13DF006EEBEC /* LinuxMain.stencil in Resources */,
 				6D130B7C1ECACEB800E9642A /* AutoLenses.generated.swift in Resources */,
 				6D342C871EBA13DF006EEBEC /* AutoMockable.stencil in Resources */,
+				DFBDBE68218CC9DC009AD3D2 /* EnumsDefaults.swifttemplate in Resources */,
 				6D4D84491EC667650005932D /* AutoHashable.generated.swift in Resources */,
 				6D342C861EBA13DF006EEBEC /* AutoLenses.stencil in Resources */,
 				6D342C851EBA13DF006EEBEC /* AutoHashable.stencil in Resources */,
 				6DC27BD81EC6592700B73CAF /* AutoHashable.expected in Resources */,
 				6D342C831EBA13DF006EEBEC /* AutoCases.stencil in Resources */,
 				636D78572081781E00160CC4 /* AutoCodable.swifttemplate in Resources */,
+				DFBDBE6E218CCC7E009AD3D2 /* EnumsDefaults.expected in Resources */,
 				6D342CA31EBA5415006EEBEC /* AutoCases.expected in Resources */,
 				6D342CA41EBA54DF006EEBEC /* AutoCases.generated.swift in Resources */,
 				6D037EA31EC26E6A00FA6C91 /* AutoEquatable.expected in Resources */,
@@ -552,11 +568,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				6D037EA11EC26E6300FA6C91 /* AutoEquatable.swift in Sources */,
+				DFBDBE6C218CCAC6009AD3D2 /* EnumsDefaults.generated.swift in Sources */,
 				6D130B791ECACCDF00E9642A /* AutoLenses.swift in Sources */,
 				6D342C941EBA155A006EEBEC /* AutoCases.swift in Sources */,
 				6D6645C51ECC184A004C1948 /* AutoMockable.swift in Sources */,
 				6D0AF6BC1EC5EDD100F9A410 /* AutoHashable.swift in Sources */,
 				6D342C911EBA146F006EEBEC /* TemplatesTests.swift in Sources */,
+				DFBDBE6A218CC9EC009AD3D2 /* EnumsDefaults.swift in Sources */,
 				6D6645CA1ECC219C004C1948 /* LinuxMain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Templates/Templates/EnumsDefaults.swifttemplate
+++ b/Templates/Templates/EnumsDefaults.swifttemplate
@@ -1,0 +1,74 @@
+// swiftlint:disable all
+
+<%
+typealias CaseInfo = (localName: String?, externalName: String, typeName: String, isClosure: Bool, defaultValue: String?)
+
+for type in types.enums where type.hasAssociatedValues {
+	var allValues: [String: [CaseInfo]] = [:]
+	for `case` in type.cases {
+		for (index, associatedValue) in `case`.associatedValues.enumerated() {
+			let associatedValueLocalName = associatedValue.localName
+			let associatedValueExternalName = associatedValue.externalName ?? "data"
+			let defaultValue = `case`.annotations[associatedValueExternalName] as? String
+			allValues[`case`.name, default: []].append((associatedValueLocalName, "arg\(index)", associatedValue.typeName.name, associatedValue.typeName.isClosure && !associatedValue.typeName.isOptional, defaultValue))
+		}
+	}
+
+	if allValues.flatMap({ $0.value }).compactMap({ $0.defaultValue }).isEmpty {
+		continue
+	}
+
+-%>
+extension <%= type.name %> {
+<%
+
+for (associatedValueName, allValues) in allValues {
+	func combos(_ elements: [CaseInfo]) -> [[CaseInfo]] {
+		guard let first = elements.first else {
+			return [[]]
+		}
+
+		var result: [[CaseInfo]] = []
+		let subcombos = combos(Array(elements.dropFirst()))
+		if first.defaultValue != nil {
+			result += subcombos.map { [(first.localName, first.externalName, first.typeName, first.isClosure, nil)] + $0 }
+		}
+		result += subcombos.map { [first] + $0 }
+		return result
+	}
+
+	var allCombinations: [[CaseInfo]] = combos(allValues)
+
+	for combinations in allCombinations where combinations.contains(where: { $0.defaultValue != nil }) {
+		let allParameters = combinations.filter { $0.defaultValue == nil }
+	-%>
+	<%= type.accessLevel %> static <% if allParameters.isEmpty { -%>var<% } else { -%>func<% } -%> <%= associatedValueName %><% if !allParameters.isEmpty { -%>(<% } %>
+<%
+		for i in allParameters.indices {
+			let (localName, externalName, typeName, isClosure, defaultValue) = allParameters[i]
+-%>
+			<% if let localName = localName { -%><%= localName %> <% } else {-%>_ <% } -%><%= externalName %>: <% if isClosure { -%>@escaping <% } -%><%= typeName %><% if i < allParameters.count - 1 { -%>,<% } -%><%_ %>
+<%
+		}
+-%>
+		<% if allParameters.isEmpty { -%>:<% } else { -%>) -><% } -%> <%= type.name %> {
+		return .<%= associatedValueName %>(
+			<%
+		for i in combinations.indices {
+			let (localName, externalName, typeName, _, defaultValue) = combinations[i]
+-%>
+			<%_ %><% if let localName = localName { -%><%= localName %>: <% }; if let defaultValue = defaultValue { -%><%= defaultValue %><% } else { -%><%= externalName %><% } -%><% if i < combinations.count - 1 { -%>,
+			<% } -%>
+<%
+		}
+-%><%_ %>
+		)
+	}
+
+<%
+	}
+}
+-%><%_ %>
+}
+
+<%_ } -%>

--- a/Templates/Tests/Context/EnumsDefaults.swift
+++ b/Templates/Tests/Context/EnumsDefaults.swift
@@ -1,0 +1,28 @@
+//
+//  EnumsDefaults.swift
+//  TemplatesTests
+//
+//  Created by Stéphane Copin on 11/2/18.
+//  Copyright © 2018 Pixle. All rights reserved.
+//
+
+import Foundation
+
+protocol Protocol {
+
+}
+
+final class DefaultImplementation: Protocol {
+
+}
+
+enum AssociatedVariablesEnum {
+	// sourcery: a = '"test"', b = "true", c = "0", d = "nil"
+	case one(a: String, b: Bool, c: Int, d: Any?)
+	// sourcery: 0 = '"test"'
+	case two(String, Bool, Int, d: Any?)
+	// sourcery: a = '"test"', d = "nil", c = "true", 1 = "true"
+	case three(a: String, b: Bool, c: Int, d: Any?)
+	// sourcery: a = '"test"', c = "true", 1 = "true", d = "DefaultImplementation()"
+	case four(a: String, b: Bool, c: Int, d: Protocol)
+}

--- a/Templates/Tests/Expected/EnumsDefaults.expected
+++ b/Templates/Tests/Expected/EnumsDefaults.expected
@@ -1,0 +1,369 @@
+// swiftlint:disable all
+
+extension AssociatedVariablesEnum {
+	internal static func two(
+			_ arg1: Bool,
+			_ arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .two(
+			"test",
+			arg1,
+			arg2,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: arg1,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			b arg1: Bool,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: arg1,
+			c: 0,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: arg1,
+			c: 0,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			c arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: true,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: true,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: true,
+			c: 0,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			a arg0: String
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: true,
+			c: 0,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			b arg1: Bool,
+			c arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			b arg1: Bool,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: arg1,
+			c: 0,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: arg1,
+			c: 0,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			c arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: true,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: true,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: true,
+			c: 0,
+			d: arg3
+		)
+	}
+
+	internal static var one
+		: AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: true,
+			c: 0,
+			d: nil
+		)
+	}
+
+	internal static func four(
+			a arg0: String,
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: arg0,
+			b: arg1,
+			c: arg2,
+			d: DefaultImplementation()
+		)
+	}
+
+	internal static func four(
+			a arg0: String,
+			b arg1: Bool,
+			d arg3: Protocol
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: arg0,
+			b: arg1,
+			c: true,
+			d: arg3
+		)
+	}
+
+	internal static func four(
+			a arg0: String,
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: arg0,
+			b: arg1,
+			c: true,
+			d: DefaultImplementation()
+		)
+	}
+
+	internal static func four(
+			b arg1: Bool,
+			c arg2: Int,
+			d arg3: Protocol
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func four(
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: DefaultImplementation()
+		)
+	}
+
+	internal static func four(
+			b arg1: Bool,
+			d arg3: Protocol
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: "test",
+			b: arg1,
+			c: true,
+			d: arg3
+		)
+	}
+
+	internal static func four(
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: "test",
+			b: arg1,
+			c: true,
+			d: DefaultImplementation()
+		)
+	}
+
+	internal static func three(
+			a arg0: String,
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: arg0,
+			b: arg1,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func three(
+			a arg0: String,
+			b arg1: Bool,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: arg0,
+			b: arg1,
+			c: true,
+			d: arg3
+		)
+	}
+
+	internal static func three(
+			a arg0: String,
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: arg0,
+			b: arg1,
+			c: true,
+			d: nil
+		)
+	}
+
+	internal static func three(
+			b arg1: Bool,
+			c arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func three(
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func three(
+			b arg1: Bool,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: "test",
+			b: arg1,
+			c: true,
+			d: arg3
+		)
+	}
+
+	internal static func three(
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: "test",
+			b: arg1,
+			c: true,
+			d: nil
+		)
+	}
+
+
+}
+

--- a/Templates/Tests/Generated/EnumsDefaults.generated.swift
+++ b/Templates/Tests/Generated/EnumsDefaults.generated.swift
@@ -1,0 +1,372 @@
+// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable all
+
+extension AssociatedVariablesEnum {
+	internal static func three(
+			a arg0: String,
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: arg0,
+			b: arg1,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func three(
+			a arg0: String,
+			b arg1: Bool,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: arg0,
+			b: arg1,
+			c: true,
+			d: arg3
+		)
+	}
+
+	internal static func three(
+			a arg0: String,
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: arg0,
+			b: arg1,
+			c: true,
+			d: nil
+		)
+	}
+
+	internal static func three(
+			b arg1: Bool,
+			c arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func three(
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func three(
+			b arg1: Bool,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: "test",
+			b: arg1,
+			c: true,
+			d: arg3
+		)
+	}
+
+	internal static func three(
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .three(
+			a: "test",
+			b: arg1,
+			c: true,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: arg1,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			b arg1: Bool,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: arg1,
+			c: 0,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: arg1,
+			c: 0,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			c arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: true,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: true,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			a arg0: String,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: true,
+			c: 0,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			a arg0: String
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: arg0,
+			b: true,
+			c: 0,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			b arg1: Bool,
+			c arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			b arg1: Bool,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: arg1,
+			c: 0,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: arg1,
+			c: 0,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			c arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: true,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func one(
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: true,
+			c: arg2,
+			d: nil
+		)
+	}
+
+	internal static func one(
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: true,
+			c: 0,
+			d: arg3
+		)
+	}
+
+	internal static var one
+		: AssociatedVariablesEnum {
+		return .one(
+			a: "test",
+			b: true,
+			c: 0,
+			d: nil
+		)
+	}
+
+	internal static func two(
+			_ arg1: Bool,
+			_ arg2: Int,
+			d arg3: Any?
+		) -> AssociatedVariablesEnum {
+		return .two(
+			"test",
+			arg1,
+			arg2,
+			d: arg3
+		)
+	}
+
+	internal static func four(
+			a arg0: String,
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: arg0,
+			b: arg1,
+			c: arg2,
+			d: DefaultImplementation()
+		)
+	}
+
+	internal static func four(
+			a arg0: String,
+			b arg1: Bool,
+			d arg3: Protocol
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: arg0,
+			b: arg1,
+			c: true,
+			d: arg3
+		)
+	}
+
+	internal static func four(
+			a arg0: String,
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: arg0,
+			b: arg1,
+			c: true,
+			d: DefaultImplementation()
+		)
+	}
+
+	internal static func four(
+			b arg1: Bool,
+			c arg2: Int,
+			d arg3: Protocol
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: arg3
+		)
+	}
+
+	internal static func four(
+			b arg1: Bool,
+			c arg2: Int
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: "test",
+			b: arg1,
+			c: arg2,
+			d: DefaultImplementation()
+		)
+	}
+
+	internal static func four(
+			b arg1: Bool,
+			d arg3: Protocol
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: "test",
+			b: arg1,
+			c: true,
+			d: arg3
+		)
+	}
+
+	internal static func four(
+			b arg1: Bool
+		) -> AssociatedVariablesEnum {
+		return .four(
+			a: "test",
+			b: arg1,
+			c: true,
+			d: DefaultImplementation()
+		)
+	}
+
+
+}
+

--- a/Templates/Tests/TemplatesTests.swift
+++ b/Templates/Tests/TemplatesTests.swift
@@ -69,5 +69,11 @@ class TemplatesTests: QuickSpec {
                 check(template: "AutoCodable")
             }
         }
+
+        describe("EnumsDefaults template") {
+            it("generates expected code") {
+                check(template: "EnumsDefaults")
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new template that generates helper functions allowing to use default values for Swift's enumerations with associated values, using sourcery's annotations system.
For example, with this template, consider the following enumeration:
```
enum AssociatedVariablesEnum {
	// sourcery: a = '"test"', b = "true", c = "0", d = "nil"
	case one(a: String, b: Bool, c: Int, d: Any?)
	// sourcery: 0 = '"test"'
	case two(String, Bool, Int, d: Any?)
	// sourcery: a = '"test"', d = "nil", c = "true", 1 = "true"
	case three(a: String, b: Bool, c: Int, d: Any?)
	// sourcery: a = '"test"', c = "true", 1 = "true", d = "DefaultImplementation()"
	case four(a: String, b: Bool, c: Int, d: Protocol)
}
```
may then be used in the following way:
```
let test1: AssociatedVariablesEnum = .one
let test2: AssociatedVariablesEnum = .two(d: nil)
let test3: AssociatedVariablesEnum = .three(true, 0, d: nil)
let test4: AssociatedVariablesEnum = .four(b: true, 0)
```
And all the other combinations of default parameters.
The variable name has to be used to specify its default value, and if the variable name is not specified then its parameter index can be specified.

Swift prevents by default from adding a static function that adds the default value:
```
enum Test {
    case test(String?)

    static func test(_ value: String? = nil) { // Will not compile
        return .test(value)
    }
}
```
However, with overloading it become possible to do it without an ambiguity:
```
enum Test {
    case test(String?)

    static func test() { // Works
        return .test(nil)
    }
}
```
Writing such overloads is possible to do manually for a small amount of default values, but as you can see from the size of the generated file, it can quickly get out of hand (and unmaintanable), hence how this template was born.

I'd love to get feedback (also the name can change, I had no inspiration for a short but meaningful name).