### PR TITLE
Added `optional` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ---
 ## Master
 
+- Support for `optional` methods in ObjC protocols
 - Support for parsing lazy vars into Variable's attributes.
 - Updated Stencil to 0.13.1 and SwiftStencilKit to 2.7.0
 - In Swift templates CLI arguments should now be accessed via `argument` instead of `arguments`, to be consistent with Stencil and JS templates.

--- a/SourceryRuntime/Sources/Attribute.swift
+++ b/SourceryRuntime/Sources/Attribute.swift
@@ -60,6 +60,7 @@ import Foundation
         case internalSetter = "setter_access.internal"
         case privateSetter = "setter_access.private"
         case fileprivateSetter = "setter_access.fileprivate"
+        case optional
 
         public init?(identifier: String) {
             let identifier = identifier.trimmingPrefix("source.decl.attribute.")

--- a/SourceryRuntime/Sources/Method.swift
+++ b/SourceryRuntime/Sources/Method.swift
@@ -205,6 +205,12 @@ public typealias SourceryMethod = Method
         return shortName.hasSuffix(">")
     }
 
+    // sourcery: skipEquality, skipDescription
+    /// Whether method is optional (in an Objective-C protocol)
+    public var isOptional: Bool {
+        return attributes[Attribute.Identifier.optional.name] != nil
+    }
+
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
     public let annotations: [String: NSObject]
 

--- a/SourceryTests/Parsing/FileParser + AttributesSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AttributesSpec.swift
@@ -91,6 +91,11 @@ class FileParserAttributesSpec: QuickSpec {
                 expect(parse("class Foo { final func some() {} }").first?.methods.first?.attributes).to(equal([
                     "final": Attribute(name: "final", description: "final")
                     ]))
+
+                expect(parse("@objc protocol Foo { @objc optional func some() {} }").first?.methods.first?.attributes).to(equal([
+                    "objc": Attribute(name: "objc", description: "@objc"),
+                    "optional": Attribute(name: "optional", description: "optional")
+                    ]))
             }
 
             it("extracts method parameter attributes") {


### PR DESCRIPTION
Protocols exposed to ObjC may have methods with `optional` attribute, e.g.

```swift
@objc protocol MyProto {
    @objc optional func someFunc()
}
```

translates to

```objc
@protocol MyProto
@optional
- (void)someFunc;
@end
```

in ObjC.

Apparently Sourcery has been missing the `optional` attribute, hence this PR.