### PR TITLE
Fix issue where Swift templates would fail to compile correctly but the compilation error would not be reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix ReceivedInvocations's type for the method which have only one parameter in AutoMockable.stencil
 - Fix missing folder error that could happen when running a Swift template with existing cache
 - Don't add indentation to empty line when using inline generated code.
+- Fix issue where errors in Swift Template would not be reported correctly when using Xcode 10.2.
 
 ### Internal Changes
 

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -19,6 +19,7 @@ private enum Delimiters {
 private struct ProcessResult {
     let output: String
     let error: String
+    let exitCode: Int32
 }
 
 open class SwiftTemplate {
@@ -237,7 +238,7 @@ open class SwiftTemplate {
                                                        arguments: arguments,
                                                        currentDirectoryPath: buildDir)
 
-        if !compilationResult.error.isEmpty {
+        if compilationResult.exitCode != 0 || !compilationResult.error.isEmpty {
             throw compilationResult.output
         }
 
@@ -330,7 +331,7 @@ private extension Process {
         let output = String(data: outputData, encoding: .utf8) ?? ""
         let error = String(data: errorData, encoding: .utf8) ?? ""
 
-        return ProcessResult(output: output, error: error)
+        return ProcessResult(output: output, error: error, exitCode: task.terminationStatus)
     }
 }
 


### PR DESCRIPTION
This is an issue that probably doesn't happen that often, but should future-proof in case `swift` keeps the same behavior in some instances.

The core issue was that, for some (probably rare) case, `xcrun swift build` might output an error in `stdout` but not output anything in `stderr`, making `SwiftTemplate.render(_:)` incorrectly report a success rather than a failure.
This resulting in a rather cryptic error message:
```bash
$ sourcery <...>
error: Error Domain=NSCocoaErrorDomain Code=4 "“SwiftTemplate” couldn’t be moved to “MyTemplate.swifttemplate” because either the former doesn’t exist, or the folder containing the latter doesn’t exist." UserInfo={NSSourceFilePathErrorKey=/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/.build/debug/SwiftTemplate, NSUserStringVariant=(
    Move
), NSDestinationFilePath=/Users/stephane/Library/Caches/Sourcery/APIKit.swifttemplate/w8XcSmDyWsgtql9%2Bo0GYatquItsONIuIix%2BRU8V8kjU%3D, NSFilePath=/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/.build/debug/SwiftTemplate, NSUnderlyingError=0x600000c533f0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```

This was the output of `ProcessResult` from `Process.runCommand(...)`:
```lldb

(lldb) po compilationResult
▿ ProcessResult
  - output : "[1/3] Compiling Swift Module \'SourceryRuntime\' (27 sources)\n[2/3] Compiling Swift Module \'SwiftTemplate\' (1 sources)\n/private/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/Sources/SwiftTemplate/main.swift:48:36: error: \'archivedData(withRootObject:)\' is only available on OS X 10.11 or newer\n                let clonedData = NSKeyedArchiver.archivedData(withRootObject: supertype)\n                                                 ^\n/private/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/Sources/SwiftTemplate/main.swift:48:36: note: add \'if #available\' version check\n                let clonedData = NSKeyedArchiver.archivedData(withRootObject: supertype)\n                                                 ^\n/private/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/Sources/SwiftTemplate/main.swift:36:6: note: add @available attribute to enclosing global function\nfunc resolveSupertypes(_ type: Type) {\n     ^\n/private/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/Sources/SwiftTemplate/main.swift:192:15: error: type of expression is ambiguous without more context\n                        variables: [\n                                   ^\n"
  - error : ""
```

The error would output for any Swift templates.

This PR adds a `exitCode` property (I'm open to renaming it, just thought it's the best way to describe what it is), that the users of `runCommand()` can check against if they expect that commands that run fine returns `0`.

This PR fixes the issue so the proper error is displayed:
```bash
$ sourcery <...>
error: [1/3] Compiling Swift Module 'SourceryRuntime' (27 sources)
[2/3] Compiling Swift Module 'SwiftTemplate' (1 sources)
/private/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/Sources/SwiftTemplate/main.swift:48:36: error: 'archivedData(withRootObject:)' is only available on OS X 10.11 or newer
                let clonedData = NSKeyedArchiver.archivedData(withRootObject: supertype)
                                                 ^
/private/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/Sources/SwiftTemplate/main.swift:48:36: note: add 'if #available' version check
                let clonedData = NSKeyedArchiver.archivedData(withRootObject: supertype)
                                                 ^
/private/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/Sources/SwiftTemplate/main.swift:36:6: note: add @available attribute to enclosing global function
func resolveSupertypes(_ type: Type) {
     ^
/private/var/folders/dp/c00zlqc16hz9j4501jw8bkmm0000gn/T/SwiftTemplate/0.16.1/Sources/SwiftTemplate/main.swift:192:15: error: type of expression is ambiguous without more context
                        variables: [
                                   ^
```

The was related to my template which just had a compile error which wasn't passed on correctly (I just resorted to not using `NSKeyedArchiver.archivedData(withRootObject:)` anymore).