### PR TITLE
Indent inline generated code to match the `// sourcery:inline:` annotation

### DIFF
--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -53,6 +53,7 @@ public final class FileParser {
     fileprivate var contents: String!
     fileprivate var annotations: AnnotationsParser!
     fileprivate var inlineRanges: [String: NSRange]!
+    fileprivate var inlineIndentations: [String: String]!
 
     fileprivate var logPrefix: String {
         return path.flatMap { "\($0):" } ?? ""
@@ -81,7 +82,8 @@ public final class FileParser {
 
         let inline = TemplateAnnotationsParser.parseAnnotations("inline", contents: initialContents)
         contents = inline.contents
-        inlineRanges = inline.annotatedRanges.mapValues({ $0[0] })
+        inlineRanges = inline.annotatedRanges.mapValues { $0[0].range }
+        inlineIndentations = inline.annotatedRanges.mapValues { $0[0].indentation }
         annotations = AnnotationsParser(contents: contents)
         return contents
     }
@@ -99,7 +101,7 @@ public final class FileParser {
         let source = try Structure(file: file).dictionary
 
         let (types, typealiases) = try parseTypes(source)
-        return FileParserResult(path: path, module: module, types: types, typealiases: typealiases, inlineRanges: inlineRanges, contentSha: initialContents.sha256() ?? "", sourceryVersion: Version.current.value)
+        return FileParserResult(path: path, module: module, types: types, typealiases: typealiases, inlineRanges: inlineRanges, inlineIndentations: inlineIndentations, contentSha: initialContents.sha256() ?? "", sourceryVersion: Version.current.value)
     }
 
     internal func parseTypes(_ source: [String: SourceKitRepresentable]) throws -> ([Type], [Typealias]) {

--- a/SourceryFramework/Sources/Parsing/Utils/InlineParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/InlineParser.swift
@@ -48,7 +48,6 @@ public enum TemplateAnnotationsParser {
             let endLineRange = result.range(at: 5)
 
             let indentation = bridged.substring(with: indentationRange)
-            print("indentation raw \(indentation) \(indentation.count)")
             let name = bridged.substring(with: nameRange)
             let range = NSRange(
                 location: startLineRange.location,

--- a/SourceryFramework/Sources/Parsing/Utils/InlineParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/InlineParser.swift
@@ -7,16 +7,18 @@ import Foundation
 
 public enum TemplateAnnotationsParser {
 
+    public typealias AnnotatedRanges = [String: [(range: NSRange, indentation: String)]]
+
     private static func regex(annotation: String) throws -> NSRegularExpression {
         let commentPattern = NSRegularExpression.escapedPattern(for: "//")
         let regex = try NSRegularExpression(
-            pattern: "(^\\s*?\(commentPattern)\\s*?sourcery:\(annotation):)(\\S*)\\s*?(^.*?)(^\\s*?\(commentPattern)\\s*?sourcery:end)",
+            pattern: "(^(?:\\s*?\\n)?(\\s*)\(commentPattern)\\s*?sourcery:\(annotation):)(\\S*)\\s*?(^.*?)(^\\s*?\(commentPattern)\\s*?sourcery:end)",
             options: [.allowCommentsAndWhitespace, .anchorsMatchLines, .dotMatchesLineSeparators]
         )
         return regex
     }
 
-    public static func parseAnnotations(_ annotation: String, contents: String, aggregate: Bool = false) -> (contents: String, annotatedRanges: [String: [NSRange]]) {
+    public static func parseAnnotations(_ annotation: String, contents: String, aggregate: Bool = false) -> (contents: String, annotatedRanges: AnnotatedRanges) {
         let (annotatedRanges, rangesToReplace) = annotationRanges(annotation, contents: contents, aggregate: aggregate)
 
         var bridged = contents.bridge()
@@ -28,22 +30,25 @@ public enum TemplateAnnotationsParser {
         return (bridged as String, annotatedRanges)
     }
 
-    public static func annotationRanges(_ annotation: String, contents: String, aggregate: Bool = false) -> (annotatedRanges: [String: [NSRange]], rangesToReplace: Set<NSRange>) {
+    public static func annotationRanges(_ annotation: String, contents: String, aggregate: Bool = false) -> (annotatedRanges: AnnotatedRanges, rangesToReplace: Set<NSRange>) {
         let bridged = contents.bridge()
         let regex = try? self.regex(annotation: annotation)
 
         var rangesToReplace = Set<NSRange>()
-        var annotatedRanges = [String: [NSRange]]()
+        var annotatedRanges = AnnotatedRanges()
 
         regex?.enumerateMatches(in: contents, options: [], range: bridged.entireRange) { result, _, _ in
-            guard let result = result, result.numberOfRanges == 5 else {
+            guard let result = result, result.numberOfRanges == 6 else {
                 return
             }
 
-            let nameRange = result.range(at: 2)
-            let startLineRange = result.range(at: 3)
-            let endLineRange = result.range(at: 4)
+            let indentationRange = result.range(at: 2)
+            let nameRange = result.range(at: 3)
+            let startLineRange = result.range(at: 4)
+            let endLineRange = result.range(at: 5)
 
+            let indentation = bridged.substring(with: indentationRange)
+            print("indentation raw \(indentation) \(indentation.count)")
             let name = bridged.substring(with: nameRange)
             let range = NSRange(
                 location: startLineRange.location,
@@ -51,10 +56,10 @@ public enum TemplateAnnotationsParser {
             )
             if aggregate {
                 var ranges = annotatedRanges[name] ?? []
-                ranges.append(range)
+                ranges.append((range: range, indentation: indentation))
                 annotatedRanges[name] = ranges
             } else {
-                annotatedRanges[name] = [range]
+                annotatedRanges[name] = [(range: range, indentation: indentation)]
             }
             rangesToReplace.insert(range)
         }
@@ -69,13 +74,13 @@ public enum TemplateAnnotationsParser {
         var rangesToReplace = [NSRange]()
 
         regex?.enumerateMatches(in: content, options: [], range: bridged.entireRange) { result, _, _ in
-            guard let result = result, result.numberOfRanges == 5 else {
+            guard let result = result, result.numberOfRanges == 6 else {
                 return
             }
 
             let annotationStartRange = result.range(at: 1)
-            let startLineRange = result.range(at: 3)
-            let endLineRange = result.range(at: 4)
+            let startLineRange = result.range(at: 4)
+            let endLineRange = result.range(at: 5)
             if startLineRange.length == 0 {
                 rangesToReplace.append(NSRange(
                     location: annotationStartRange.location,

--- a/SourceryRuntime/Sources/FileParserResult.swift
+++ b/SourceryRuntime/Sources/FileParserResult.swift
@@ -23,16 +23,18 @@ import Foundation
     }
     public var typealiases = [Typealias]()
     public var inlineRanges = [String: NSRange]()
+    public var inlineIndentations = [String: String]()
 
     public var contentSha: String?
     public var sourceryVersion: String
 
-    public init(path: String?, module: String?, types: [Type], typealiases: [Typealias] = [], inlineRanges: [String: NSRange] = [:], contentSha: String = "", sourceryVersion: String = "") {
+    public init(path: String?, module: String?, types: [Type], typealiases: [Typealias] = [], inlineRanges: [String: NSRange] = [:], inlineIndentations: [String: String] = [:], contentSha: String = "", sourceryVersion: String = "") {
         self.path = path
         self.module = module
         self.types = types
         self.typealiases = typealiases
         self.inlineRanges = inlineRanges
+        self.inlineIndentations = inlineIndentations
         self.contentSha = contentSha
         self.sourceryVersion = sourceryVersion
 
@@ -47,6 +49,7 @@ import Foundation
             guard let types: [Type] = aDecoder.decode(forKey: "types") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["types"])); fatalError() }; self.types = types
             guard let typealiases: [Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             guard let inlineRanges: [String: NSRange] = aDecoder.decode(forKey: "inlineRanges") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineRanges"])); fatalError() }; self.inlineRanges = inlineRanges
+            guard let inlineIndentations: [String: String] = aDecoder.decode(forKey: "inlineIndentations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineIndentations"])); fatalError() }; self.inlineIndentations = inlineIndentations
             self.contentSha = aDecoder.decode(forKey: "contentSha")
             guard let sourceryVersion: String = aDecoder.decode(forKey: "sourceryVersion") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["sourceryVersion"])); fatalError() }; self.sourceryVersion = sourceryVersion
         }
@@ -58,6 +61,7 @@ import Foundation
             aCoder.encode(self.types, forKey: "types")
             aCoder.encode(self.typealiases, forKey: "typealiases")
             aCoder.encode(self.inlineRanges, forKey: "inlineRanges")
+            aCoder.encode(self.inlineIndentations, forKey: "inlineIndentations")
             aCoder.encode(self.contentSha, forKey: "contentSha")
             aCoder.encode(self.sourceryVersion, forKey: "sourceryVersion")
         }

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -2015,16 +2015,18 @@ import Foundation
     }
     public var typealiases = [Typealias]()
     public var inlineRanges = [String: NSRange]()
+    public var inlineIndentations = [String: String]()
 
     public var contentSha: String?
     public var sourceryVersion: String
 
-    public init(path: String?, module: String?, types: [Type], typealiases: [Typealias] = [], inlineRanges: [String: NSRange] = [:], contentSha: String = "", sourceryVersion: String = "") {
+    public init(path: String?, module: String?, types: [Type], typealiases: [Typealias] = [], inlineRanges: [String: NSRange] = [:], inlineIndentations: [String: String] = [:], contentSha: String = "", sourceryVersion: String = "") {
         self.path = path
         self.module = module
         self.types = types
         self.typealiases = typealiases
         self.inlineRanges = inlineRanges
+        self.inlineIndentations = inlineIndentations
         self.contentSha = contentSha
         self.sourceryVersion = sourceryVersion
 
@@ -2039,6 +2041,7 @@ import Foundation
             guard let types: [Type] = aDecoder.decode(forKey: "types") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["types"])); fatalError() }; self.types = types
             guard let typealiases: [Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             guard let inlineRanges: [String: NSRange] = aDecoder.decode(forKey: "inlineRanges") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineRanges"])); fatalError() }; self.inlineRanges = inlineRanges
+            guard let inlineIndentations: [String: String] = aDecoder.decode(forKey: "inlineIndentations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineIndentations"])); fatalError() }; self.inlineIndentations = inlineIndentations
             self.contentSha = aDecoder.decode(forKey: "contentSha")
             guard let sourceryVersion: String = aDecoder.decode(forKey: "sourceryVersion") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["sourceryVersion"])); fatalError() }; self.sourceryVersion = sourceryVersion
         }
@@ -2050,6 +2053,7 @@ import Foundation
             aCoder.encode(self.types, forKey: "types")
             aCoder.encode(self.typealiases, forKey: "typealiases")
             aCoder.encode(self.inlineRanges, forKey: "inlineRanges")
+            aCoder.encode(self.inlineIndentations, forKey: "inlineIndentations")
             aCoder.encode(self.contentSha, forKey: "contentSha")
             aCoder.encode(self.sourceryVersion, forKey: "sourceryVersion")
         }

--- a/SourceryTests/Parsing/TemplateAnnotationsParserSpec.swift
+++ b/SourceryTests/Parsing/TemplateAnnotationsParserSpec.swift
@@ -18,22 +18,48 @@ private func build(_ source: String) -> [String: SourceKitRepresentable]? {
 class TemplateAnnotationsParserSpec: QuickSpec {
     override func spec() {
         describe("InlineParser") {
-            let source =
-                    "// sourcery:inline:Type.AutoCoding\n" +
-                    "var something: Int\n" +
-                    "// sourcery:end\n"
+            context("without indentation") {
+                let source =
+                        "// sourcery:inline:Type.AutoCoding\n" +
+                        "var something: Int\n" +
+                        "// sourcery:end\n"
 
-            let result = TemplateAnnotationsParser.parseAnnotations("inline", contents: source)
+                let result = TemplateAnnotationsParser.parseAnnotations("inline", contents: source)
 
-            it("tracks it") {
-                expect(result.annotatedRanges["Type.AutoCoding"]).to(equal([NSRange(location: 35, length: 19)]))
+                it("tracks it") {
+                    let annotatedRanges = result.annotatedRanges["Type.AutoCoding"]
+                    expect(annotatedRanges?.map { $0.range }).to(equal([NSRange(location: 35, length: 19)]))
+                    expect(annotatedRanges?.map { $0.indentation }).to(equal([""]))
+                }
+
+                it("removes content between the markup") {
+                    expect(result.contents).to(equal(
+                        "// sourcery:inline:Type.AutoCoding\n" +
+                        "// sourcery:end\n"
+                    ))
+                }
             }
 
-            it("removes content between the markup") {
-                expect(result.contents).to(equal(
-                    "// sourcery:inline:Type.AutoCoding\n" +
-                    "// sourcery:end\n"
-                ))
+            context("with indentation") {
+                let source =
+                        "    // sourcery:inline:Type.AutoCoding\n" +
+                        "    var something: Int\n" +
+                        "    // sourcery:end\n"
+
+                let result = TemplateAnnotationsParser.parseAnnotations("inline", contents: source)
+
+                it("tracks it") {
+                    let annotatedRanges = result.annotatedRanges["Type.AutoCoding"]
+                    expect(annotatedRanges?.map { $0.range }).to(equal([NSRange(location: 39, length: 23)]))
+                    expect(annotatedRanges?.map { $0.indentation }).to(equal(["    "]))
+                }
+
+                it("removes content between the markup") {
+                    expect(result.contents).to(equal(
+                        "    // sourcery:inline:Type.AutoCoding\n" +
+                        "    // sourcery:end\n"
+                    ))
+                }
             }
         }
     }


### PR DESCRIPTION
This allows specifying the indentation of the inline generated code, as requested in #537, by matching it with the indentation of the `// sourcery:inline:` annotation.

This should be particularly useful for nested types with inline generated code, allowing it to keep the correct indentation, for example:
```swift
class Foo: AutoName {
    // sourcery:inline:Foo.AutoName
    var name: String { "Foo" }
    // sourcery:end

    class Bar: AutoName {
        // sourcery:inline:Bar.AutoName
        var name: String { "Bar" }
        // sourcery:end
    }
}
```
```
{% for type in types.implementing.AutoName %}
// sourcery:inline:{{ type.name }}.AutoName
var name: String { "{{ type.name }}" }
// sourcery:end
{% endfor %}
```