### PR TITLE
Make sure function with implicit optional return types mock closure r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ---
 ## Master
 
+- Fixes warning in generated AutoMockable methods that have implicit optional return values
 - Support for `optional` methods in ObjC protocols
 - Support for parsing lazy vars into Variable's attributes.
 - Updated Stencil to 0.13.1 and SwiftStencilKit to 2.7.0

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -32,8 +32,10 @@ import AppKit
 
 {% macro methodClosureName method %}{% call swiftifyMethodName method.selectorName %}Closure{% endmacro %}
 
+{% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
+
 {% macro methodClosureDeclaration method %}
-    var {% call methodClosureName method %}: (({% for param in method.parameters %}{{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{{ method.returnTypeName }}{% endif %})?
+    var {% call methodClosureName method %}: (({% for param in method.parameters %}{{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call closureReturnTypeName method %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -18,6 +18,10 @@ protocol BasicProtocol: AutoMockable {
     func save(configuration: String)
 }
 
+protocol ImplicitlyUnwrappedOptionalReturnValueProtocol: AutoMockable {
+  func implicitReturn() -> String!
+}
+
 protocol InitializationProtocol: AutoMockable {
     init(intParameter: Int, stringParameter: String, optionalParameter: String?)
     func start()

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -115,6 +115,23 @@ class ExtendableProtocolMock: ExtendableProtocol {
     }
 
 }
+class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOptionalReturnValueProtocol {
+
+    //MARK: - implicitReturn
+
+    var implicitReturnCallsCount = 0
+    var implicitReturnCalled: Bool {
+        return implicitReturnCallsCount > 0
+    }
+    var implicitReturnReturnValue: String!
+    var implicitReturnClosure: (() -> String?)?
+
+    func implicitReturn() -> String! {
+        implicitReturnCallsCount += 1
+        return implicitReturnClosure.map({ $0() }) ?? implicitReturnReturnValue
+    }
+
+}
 class InitializationProtocolMock: InitializationProtocol {
 
     //MARK: - init

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -23,6 +23,7 @@ import AppKit
 
 
 
+
 class AnnotatedProtocolMock: AnnotatedProtocol {
 
     //MARK: - sayHelloWith
@@ -129,6 +130,23 @@ class ExtendableProtocolMock: ExtendableProtocol {
         reportMessageCallsCount += 1
         reportMessageReceivedMessage = message
         reportMessageClosure?(message)
+    }
+
+}
+class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOptionalReturnValueProtocol {
+
+    //MARK: - implicitReturn
+
+    var implicitReturnCallsCount = 0
+    var implicitReturnCalled: Bool {
+        return implicitReturnCallsCount > 0
+    }
+    var implicitReturnReturnValue: String!
+    var implicitReturnClosure: (() -> String?)?
+
+    func implicitReturn() -> String! {
+        implicitReturnCallsCount += 1
+        return implicitReturnClosure.map({ $0() }) ?? implicitReturnReturnValue
     }
 
 }


### PR DESCRIPTION
…eturn type is optional to prevent compiler warning.

Fixes https://github.com/krzysztofzablocki/Sourcery/issues/704