### PR TITLE
Don't add indentation to empty line when using inline generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug fixes
 
 - Fix missing folder error that could happen when running a Swift template with existing cache
+- Don't add indentation to empty line when using inline generated code.
 
 ## 0.16.0
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -555,7 +555,15 @@ extension Sourcery {
             return toInsert
         }
         let lines = toInsert.components(separatedBy: "\n")
-        return lines.enumerated().map { $0 == lines.count - 1 ? $1 : indentation + $1 }.joined(separator: "\n")
+        return lines.enumerated()
+            .map { index, line in
+                guard !line.isEmpty else {
+                    return line
+                }
+
+                return index == lines.count - 1 ? line : indentation + line
+            }
+            .joined(separator: "\n")
     }
 
     internal func generatedPath(`for` templatePath: Path) -> Path {

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -257,6 +257,7 @@ class SourcerySpecTests: QuickSpec {
                             // Line One
                             // sourcery:inline:Bar.Inlined
                             var property = bar
+
                             // Line Three
                             // sourcery:end
                             // Line One
@@ -278,6 +279,7 @@ class SourcerySpecTests: QuickSpec {
                                 class Bar {
                                     // sourcery:inline:Bar.Inlined
                                     var property = bar
+
                                     // Line Three
                                     // sourcery:end
                                 }


### PR DESCRIPTION
Fixes #747