### PR TITLE
Fix templates for AutoMockable.stencil

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -53,7 +53,7 @@ import AppKit
     {% if method.parameters.count == 1 %}
     var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
     {% elif not method.parameters.count == 0 %}
-    var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})?
+    var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})?
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
     var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ method.returnTypeName }}{{ '!' if not method.isOptionalReturnType }}


### PR DESCRIPTION
## What
Fix templates for AutoMockable.stencil

## Why
I got this error after the command.
I guess to use missing format and it was using old templates.

```
$ sourcery --sources ./SourceryDemo/ViewController.swift --templates ./templates/AutoMockable.stencil --output ./SourceryDemo/Generated/Mock.generated.swift
```

```
sourcery --sources ./SourceryDemo/Demo.swift --templates ./templates/AutoMockable.stencil --output ./SourceryDemo/Generated/Mock.generated.swift                            
No config file provided or it does not exist. Using command line arguments.
Scanning sources...
Found 9 types.
Loading templates...
Loaded 1 templates.
Generating code...
2018-12-14 17:52:05.997 sourcery[3633:2254158] *** Terminating app due to uncaught exception 'NSUnknownKeyException', reason: '[<SourceryRuntime.MethodParameter 0x7fc210c14b00> valueForUndefinedKey:]: this class is not key value coding-compliant for the key unwrappedTypeName if param.'
*** First throw call stack:
(
        0   CoreFoundation                      0x00007fff424cae65 __exceptionPreprocess + 256
        1   libobjc.A.dylib                     0x00007fff6e526720 objc_exception_throw + 48
        2   CoreFoundation                      0x00007fff424e48e5 -[NSException raise] + 9
        3   Foundation                          0x00007fff448fcb74 -[NSObject(NSKeyValueCoding) valueForUndefinedKey:] + 226
        4   Foundation                          0x00007fff447843a4 -[NSObject(NSKeyValueCoding) valueForKey:] + 284
        5   sourcery                            0x000000010348ba67 $S7Stencil8VariableV7resolveyypSgAA7ContextCKF + 2007
        6   sourcery                            0x000000010348ca3c $S7Stencil16FilterExpressionC7resolveyypSgAA7ContextCKF + 44
        7   sourcery                            0x000000010348cef0 $S7Stencil16FilterExpressionCAA10ResolvableA2aDP7resolveyypSgAA7ContextCKFTW + 16
        8   sourcery                            0x000000010347e6e9 $S7Stencil12VariableNodeCAA0C4TypeA2aDP6renderySSAA7ContextCKFTW + 73
        9   sourcery                            0x000000010345fd91 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_SSyKXEfU_SSyKXEfU_ + 241
        10  sourcery                            0x0000000103462681 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_SSyKXEfU_SSyKXEfU_TA + 17
        11  sourcery                            0x000000010345cbd8 $S7Stencil7ForNodeC4push5value7context7closurexyp_AA7ContextCxyKXEtKlFSS_Tg535$SSSs5Error_pIgozo_SSsAA_pIegrzo_TRSSs0J0_pIgozo_Tf1nncn_n + 1016
        12  sourcery                            0x000000010345fb16 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_ + 934
        13  sourcery                            0x000000010345e6c9 $S7Stencil7ForNodeC6renderySSAA7ContextCKF + 4201
        14  sourcery                            0x0000000103460100 $S7Stencil7ForNodeCAA0C4TypeA2aDP6renderySSAA7ContextCKFTW + 16
        15  sourcery                            0x0000000103463aec $S7Stencil11IfConditionC6renderySSAA7ContextCKF + 412
        16  sourcery                            0x0000000103466135 $S7Stencil6IfNodeC6renderySSAA7ContextCKF + 469
        17  sourcery                            0x00000001034666b0 $S7Stencil6IfNodeCAA0C4TypeA2aDP6renderySSAA7ContextCKFTW + 16
        18  sourcery                            0x000000010347d3a1 $S7Stencil11renderNodesySSSayAA8NodeType_pG_AA7ContextCtKF + 241
        19  sourcery                            0x000000010349426c $S15StencilSwiftKit8CallNodeC6renderySS0A07ContextCKFSSyKXEfU_TA + 44
        20  sourcery                            0x000000010349c54f $SSSs5Error_pIgozo_SSsAA_pIegrzo_TR + 15
        21  sourcery                            0x00000001034942d1 $SSSs5Error_pIgozo_SSsAA_pIegrzo_TRTA + 17
        22  sourcery                            0x000000010344b26c $S7Stencil7ContextC4push10dictionary7closurexSDySSypGSg_xyKXEtKlF + 188
        23  sourcery                            0x00000001034935c2 $S15StencilSwiftKit8CallNodeC6renderySS0A07ContextCKF + 738
        24  sourcery                            0x00000001034936d0 $S15StencilSwiftKit8CallNodeC0A00E4TypeAadEP6renderySSAD7ContextCKFTW + 16
        25  sourcery                            0x000000010345fd91 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_SSyKXEfU_SSyKXEfU_ + 241
        26  sourcery                            0x0000000103462681 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_SSyKXEfU_SSyKXEfU_TA + 17
        27  sourcery                            0x000000010345cbd8 $S7Stencil7ForNodeC4push5value7context7closurexyp_AA7ContextCxyKXEtKlFSS_Tg535$SSSs5Error_pIgozo_SSsAA_pIegrzo_TRSSs0J0_pIgozo_Tf1nncn_n + 1016
        28  sourcery                            0x000000010345fb16 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_ + 934
        29  sourcery                            0x000000010345e6c9 $S7Stencil7ForNodeC6renderySSAA7ContextCKF + 4201
        30  sourcery                            0x0000000103460100 $S7Stencil7ForNodeCAA0C4TypeA2aDP6renderySSAA7ContextCKFTW + 16
        31  sourcery                            0x0000000103463aec $S7Stencil11IfConditionC6renderySSAA7ContextCKF + 412
        32  sourcery                            0x0000000103466135 $S7Stencil6IfNodeC6renderySSAA7ContextCKF + 469
        33  sourcery                            0x00000001034666b0 $S7Stencil6IfNodeCAA0C4TypeA2aDP6renderySSAA7ContextCKFTW + 16
        34  sourcery                            0x000000010345fd91 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_SSyKXEfU_SSyKXEfU_ + 241
        35  sourcery                            0x0000000103462681 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_SSyKXEfU_SSyKXEfU_TA + 17
        36  sourcery                            0x000000010345cbd8 $S7Stencil7ForNodeC4push5value7context7closurexyp_AA7ContextCxyKXEtKlFSS_Tg535$SSSs5Error_pIgozo_SSsAA_pIegrzo_TRSSs0J0_pIgozo_Tf1nncn_n + 1016
        37  sourcery                            0x000000010345fb16 $S7Stencil7ForNodeC6renderySSAA7ContextCKFSSSi_yptKXEfU1_ + 934
        38  sourcery                            0x000000010345e6c9 $S7Stencil7ForNodeC6renderySSAA7ContextCKF + 4201
        39  sourcery                            0x0000000103460100 $S7Stencil7ForNodeCAA0C4TypeA2aDP6renderySSAA7ContextCKFTW + 16
        40  sourcery                            0x0000000103486b4c $S7Stencil8TemplateC6renderySSAA7ContextCKF + 396
        41  sourcery                            0x0000000103486ea2 $S7Stencil8TemplateC6renderySSSDySSypGSgKF + 130
        42  sourcery                            0x00000001034a472b $S15StencilSwiftKit0aB8TemplateC6renderySSSDySSypGSgKF + 43
        43  sourcery                            0x00000001033722eb $S8Sourcery15StencilTemplateC6renderySS0A7Runtime0C7ContextCKF + 59
        44  sourcery                            0x00000001033758b0 $S8Sourcery15StencilTemplateCAA0C0A2aDP6renderySS0A7Runtime0C7ContextCKFTW + 16
        45  sourcery                            0x0000000103370f05 $S8Sourcery9GeneratorO8generate_8template9argumentsSS0A7Runtime5TypesC_AA8Template_pSDySSSo8NSObjectCGtKFZTf4nnnd_n + 437
        46  sourcery                            0x00000001033be54a $S8SourceryAAC8generate33_DB5C4364BFA94633EE953DD412A08C30LL_16forParsingResult10outputPathSSAA8Template_p_0A7Runtime5TypesC5types_SaySS4file_SDySSSo8_NSRangeVG6rangestG12inlineRangest0N3Kit0N0VtKF + 826
        47  sourcery                            0x00000001033cbf2d $S8SourceryAAC8generate33_DB5C4364BFA94633EE953DD412A08C30LL6source13templatePaths6output13parsingResultyAA6SourceO_AA0L0VAA6OutputV0A7Runtime5TypesC5types_SaySS4file_SDySSSo8_NSRangeVG6rangestG12inlineRangesttKFTf4dxnnnn_n + 1501
        48  sourcery                            0x00000001033cd0b6 $S8SourceryAAC12processFiles_14usingTemplates6output10forceParseSayAA13FolderWatcherO5LocalCGSgAA6SourceO_AA5PathsVAA6OutputVSaySSGtKF0A7Runtime5TypesC5types_SaySS4file_SDySSSo8_NSRangeVG6rangestG12inlineRangestANKcfU1_Tf4nnnxn_n + 3542
        49  sourcery                            0x00000001033ce053 $S8SourceryAAC12processFiles_14usingTemplates6output10forceParseSayAA13FolderWatcherO5LocalCGSgAA6SourceO_AA5PathsVAA6OutputVSaySSGtKFTf4nxnnn_n + 1843
        50  sourcery                            0x0000000103361c0e $S8Sourcery6runCLIyyFySb_S4bSay7PathKit0D0VGA3f2ESaySSGAgEtcfU_ + 2238
        51  sourcery                            0x0000000103362230 $SS5bSay7PathKit0A0VGA3d2CSaySSGAeCs5Error_pIegyyyyyggggnnggnzo_S5bA4d2c2eCsAF_pIegnnnnnnnnnnnnnnzo_TR032$S8Sourcery6runCLIyyFySb_S4bSay7A27Kit0D0VGA3f2ESaySSGAgEtcfU_Tf3nnnnnnnnnnnnnnpf_n + 80
        52  sourcery                            0x00000001032cd2ff $S9Commander7commandyAA11CommandType_px_q_q0_q1_q2_q3_q4_q5_q6_q7_q8_q9_q10_q11_y05ValueD0Qz_ADQy_ADQy0_ADQy1_ADQy2_ADQy3_ADQy4_ADQy5_ADQy6_ADQy7_ADQy8_ADQy9_ADQy10_ADQy11_tKctAA18ArgumentDescriptorRzAaSR_AaSR0_AaSR1_AaSR2_AaSR3_AaSR4_AaSR5_AaSR6_AaSR7_AaSR8_AaSR9_AaSR10_AaSR11_r12_lFyAA0F6ParserCKcfU_ + 4815
        53  sourcery                            0x00000001032cd607 $S9Commander7commandyAA11CommandType_px_q_q0_q1_q2_q3_q4_q5_q6_q7_q8_q9_q10_q11_y05ValueD0Qz_ADQy_ADQy0_ADQy1_ADQy2_ADQy3_ADQy4_ADQy5_ADQy6_ADQy7_ADQy8_ADQy9_ADQy10_ADQy11_tKctAA18ArgumentDescriptorRzAaSR_AaSR0_AaSR1_AaSR2_AaSR3_AaSR4_AaSR5_AaSR6_AaSR7_AaSR8_AaSR9_AaSR10_AaSR11_r12_lFyAA0F6ParserCKcfU_TA + 279
        54  sourcery                            0x00000001032ba123 $S9Commander16AnonymousCommandVAA0C4TypeA2aDP3runyyAA14ArgumentParserCKFTW + 51
        55  sourcery                            0x00000001032ba573 $S9Commander11CommandTypePAAE3runys5NeverOSSSgF + 403
        56  sourcery                            0x000000010336134a $S8Sourcery6runCLIyyF + 2314
        57  sourcery                            0x000000010335fdb3 main + 115
        58  libdyld.dylib                       0x00007fff6f5f508d start + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
[1]    3633 abort      sourcery --sources ./SourceryDemo/Demo.swift --templates  --output
```

### Environment
```
$ sourcery --version                                                                                                                                               
0.15.0
```

