### PR TITLE
Ensure that buildDir path exists before copying the context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ---
 ## Master
 
+### Bug fixes
+
+- Fix missing folder error that could happen when running a Swift template with existing cache
 
 ## 0.16.0
 

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -192,6 +192,9 @@ open class SwiftTemplate {
 
         let serializedContextPath = buildDir + "context.bin"
         let data = NSKeyedArchiver.archivedData(withRootObject: context)
+        if !buildDir.exists {
+            try buildDir.mkpath()
+        }
         try serializedContextPath.write(data)
 
         let result = try Process.runCommand(path: binaryPath.description,

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -155,6 +155,33 @@ class SwiftTemplateTests: QuickSpec {
                         expect("\(error)").to(contain("\(templatePath): Fatal error: Index out of range\n"))
                     }))
             }
+
+            context("with existing cache") {
+                expect { try Sourcery(cacheDisabled: false).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output) }.toNot(throwError())
+
+                expect((try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))).to(equal(expectedResult))
+
+                context("and missing build dir") {
+                    guard let buildDir = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("SwiftTemplate").map({ Path($0.path) }) else {
+                        fail("Could not create buildDir path")
+                        return
+                    }
+                    if buildDir.exists {
+                        do {
+                            try buildDir.delete()
+                        } catch {
+                            fail("Failed to delete \(buildDir)")
+                        }
+                    }
+
+                    it("generates the code") {
+                        expect { try Sourcery(cacheDisabled: false).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output) }.toNot(throwError())
+
+                        let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                        expect(result).to(equal(expectedResult))
+                    }
+                }
+            }
         }
 
         describe("FolderSynchronizer") {


### PR DESCRIPTION
The `buildDir` folder may not be present when cache is found. In this case `build()` would not be called thus would not create the `buildDir`.

Fixes #741 