### PR TITLE
fix ReceivedInvocations's type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## Master
 
 ### Bug fixes
-
+- Fix ReceivedInvocations's type for the method which have only one parameter in AutoMockable.stencil
 - Fix missing folder error that could happen when running a Swift template with existing cache
 - Don't add indentation to empty line when using inline generated code.
 

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -56,7 +56,7 @@ import AppKit
     {% endif %}
     {% if method.parameters.count == 1 %}
     var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
-    var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}]{% endfor %} = []
+    var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.typeName }}{{ ')' if param.isClosure }}]{% endfor %} = []
     {% elif not method.parameters.count == 0 %}
     var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})?
     var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})] = []

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -56,7 +56,7 @@ import AppKit
     {% endif %}
     {% if method.parameters.count == 1 %}
     var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
-    var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.typeName }}{{ ')' if param.isClosure }}]{% endfor %} = []
+    var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 %}
     var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})?
     var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})] = []

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -75,3 +75,7 @@ protocol ClosureProtocol: AutoMockable {
 protocol AnnotatedProtocol {
     func sayHelloWith(name: String)
 }
+
+protocol SingleOptionalParameterFunction: AutoMockable {
+    func send(message: String?)
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -21,7 +21,7 @@ class AnnotatedProtocolMock: AnnotatedProtocol {
     func sayHelloWith(name: String) {
         sayHelloWithNameCallsCount += 1
         sayHelloWithNameReceivedName = name
-        sayHelloWithNameInvocations.append(name)
+        sayHelloWithNameReceivedInvocations.append(name)
         sayHelloWithNameClosure?(name)
     }
 
@@ -55,7 +55,7 @@ class BasicProtocolMock: BasicProtocol {
     func save(configuration: String) {
         saveConfigurationCallsCount += 1
         saveConfigurationReceivedConfiguration = configuration
-        saveConfigurationInvocations.append(configuration)
+        saveConfigurationReceivedInvocations.append(configuration)
         saveConfigurationClosure?(configuration)
     }
 
@@ -75,7 +75,7 @@ class ClosureProtocolMock: ClosureProtocol {
     func setClosure(_ closure: @escaping () -> Void) {
         setClosureCallsCount += 1
         setClosureReceivedClosure = closure
-        setClosureInvocations.append(closure)
+        setClosureReceivedInvocations.append(closure)
         setClosureClosure?(closure)
     }
 
@@ -95,7 +95,7 @@ class CurrencyPresenterMock: CurrencyPresenter {
     func showSourceCurrency(_ currency: String) {
         showSourceCurrencyCallsCount += 1
         showSourceCurrencyReceivedCurrency = currency
-        showSourceCurrencyInvocations.append(currency)
+        showSourceCurrencyReceivedInvocations.append(currency)
         showSourceCurrencyClosure?(currency)
     }
 
@@ -120,7 +120,7 @@ class ExtendableProtocolMock: ExtendableProtocol {
     func report(message: String) {
         reportMessageCallsCount += 1
         reportMessageReceivedMessage = message
-        reportMessageInvocations.append(message)
+        reportMessageReceivedInvocations.append(message)
         reportMessageClosure?(message)
     }
 
@@ -152,7 +152,7 @@ class InitializationProtocolMock: InitializationProtocol {
 
     required init(intParameter: Int, stringParameter: String, optionalParameter: String?) {
         initIntParameterStringParameterOptionalParameterReceivedArguments = (intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter)
-        initIntParameterStringParameterOptionalParameterInvocations.append((intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter))
+        initIntParameterStringParameterOptionalParameterReceivedInvocations.append((intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter))
         initIntParameterStringParameterOptionalParameterClosure?(intParameter, stringParameter, optionalParameter)
     }
     //MARK: - start
@@ -198,7 +198,7 @@ class ReservedWordsProtocolMock: ReservedWordsProtocol {
     func `continue`(with message: String) -> String {
         continueWithCallsCount += 1
         continueWithReceivedMessage = message
-        continueWithInvocations.append(message)
+        continueWithReceivedInvocations.append(message)
         return continueWithClosure.map({ $0(message) }) ?? continueWithReturnValue
     }
 
@@ -218,7 +218,7 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
     func start(car: String, of model: String) {
         startCarOfCallsCount += 1
         startCarOfReceivedArguments = (car: car, model: model)
-        startCarOfInvocations.append((car: car, model: model))
+        startCarOfReceivedInvocations.append((car: car, model: model))
         startCarOfClosure?(car, model)
     }
 
@@ -235,11 +235,31 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
     func start(plane: String, of model: String) {
         startPlaneOfCallsCount += 1
         startPlaneOfReceivedArguments = (plane: plane, model: model)
-        startPlaneOfInvocations.append((plane: plane, model: model))
+        startPlaneOfReceivedInvocations.append((plane: plane, model: model))
         startPlaneOfClosure?(plane, model)
     }
 
 }
+class SingleOptionalParameterFunctionMock: SingleOptionalParameterFunction {
+
+    //MARK: - send
+
+    var sendMessageCallsCount = 0
+    var sendMessageCalled: Bool {
+        return sendMessageCallsCount > 0
+    }
+    var sendMessageReceivedMessage: String?
+    var sendMessageReceivedInvocations: [String?] = []
+    var sendMessageClosure: ((String?) -> Void)?
+
+    func send(message: String?) {
+        sendMessageCallsCount += 1
+        sendMessageReceivedMessage = message
+        sendMessageReceivedInvocations.append(message)
+        sendMessageClosure?(message)
+    }
+}
+
 class ThrowableProtocolMock: ThrowableProtocol {
 
     //MARK: - doOrThrow

--- a/Templates/Tests/Generated/AutoCases.generated.swift
+++ b/Templates/Tests/Generated/AutoCases.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoCodable.generated.swift
+++ b/Templates/Tests/Generated/AutoCodable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all

--- a/Templates/Tests/Generated/AutoLenses.generated.swift
+++ b/Templates/Tests/Generated/AutoLenses.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable variable_name

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length
@@ -39,7 +39,7 @@ class AnnotatedProtocolMock: AnnotatedProtocol {
     func sayHelloWith(name: String) {
         sayHelloWithNameCallsCount += 1
         sayHelloWithNameReceivedName = name
-        sayHelloWithNameInvocations.append(name)
+        sayHelloWithNameReceivedInvocations.append(name)
         sayHelloWithNameClosure?(name)
     }
 
@@ -73,7 +73,7 @@ class BasicProtocolMock: BasicProtocol {
     func save(configuration: String) {
         saveConfigurationCallsCount += 1
         saveConfigurationReceivedConfiguration = configuration
-        saveConfigurationInvocations.append(configuration)
+        saveConfigurationReceivedInvocations.append(configuration)
         saveConfigurationClosure?(configuration)
     }
 
@@ -93,7 +93,7 @@ class ClosureProtocolMock: ClosureProtocol {
     func setClosure(_ closure: @escaping () -> Void) {
         setClosureCallsCount += 1
         setClosureReceivedClosure = closure
-        setClosureInvocations.append(closure)
+        setClosureReceivedInvocations.append(closure)
         setClosureClosure?(closure)
     }
 
@@ -113,7 +113,7 @@ class CurrencyPresenterMock: CurrencyPresenter {
     func showSourceCurrency(_ currency: String) {
         showSourceCurrencyCallsCount += 1
         showSourceCurrencyReceivedCurrency = currency
-        showSourceCurrencyInvocations.append(currency)
+        showSourceCurrencyReceivedInvocations.append(currency)
         showSourceCurrencyClosure?(currency)
     }
 
@@ -138,7 +138,7 @@ class ExtendableProtocolMock: ExtendableProtocol {
     func report(message: String) {
         reportMessageCallsCount += 1
         reportMessageReceivedMessage = message
-        reportMessageInvocations.append(message)
+        reportMessageReceivedInvocations.append(message)
         reportMessageClosure?(message)
     }
 
@@ -170,7 +170,7 @@ class InitializationProtocolMock: InitializationProtocol {
 
     required init(intParameter: Int, stringParameter: String, optionalParameter: String?) {
         initIntParameterStringParameterOptionalParameterReceivedArguments = (intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter)
-        initIntParameterStringParameterOptionalParameterInvocations.append((intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter))
+        initIntParameterStringParameterOptionalParameterReceivedInvocations.append((intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter))
         initIntParameterStringParameterOptionalParameterClosure?(intParameter, stringParameter, optionalParameter)
     }
     //MARK: - start
@@ -216,7 +216,7 @@ class ReservedWordsProtocolMock: ReservedWordsProtocol {
     func `continue`(with message: String) -> String {
         continueWithCallsCount += 1
         continueWithReceivedMessage = message
-        continueWithInvocations.append(message)
+        continueWithReceivedInvocations.append(message)
         return continueWithClosure.map({ $0(message) }) ?? continueWithReturnValue
     }
 
@@ -236,7 +236,7 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
     func start(car: String, of model: String) {
         startCarOfCallsCount += 1
         startCarOfReceivedArguments = (car: car, model: model)
-        startCarOfInvocations.append((car: car, model: model))
+        startCarOfReceivedInvocations.append((car: car, model: model))
         startCarOfClosure?(car, model)
     }
 
@@ -253,8 +253,28 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
     func start(plane: String, of model: String) {
         startPlaneOfCallsCount += 1
         startPlaneOfReceivedArguments = (plane: plane, model: model)
-        startPlaneOfInvocations.append((plane: plane, model: model))
+        startPlaneOfReceivedInvocations.append((plane: plane, model: model))
         startPlaneOfClosure?(plane, model)
+    }
+
+}
+class SingleOptionalParameterFunctionMock: SingleOptionalParameterFunction {
+
+    //MARK: - send
+
+    var sendMessageCallsCount = 0
+    var sendMessageCalled: Bool {
+        return sendMessageCallsCount > 0
+    }
+    var sendMessageReceivedMessage: String?
+    var sendMessageReceivedInvocations: [String?] = []
+    var sendMessageClosure: ((String?) -> Void)?
+
+    func send(message: String?) {
+        sendMessageCallsCount += 1
+        sendMessageReceivedMessage = message
+        sendMessageReceivedInvocations.append(message)
+        sendMessageClosure?(message)
     }
 
 }

--- a/Templates/Tests/Generated/LinuxMain.generated.swift
+++ b/Templates/Tests/Generated/LinuxMain.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest


### PR DESCRIPTION
Recently I am using Sourcery to refactoring my project, it is awesome project!  I also use the AutoMockable to help me generate the mock class for unit test. Then I find a tiny problem.

```swift
//sourcery:AutoMockable
protocol Test {
    func send(message: String?)
}
```
the generated code is
```swift
class TestMock: Test {
    //MARK: - send

    var sendMessageCallsCount = 0
    var sendMessageCalled: Bool {
        return sendMessageCallsCount > 0
    }
    var sendMessageReceivedMessage: String?
    var sendMessageReceivedInvocations: [String] = []
    var sendMessageClosure: ((String?) -> Void)?

    func send(message: String?) {
        sendMessageCallsCount += 1
        sendMessageReceivedMessage = message
        sendMessageReceivedInvocations.append(message) // this will cause compile error
        sendMessageClosure?(message)
    }
}
```
So I edit the AutoMockable.stencil, and It works, hope my solution is the right way.