### PR TITLE
Update cocoapods bundler gem to 1.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', '1.6.0.beta.1'
+gem 'cocoapods', '1.6.1'
 gem 'cocoapods-update-if-you-dare'
 gem 'danger'
 gem 'danger-jazzy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.3.6)
-    activesupport (4.2.11)
+    activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -16,12 +16,12 @@ GEM
       nap
       open4 (~> 1.3)
     clamp (0.6.5)
-    cocoapods (1.6.0.beta.1)
+    cocoapods (1.6.1)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.6.0.beta.1)
+      cocoapods-core (= 1.6.1)
       cocoapods-deintegrate (>= 1.0.2, < 2.0)
-      cocoapods-downloader (>= 1.2.1, < 2.0)
+      cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-stats (>= 1.0.0, < 2.0)
@@ -29,22 +29,22 @@ GEM
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
-      fourflusher (~> 2.0.1)
+      fourflusher (>= 2.2.0, < 3.0)
       gh_inspector (~> 1.0)
       molinillo (~> 0.6.6)
       nap (~> 1.0)
-      ruby-macho (~> 1.2)
-      xcodeproj (>= 1.6.0, < 2.0)
-    cocoapods-core (1.6.0.beta.1)
+      ruby-macho (~> 1.4)
+      xcodeproj (>= 1.8.1, < 2.0)
+    cocoapods-core (1.6.1)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
-    cocoapods-deintegrate (1.0.2)
+    cocoapods-deintegrate (1.0.4)
     cocoapods-downloader (1.2.2)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
-    cocoapods-stats (1.0.0)
+    cocoapods-stats (1.1.0)
     cocoapods-trunk (1.3.1)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
@@ -52,7 +52,7 @@ GEM
     cocoapods-update-if-you-dare (0.2.0)
       colored2
     colored2 (3.1.2)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     cork (0.3.0)
       colored2 (~> 3.1)
     danger (5.11.0)
@@ -78,7 +78,7 @@ GEM
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
     ffi (1.9.25)
-    fourflusher (2.0.1)
+    fourflusher (2.2.0)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     git (1.5.0)
@@ -117,7 +117,7 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.4.0)
     rouge (1.11.1)
-    ruby-macho (1.3.1)
+    ruby-macho (1.4.0)
     sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -141,7 +141,7 @@ GEM
     unicode-display_width (1.4.1)
     xcinvoke (0.3.0)
       liferaft (~> 0.0.6)
-    xcodeproj (1.7.0)
+    xcodeproj (1.8.2)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -154,7 +154,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.6.0.beta.1)
+  cocoapods (= 1.6.1)
   cocoapods-update-if-you-dare
   danger
   danger-jazzy


### PR DESCRIPTION
#737 did not use the bundler version of Cocoapods, so we now have a discrepency between the [`Gemfile.lock`](https://github.com/krzysztofzablocki/Sourcery/blob/8459a765aafaad3448184e6b99c4fb8e93b762d1/Gemfile.lock#L19) and the [`Pods/Manifest.lock`](https://github.com/krzysztofzablocki/Sourcery/blob/8459a765aafaad3448184e6b99c4fb8e93b762d1/Pods/Manifest.lock#L73) that needs to be resolved.

This PR just fixes the bundler setup and is mostly FYI