### PR TITLE
Use updated version of SwiftTryCatch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten.git", .exact("0.21.2")),
         .package(url: "https://github.com/kylef/Stencil.git", .exact("0.13.1")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.7.0")),
-        .package(url: "https://github.com/seanparsons/SwiftTryCatch.git", .revision("e7074a72e4d4dc516f391bc4d4afd8ca6a845b4b")),
+        .package(url: "https://github.com/seanparsons/SwiftTryCatch.git", .exact("1.0.0")),
         .package(url: "https://github.com/tuist/xcodeproj", .exact("4.3.1")),
         .package(url: "https://github.com/tadija/AEXML.git", .exact("4.3.3")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten.git", .exact("0.21.2")),
         .package(url: "https://github.com/kylef/Stencil.git", .exact("0.13.1")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.7.0")),
-        .package(url: "https://github.com/seanparsons/SwiftTryCatch.git", .exact("1.0.0")),
+        .package(url: "https://github.com/seanparsons/SwiftTryCatch.git", .revision("6a177252cfa2ef649b0aa7b2d16ab221386ca51c")),
         .package(url: "https://github.com/tuist/xcodeproj", .exact("4.3.1")),
         .package(url: "https://github.com/tadija/AEXML.git", .exact("4.3.3")),
     ],


### PR DESCRIPTION
If I try to use Sourcery with Swift Package Manager, I get this error:

```
error: the package sourcery[https://github.com/krzysztofzablocki/Sourcery] @ 0.15.0 contains incompatible dependencies:
    swifttrycatch[https://github.com/seanparsons/SwiftTryCatch.git] @ e7074a72e4d4dc516f391bc4d4afd8ca6a845b4b
```

SwiftTryCatch has a released version now, so this should point to that version now, which should be compatible with swift 4.2.