### PR TITLE
Fix annotations EnumCase not supporting commas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix missing folder error that could happen when running a Swift template with existing cache
 - Don't add indentation to empty line when using inline generated code.
 - Fix issue where errors in Swift Template would not be reported correctly when using Xcode 10.2.
+- Fix annotations for enum cases with associated values that wouldn't parses them correctly when commas were used
 
 ### Internal Changes
 

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -706,7 +706,10 @@
 				003958827841F12BBF99EB67 /* Frameworks */,
 				BF6C9BBD135B544916C5F0CD /* Pods */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		CD754C8C1D853F000082B512 /* Products */ = {
 			isa = PBXGroup;

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -655,7 +655,7 @@ extension FileParser {
     fileprivate func parseEnumAssociatedValues(_ body: String) -> [AssociatedValue] {
         guard !body.isEmpty else { return [AssociatedValue(localName: nil, externalName: nil, typeName: TypeName("()"))] }
 
-        let items = body.commaSeparated()
+        let items = body.commaSeparated(ignoringComments: true)
         return items
             .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
             .enumerated()

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -655,7 +655,10 @@ extension FileParser {
     fileprivate func parseEnumAssociatedValues(_ body: String) -> [AssociatedValue] {
         guard !body.isEmpty else { return [AssociatedValue(localName: nil, externalName: nil, typeName: TypeName("()"))] }
 
-        let items = body.commaSeparated(ignoringComments: true)
+        let items = body.components(
+            separatedBy: ",",
+            excludingDelimiterBetween: (["<", "[", "(", "{", "/*", "//"], ["}", ")", "]", ">", "*/", "\n"])
+        )
         return items
             .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
             .enumerated()

--- a/SourceryRuntime/Sources/Extensions.swift
+++ b/SourceryRuntime/Sources/Extensions.swift
@@ -112,8 +112,13 @@ public extension String {
 
     /// :nodoc:
     /// Returns components separated with a comma respecting nested types
-    func commaSeparated() -> [String] {
-        return components(separatedBy: ",", excludingDelimiterBetween: ("<[({", "})]>"))
+    func commaSeparated(ignoringComments: Bool = false) -> [String] {
+        var (open, close) = (["<", "[", "(", "{"], ["}", ")", "]", ">"])
+        if ignoringComments {
+            open += ["/*", "//"]
+            close += ["*/", "\n"]
+        }
+        return components(separatedBy: ",", excludingDelimiterBetween: (open, close))
     }
 
     /// :nodoc:
@@ -130,47 +135,46 @@ public extension String {
 
     /// :nodoc:
     func components(separatedBy delimiter: String, excludingDelimiterBetween between: (open: String, close: String)) -> [String] {
+        return self.components(separatedBy: delimiter, excludingDelimiterBetween: (between.open.map { String($0) }, between.close.map { String($0) }))
+    }
+
+    /// :nodoc:
+    func components(separatedBy delimiter: String, excludingDelimiterBetween between: (open: [String], close: [String])) -> [String] {
         var boundingCharactersCount: Int = 0
         var quotesCount: Int = 0
         var item = ""
         var items = [String]()
         var matchedDelimiter = (alreadyMatched: "", leftToMatch: delimiter)
 
-        for char in self {
-            if between.open.contains(char) {
-                if !(boundingCharactersCount == 0 && String(char) == delimiter) {
+        var i = self.startIndex
+        while i < self.endIndex {
+            var increaseOffset = 1
+            defer {
+                i = self.index(i, offsetBy: increaseOffset)
+            }
+            let current = self[i..<(self.index(i, offsetBy: delimiter.count, limitedBy: self.endIndex) ?? self.endIndex)]
+            if let index = between.open.index(where: { String(self[i...]).starts(with: $0) }) {
+                if !(boundingCharactersCount == 0 && String(self[i]) == delimiter) {
                     boundingCharactersCount += 1
                 }
-            } else if between.close.contains(char) {
+                increaseOffset = between.open[index].count
+            } else if let index = between.close.index(where: { String(self[i...]).starts(with: $0) }) {
                 // do not count `->`
-                if !(char == ">" && item.last == "-") {
+                if !(self[i] == ">" && item.last == "-") {
                     boundingCharactersCount = max(0, boundingCharactersCount - 1)
                 }
+                increaseOffset = between.close[index].count
             }
-            if char == "\"" {
+            if self[i] == "\"" {
                 quotesCount += 1
             }
 
-            guard boundingCharactersCount == 0 && quotesCount % 2 == 0 else {
-                item.append(char)
-                continue
-            }
-
-            if char == matchedDelimiter.leftToMatch.first {
-                matchedDelimiter.alreadyMatched.append(char)
-                matchedDelimiter.leftToMatch = String(matchedDelimiter.leftToMatch.dropFirst())
-                if matchedDelimiter.leftToMatch.isEmpty {
-                    items.append(item)
-                    item = ""
-                    matchedDelimiter = (alreadyMatched: "", leftToMatch: delimiter)
-                }
+            if current == delimiter && boundingCharactersCount == 0 && quotesCount % 2 == 0 {
+                items.append(item)
+                item = ""
+                i = self.index(i, offsetBy: delimiter.count - 1)
             } else {
-                if matchedDelimiter.alreadyMatched.isEmpty {
-                    item.append(char)
-                } else {
-                    item.append(matchedDelimiter.alreadyMatched)
-                    matchedDelimiter = (alreadyMatched: "", leftToMatch: delimiter)
-                }
+                item += self[i..<self.index(i, offsetBy: increaseOffset)]
             }
         }
         items.append(item)

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -1918,13 +1918,8 @@ public extension String {
 
     /// :nodoc:
     /// Returns components separated with a comma respecting nested types
-    func commaSeparated(ignoringComments: Bool = false) -> [String] {
-        var (open, close) = (["<", "[", "(", "{"], ["}", ")", "]", ">"])
-        if ignoringComments {
-            open += ["/*", "//"]
-            close += ["*/", "\\n"]
-        }
-        return components(separatedBy: ",", excludingDelimiterBetween: (open, close))
+    func commaSeparated() -> [String] {
+        return components(separatedBy: ",", excludingDelimiterBetween: ("<[({", "})]>"))
     }
 
     /// :nodoc:
@@ -1954,33 +1949,33 @@ public extension String {
 
         var i = self.startIndex
         while i < self.endIndex {
-            var increaseOffset = 1
+            var offset = 1
             defer {
-                i = self.index(i, offsetBy: increaseOffset)
+                i = self.index(i, offsetBy: offset)
             }
-            let current = self[i..<(self.index(i, offsetBy: delimiter.count, limitedBy: self.endIndex) ?? self.endIndex)]
-            if let index = between.open.index(where: { String(self[i...]).starts(with: $0) }) {
+            let currentlyScanned = self[i..<(self.index(i, offsetBy: delimiter.count, limitedBy: self.endIndex) ?? self.endIndex)]
+            if let openString = between.open.first(where: { String(self[i...]).starts(with: $0) }) {
                 if !(boundingCharactersCount == 0 && String(self[i]) == delimiter) {
                     boundingCharactersCount += 1
                 }
-                increaseOffset = between.open[index].count
-            } else if let index = between.close.index(where: { String(self[i...]).starts(with: $0) }) {
+                offset = openString.count
+            } else if let closeString = between.close.first(where: { String(self[i...]).starts(with: $0) }) {
                 // do not count `->`
                 if !(self[i] == ">" && item.last == "-") {
                     boundingCharactersCount = max(0, boundingCharactersCount - 1)
                 }
-                increaseOffset = between.close[index].count
+                offset = closeString.count
             }
             if self[i] == "\\"" {
                 quotesCount += 1
             }
 
-            if current == delimiter && boundingCharactersCount == 0 && quotesCount % 2 == 0 {
+            if currentlyScanned == delimiter && boundingCharactersCount == 0 && quotesCount % 2 == 0 {
                 items.append(item)
                 item = ""
                 i = self.index(i, offsetBy: delimiter.count - 1)
             } else {
-                item += self[i..<self.index(i, offsetBy: increaseOffset)]
+                item += self[i..<self.index(i, offsetBy: offset)]
             }
         }
         items.append(item)

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -379,7 +379,7 @@ class FileParserSpec: QuickSpec {
                                 Enum(name: "Foo",
                                      cases: [
                                         EnumCase(name: "optionA", associatedValues: [
-																					AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: ["first": NSNumber(value: true), "second": NSNumber(value: true), "third": "value" as NSString])
+                                            AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: ["first": NSNumber(value: true), "second": NSNumber(value: true), "third": "value" as NSString])
                                             ]),
                                         EnumCase(name: "optionB")
                                     ])

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -276,11 +276,14 @@ class FileParserSpec: QuickSpec {
                     context("given enum cases annotations") {
 
                         it("extracts cases with annotations properly") {
-                            expect(parse("enum Foo {\n //sourcery:begin: block\n// sourcery: first, second=\"value\"\n case optionA(/* sourcery: value */Int)\n // sourcery: third\n case optionB\n case optionC \n//sourcery:end}"))
+                            expect(parse("enum Foo {\n //sourcery:begin: block\n// sourcery: first, second=\"value\"\n case optionA(/* sourcery: first, second = \"value\" */Int)\n // sourcery: third\n case optionB\n case optionC \n//sourcery:end}"))
                                 .to(equal([
                                     Enum(name: "Foo", cases: [
                                         EnumCase(name: "optionA", associatedValues: [
-                                            AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: ["value": NSNumber(value: true)])
+                                            AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: [
+                                                "first": NSNumber(value: true),
+                                                "second": "value" as NSString
+                                                ])
                                             ], annotations: [
                                                 "block": NSNumber(value: true),
                                                 "first": NSNumber(value: true),
@@ -300,12 +303,13 @@ class FileParserSpec: QuickSpec {
                         }
 
                         it("extracts cases with inline annotations properly") {
-                            expect(parse("enum Foo {\n //sourcery:begin: block\n/* sourcery: first, second = \"value\" */ case optionA(/* sourcery: associatedValue */Int); /* sourcery: third */ case optionB\n case optionC \n//sourcery:end\n}"))
+                            expect(parse("enum Foo {\n //sourcery:begin: block\n/* sourcery: first, second = \"value\" */ case optionA(/* sourcery: first, second = \"value\" */Int); /* sourcery: third */ case optionB\n case optionC \n//sourcery:end\n}"))
                                 .to(equal([
                                     Enum(name: "Foo", cases: [
                                         EnumCase(name: "optionA", associatedValues: [
                                             AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: [
-                                                "associatedValue": NSNumber(value: true)
+                                                "first": NSNumber(value: true),
+                                                "second": "value" as NSString
                                                 ])
                                             ], annotations: [
                                                 "block": NSNumber(value: true),
@@ -369,13 +373,13 @@ class FileParserSpec: QuickSpec {
                     }
 
                     it("extracts associated value annotations properly") {
-                        let result = parse("enum Foo {\n case optionA(\n// sourcery: annotation\nInt)\n case optionB }")
+                        let result = parse("enum Foo {\n case optionA(\n// sourcery: first\n// sourcery: second, third = \"value\"\nInt)\n case optionB }")
                         expect(result)
                             .to(equal([
                                 Enum(name: "Foo",
                                      cases: [
                                         EnumCase(name: "optionA", associatedValues: [
-                                            AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: ["annotation": NSNumber(value: true)])
+																					AssociatedValue(name: nil, typeName: TypeName("Int"), annotations: ["first": NSNumber(value: true), "second": NSNumber(value: true), "third": "value" as NSString])
                                             ]),
                                         EnumCase(name: "optionB")
                                     ])


### PR DESCRIPTION
There was an issue when parsing annotation cases where basically the parser was trying to split all individual associated values using `,`, ignoring the fact that these commas may very well be in comments.

For example, the following `enum`:
```
enum Foo {
    case optionA(/* sourcery = first, second = "value" */ Int) 
}
```
The associated value would be parsed as:
![Screenshot 2019-04-16 11 35 35](https://user-images.githubusercontent.com/7003579/56233801-e5786180-6051-11e9-8c23-77e55ff02355.png)

This PR address the issue by adding a method:
```swift
components(separatedBy delimiter: String, excludingDelimiterBetween between: (open: [String], close: [String]))
```
that the previous one calls in the following way:
```swift
func components(separatedBy delimiter: String, excludingDelimiterBetween between: (open: String, close: String)) -> [String] {
    return self.components(separatedBy: delimiter, excludingDelimiterBetween: (between.open.map { String($0) }, between.close.map { String($0) }))
}
```
So that we can optionally specify (`//`, `\n`) and (`/*` and `*/`) as delimiters to ignore (note that the documentation comments `/**` and `///` are then automatically included).

This change allowed me to update the method to a version that I hope is easier to understand, reverting it to [a state]((https://github.com/krzysztofzablocki/Sourcery/blob/25b1c50f27a134beb19f4bfbb9a593e2bcdd2699/Sourcery/Parsing/Utils/Extensions.swift)) that's close to where it was before closure type detection was introduced in #131.

This PR passes all the unit tests (on my machine), but considering the method it changes is used in a lot of places and I haven't had time to test it on a real-world project, I'm creating the PR as a draft. This should also give you the opportunity to give me feedback.