### PR TITLE
typo fix in documentation

### DIFF
--- a/docs/codable.html
+++ b/docs/codable.html
@@ -359,7 +359,7 @@
 <pre class="highlight json"><code><span class="p">{</span><span class="w">
   </span><span class="nt">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"someCase"</span><span class="w"> </span><span class="err">//</span><span class="w"> </span><span class="err">enum</span><span class="w"> </span><span class="err">case</span><span class="w"> </span><span class="err">is</span><span class="w"> </span><span class="err">encoded</span><span class="w"> </span><span class="err">in</span><span class="w"> </span><span class="err">a</span><span class="w"> </span><span class="err">special</span><span class="w"> </span><span class="err">key</span><span class="w">
   </span><span class="s2">"id"</span><span class="err">:</span><span class="w"> </span><span class="mi">1</span><span class="p">,</span><span class="w">
-  </span><span class="nt">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Jhon"</span><span class="w">
+  </span><span class="nt">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"John"</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
 
@@ -369,7 +369,7 @@
 <pre class="highlight json"><code><span class="p">{</span><span class="w">
   </span><span class="nt">"someCase"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
     </span><span class="nt">"id"</span><span class="p">:</span><span class="w"> </span><span class="mi">1</span><span class="p">,</span><span class="w">
-    </span><span class="nt">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Jhon"</span><span class="w">
+    </span><span class="nt">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"John"</span><span class="w">
   </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>

--- a/docs/codable.html
+++ b/docs/codable.html
@@ -355,7 +355,7 @@
 <span class="p">}</span>
 </code></pre>
 
-<p>If you define a coding key named <code>enumCaseKey</code> then the template will genearaet code that will encode/decode enum in/from following format:</p>
+<p>If you define a coding key named <code>enumCaseKey</code> then the template will generate code that will encode/decode enum in/from following format:</p>
 <pre class="highlight json"><code><span class="p">{</span><span class="w">
   </span><span class="nt">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"someCase"</span><span class="w"> </span><span class="err">//</span><span class="w"> </span><span class="err">enum</span><span class="w"> </span><span class="err">case</span><span class="w"> </span><span class="err">is</span><span class="w"> </span><span class="err">encoded</span><span class="w"> </span><span class="err">in</span><span class="w"> </span><span class="err">a</span><span class="w"> </span><span class="err">special</span><span class="w"> </span><span class="err">key</span><span class="w">
   </span><span class="s2">"id"</span><span class="err">:</span><span class="w"> </span><span class="mi">1</span><span class="p">,</span><span class="w">

--- a/guides/Codable.md
+++ b/guides/Codable.md
@@ -213,7 +213,7 @@ enum SimpleEnum {
 }
 ```
 
-If you define a coding key named `enumCaseKey` then the template will genearaet code that will encode/decode enum in/from following format:
+If you define a coding key named `enumCaseKey` then the template will generate code that will encode/decode enum in/from following format:
 
 ```json
 {

--- a/guides/Codable.md
+++ b/guides/Codable.md
@@ -173,7 +173,7 @@ Enums with numeric or string raw values are `Codable` by default. For enums with
 For such enums template will generate decoding/encoding code that will expect values in JSON to be exactly the same as cases' names.
 
 ```swift
-enum SimpleEnum {
+enum SimpleEnum: AutoDecodable {
   case someCase
   case anotherCase
 }
@@ -191,7 +191,7 @@ For such enum template will generate code that will successfully decode from/enc
 You can define coding keys to change the values:
 
 ```swift
-enum SimpleEnum {
+enum SimpleEnum: AutoDecodable {
   case someCase
   case anotherCase
   
@@ -207,7 +207,7 @@ enum SimpleEnum {
 Template supports two different representations of such enums in JSON format.
 
 ```swift
-enum SimpleEnum {
+enum SimpleEnum: AutoDecodable {
   case someCase(id: Int, name: String)
   case anotherCase
 }

--- a/guides/Codable.md
+++ b/guides/Codable.md
@@ -219,7 +219,7 @@ If you define a coding key named `enumCaseKey` then the template will generate c
 {
   "type": "someCase" // enum case is encoded in a special key
   "id": 1,
-  "name": "Jhon"
+  "name": "John"
 }
 ```
 All enum cases associated values must be named.
@@ -230,7 +230,7 @@ If you don't define `enumCaseKey` then the template will generate code that will
 {
   "someCase": {
     "id": 1,
-    "name": "Jhon"
+    "name": "John"
   }
 }
 ```


### PR DESCRIPTION
- Several typos in documentation (`codable.html`, `Codable.md`)
- Adding `AutoDecodable` to `SimpleEnum` example