### PR TITLE
Update project to run with Xcode 10.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     macos:
-      xcode: "10.0.0"
+      xcode: "10.2.1"
     environment:
       - XCODE_WORKSPACE: Sourcery.xcworkspace
       - XCODE_PROJECT: Sourcery.xcodeproj

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: set -o pipefail
       - run: bundle exec rake build
       - run: bundle exec rake tests
-      - run: swift build && .build/x86_64-apple-macosx10.10/debug/sourcery --sources SourceryRuntime/Sources --templates Templates/Templates --output SourceryRuntime/Sources --ejsPath SourceryJS/Sources/ejs.js
+      - run: swift build && .build/x86_64-apple-macosx/debug/sourcery --sources SourceryRuntime/Sources --templates Templates/Templates --output SourceryRuntime/Sources --ejsPath SourceryJS/Sources/ejs.js
       - run: bundle exec slather coverage --scheme "$XCODE_SCHEME" --workspace "$XCODE_WORKSPACE" --output-directory $CIRCLE_ARTIFACTS --binary-basename SourceryRuntime --binary-basename Sourcery --cobertura-xml Sourcery.xcodeproj || true
       - run: bash <(curl -s https://codecov.io/bash) -f $CIRCLE_ARTIFACTS/cobertura.xml -X coveragepy -X gcov -X xcode
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,12 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 import PackageDescription
 
 let package = Package(
     name: "Sourcery",
+    platforms: [
+       .macOS(.v10_11),
+    ],
     products: [
         .executable(name: "sourcery", targets: ["Sourcery"]),
         .library(name: "SourceryRuntime", targets: ["SourceryRuntime"]),

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - AEXML (4.3.3)
   - Commander (0.7.0)
-  - Nimble (7.3.1)
+  - Nimble (8.0.1)
   - PathKit (0.9.2)
   - Quick (1.3.2)
   - SourceKittenFramework (0.21.2):
@@ -57,7 +57,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AEXML: 601f41fcaa7bda7605cad153b0f43db9ec006c0f
   Commander: a12712a84e9641e712aa5b6c196fddb8d6556189
-  Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
+  Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
   PathKit: 273f59a38e3218eb95abd9f6a61730a8bcfd2f06
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
   SourceKittenFramework: 939cbc178445dfd3700a7476187ad36443a1d756

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,7 +1,7 @@
 PODS:
   - AEXML (4.3.3)
   - Commander (0.7.0)
-  - Nimble (7.3.1)
+  - Nimble (8.0.1)
   - PathKit (0.9.2)
   - Quick (1.3.2)
   - SourceKittenFramework (0.21.2):
@@ -57,7 +57,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AEXML: 601f41fcaa7bda7605cad153b0f43db9ec006c0f
   Commander: a12712a84e9641e712aa5b6c196fddb8d6556189
-  Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
+  Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
   PathKit: 273f59a38e3218eb95abd9f6a61730a8bcfd2f06
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
   SourceKittenFramework: 939cbc178445dfd3700a7476187ad36443a1d756

--- a/Pods/Nimble/README.md
+++ b/Pods/Nimble/README.md
@@ -4,6 +4,7 @@
 [![CocoaPods](https://img.shields.io/cocoapods/v/Nimble.svg)](https://cocoapods.org/pods/Nimble)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Platforms](https://img.shields.io/cocoapods/p/Nimble.svg)](https://cocoapods.org/pods/Nimble)
+[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 Use Nimble to express the expected outcomes of Swift
 or Objective-C expressions. Inspired by
@@ -306,20 +307,8 @@ In Nimble, it's easy to make expectations on values that are updated
 asynchronously. Just use `toEventually` or `toEventuallyNot`:
 
 ```swift
-// Swift 3.0 and later
-
+// Swift
 DispatchQueue.main.async {
-    ocean.add("dolphins")
-    ocean.add("whales")
-}
-expect(ocean).toEventually(contain("dolphins", "whales"))
-```
-
-
-```swift
-// Swift 2.3 and earlier
-
-dispatch_async(dispatch_get_main_queue()) {
     ocean.add("dolphins")
     ocean.add("whales")
 }
@@ -857,11 +846,7 @@ Notes:
 
 ## Swift Error Handling
 
-If you're using Swift 2.0 or newer, you can use the `throwError` matcher to check if an error is thrown.
-
-Note:
-The following code sample references the `Swift.Error` protocol. 
-This is `Swift.ErrorProtocol` in versions of Swift prior to version 3.0.
+You can use the `throwError` matcher to check if an error is thrown.
 
 ```swift
 // Swift
@@ -1277,7 +1262,7 @@ public func equal<T: Equatable>(expectedValue: T?) -> Predicate<T> {
     //   Predicate { actual in  ... }
     //
     // But shown with types here for clarity.
-    return Predicate { (actual: Expression<T>) throws -> PredicateResult in
+    return Predicate { (actualExpression: Expression<T>) throws -> PredicateResult in
         let msg = ExpectationMessage.expectedActualValueTo("equal <\(expectedValue)>")
         if let actualValue = try actualExpression.evaluate() {
             return PredicateResult(
@@ -1673,11 +1658,11 @@ backported.
 The deprecating plan is a 3 major versions removal. Which is as follows:
 
  1. Introduce new `Predicate` API, deprecation warning for old matcher APIs.
-    (Nimble `v7.x.x`)
+    (Nimble `v7.x.x` and `v8.x.x`)
  2. Introduce warnings on migration-path features (`.predicate`,
     `Predicate`-constructors with similar arguments to old API). (Nimble
-    `v8.x.x`)
- 3. Remove old API. (Nimble `v9.x.x`)
+    `v9.x.x`)
+ 3. Remove old API. (Nimble `v10.x.x`)
 
 
 # Installing Nimble

--- a/Pods/Nimble/Sources/Nimble/Adapters/AdapterProtocols.swift
+++ b/Pods/Nimble/Sources/Nimble/Adapters/AdapterProtocols.swift
@@ -13,5 +13,6 @@ public protocol AssertionHandler {
 ///
 /// @see AssertionHandler
 public var NimbleAssertionHandler: AssertionHandler = { () -> AssertionHandler in
+    // swiftlint:disable:previous identifier_name
     return isXCTestAvailable() ? NimbleXCTestHandler() : NimbleXCTestUnavailableHandler()
 }()

--- a/Pods/Nimble/Sources/Nimble/Adapters/AssertionRecorder.swift
+++ b/Pods/Nimble/Sources/Nimble/Adapters/AssertionRecorder.swift
@@ -37,21 +37,48 @@ public class AssertionRecorder: AssertionHandler {
     }
 }
 
+extension NMBExceptionCapture {
+    internal func tryBlockThrows(_ unsafeBlock: () throws -> Void) throws {
+        var catchedError: Error?
+        tryBlock {
+            do {
+                try unsafeBlock()
+            } catch {
+                catchedError = error
+            }
+        }
+        if let error = catchedError {
+            throw error
+        }
+    }
+}
+
 /// Allows you to temporarily replace the current Nimble assertion handler with
 /// the one provided for the scope of the closure.
 ///
 /// Once the closure finishes, then the original Nimble assertion handler is restored.
 ///
 /// @see AssertionHandler
-public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler, closure: () throws -> Void) {
+public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler,
+                                 file: FileString = #file,
+                                 line: UInt = #line,
+                                 closure: () throws -> Void) {
     let environment = NimbleEnvironment.activeInstance
     let oldRecorder = environment.assertionHandler
     let capturer = NMBExceptionCapture(handler: nil, finally: ({
         environment.assertionHandler = oldRecorder
     }))
     environment.assertionHandler = tempAssertionHandler
-    capturer.tryBlock {
-        try! closure()
+
+    do {
+        try capturer.tryBlockThrows {
+            try closure()
+        }
+    } catch {
+        let failureMessage = FailureMessage()
+        failureMessage.stringValue = "unexpected error thrown: <\(error)>"
+        let location = SourceLocation(file: file, line: line)
+        tempAssertionHandler.assert(false, message: failureMessage, location: location)
     }
 }
 

--- a/Pods/Nimble/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Pods/Nimble/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 
 private func from(objcPredicate: NMBPredicate) -> Predicate<NSObject> {
     return Predicate { actualExpression in
@@ -15,6 +15,7 @@ internal struct ObjCMatcherWrapper: Matcher {
 
     func matches(_ actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool {
         return matcher.matches(
+            // swiftlint:disable:next force_try
             ({ try! actualExpression.evaluate() }),
             failureMessage: failureMessage,
             location: actualExpression.location)
@@ -22,6 +23,7 @@ internal struct ObjCMatcherWrapper: Matcher {
 
     func doesNotMatch(_ actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool {
         return matcher.doesNotMatch(
+            // swiftlint:disable:next force_try
             ({ try! actualExpression.evaluate() }),
             failureMessage: failureMessage,
             location: actualExpression.location)
@@ -30,11 +32,13 @@ internal struct ObjCMatcherWrapper: Matcher {
 
 // Equivalent to Expectation, but for Nimble's Objective-C interface
 public class NMBExpectation: NSObject {
+    // swiftlint:disable identifier_name
     internal let _actualBlock: () -> NSObject?
     internal var _negative: Bool
     internal let _file: FileString
     internal let _line: UInt
     internal var _timeout: TimeInterval = 1.0
+    // swiftlint:enable identifier_name
 
     @objc public init(actualBlock: @escaping () -> NSObject?, negative: Bool, file: FileString, line: UInt) {
         self._actualBlock = actualBlock

--- a/Pods/Nimble/Sources/Nimble/Adapters/NMBObjCMatcher.swift
+++ b/Pods/Nimble/Sources/Nimble/Adapters/NMBObjCMatcher.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 
 // swiftlint:disable line_length
 public typealias MatcherBlock = (_ actualExpression: Expression<NSObject>, _ failureMessage: FailureMessage) throws -> Bool
@@ -8,8 +8,10 @@ public typealias FullMatcherBlock = (_ actualExpression: Expression<NSObject>, _
 // swiftlint:enable line_length
 
 public class NMBObjCMatcher: NSObject, NMBMatcher {
+    // swiftlint:disable identifier_name
     let _match: MatcherBlock
     let _doesNotMatch: MatcherBlock
+    // swiftlint:enable identifier_name
     let canMatchNil: Bool
 
     public init(canMatchNil: Bool, matcher: @escaping MatcherBlock, notMatcher: @escaping MatcherBlock) {

--- a/Pods/Nimble/Sources/Nimble/Adapters/NimbleEnvironment.swift
+++ b/Pods/Nimble/Sources/Nimble/Adapters/NimbleEnvironment.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// "Global" state of Nimble is stored here. Only DSL functions should access / be aware of this
 /// class' existence
-internal class NimbleEnvironment {
+internal class NimbleEnvironment: NSObject {
     static var activeInstance: NimbleEnvironment {
         get {
             let env = Thread.current.threadDictionary["NimbleEnvironment"]
@@ -20,6 +20,7 @@ internal class NimbleEnvironment {
         }
     }
 
+    // swiftlint:disable:next todo
     // TODO: eventually migrate the global to this environment value
     var assertionHandler: AssertionHandler {
         get { return NimbleAssertionHandler }
@@ -29,17 +30,14 @@ internal class NimbleEnvironment {
     var suppressTVOSAssertionWarning: Bool = false
     var awaiter: Awaiter
 
-    init() {
-        let timeoutQueue: DispatchQueue
-        if #available(OSX 10.10, *) {
-            timeoutQueue = DispatchQueue.global(qos: .userInitiated)
-        } else {
-            timeoutQueue = DispatchQueue.global(priority: .high)
-        }
-
+    override init() {
+        let timeoutQueue = DispatchQueue.global(qos: .userInitiated)
         awaiter = Awaiter(
             waitLock: AssertionWaitLock(),
             asyncQueue: .main,
-            timeoutQueue: timeoutQueue)
+            timeoutQueue: timeoutQueue
+        )
+
+        super.init()
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Pods/Nimble/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -64,7 +64,7 @@ class NimbleXCTestUnavailableHandler: AssertionHandler {
 #endif
 
 func isXCTestAvailable() -> Bool {
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
     // XCTest is weakly linked and so may not be present
     return NSClassFromString("XCTestCase") != nil
 #else
@@ -77,15 +77,14 @@ public func recordFailure(_ message: String, location: SourceLocation) {
     XCTFail("\(message)", file: location.file, line: location.line)
 #else
     if let testCase = CurrentTestCaseTracker.sharedInstance.currentTestCase {
-        #if swift(>=4)
         let line = Int(location.line)
-        #else
-        let line = location.line
-        #endif
         testCase.recordFailure(withDescription: message, inFile: location.file, atLine: line, expected: true)
     } else {
-        let msg = "Attempted to report a test failure to XCTest while no test case was running. " +
-        "The failure was:\n\"\(message)\"\nIt occurred at: \(location.file):\(location.line)"
+        let msg = """
+            Attempted to report a test failure to XCTest while no test case was running. The failure was:
+            \"\(message)\"
+            It occurred at: \(location.file):\(location.line)
+            """
         NSException(name: .internalInconsistencyException, reason: msg, userInfo: nil).raise()
     }
 #endif

--- a/Pods/Nimble/Sources/Nimble/DSL+Wait.swift
+++ b/Pods/Nimble/Sources/Nimble/DSL+Wait.swift
@@ -14,7 +14,7 @@ internal class NMBWait: NSObject {
 // About these kind of lines, `@objc` attributes are only required for Objective-C
 // support, so that should be conditional on Darwin platforms and normal Xcode builds
 // (non-SwiftPM builds).
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
     @objc
     internal class func until(
         timeout: TimeInterval,
@@ -87,13 +87,19 @@ internal class NMBWait: NSObject {
             }
     }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
     @objc(untilFile:line:action:)
-    internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) {
+    internal class func until(
+        _ file: FileString = #file,
+        line: UInt = #line,
+        action: @escaping (@escaping () -> Void) -> Void) {
         until(timeout: 1, file: file, line: line, action: action)
     }
 #else
-    internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) {
+    internal class func until(
+        _ file: FileString = #file,
+        line: UInt = #line,
+        action: @escaping (@escaping () -> Void) -> Void) {
         until(timeout: 1, file: file, line: line, action: action)
     }
 #endif

--- a/Pods/Nimble/Sources/Nimble/DSL.swift
+++ b/Pods/Nimble/Sources/Nimble/DSL.swift
@@ -43,12 +43,13 @@ internal func nimblePrecondition(
     line: UInt = #line) {
         let result = expr()
         if !result {
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-            let e = NSException(
+#if canImport(Darwin)
+            let exception = NSException(
                 name: NSExceptionName(name()),
                 reason: message(),
-                userInfo: nil)
-            e.raise()
+                userInfo: nil
+            )
+            exception.raise()
 #else
             preconditionFailure("\(name()) - \(message())", file: file, line: line)
 #endif
@@ -56,9 +57,12 @@ internal func nimblePrecondition(
 }
 
 internal func internalError(_ msg: String, file: FileString = #file, line: UInt = #line) -> Never {
+    // swiftlint:disable line_length
     fatalError(
-        "Nimble Bug Found: \(msg) at \(file):\(line).\n" +
-        "Please file a bug to Nimble: https://github.com/Quick/Nimble/issues with the " +
-        "code snippet that caused this error."
+        """
+        Nimble Bug Found: \(msg) at \(file):\(line).
+        Please file a bug to Nimble: https://github.com/Quick/Nimble/issues with the code snippet that caused this error.
+        """
     )
+    // swiftlint:enable line_length
 }

--- a/Pods/Nimble/Sources/Nimble/ExpectationMessage.swift
+++ b/Pods/Nimble/Sources/Nimble/ExpectationMessage.swift
@@ -75,6 +75,7 @@ public indirect enum ExpectationMessage {
     }
 
     internal func visitLeafs(_ f: (ExpectationMessage) -> ExpectationMessage) -> ExpectationMessage {
+        // swiftlint:disable:previous identifier_name
         switch self {
         case .fail, .expectedTo, .expectedActualValueTo, .expectedCustomValueTo:
             return f(self)
@@ -90,6 +91,7 @@ public indirect enum ExpectationMessage {
     /// Replaces a primary expectation with one returned by f. Preserves all composite expectations
     /// that were built upon it (aka - all appended(message:) and appended(details:).
     public func replacedExpectation(_ f: @escaping (ExpectationMessage) -> ExpectationMessage) -> ExpectationMessage {
+        // swiftlint:disable:previous identifier_name
         func walk(_ msg: ExpectationMessage) -> ExpectationMessage {
             switch msg {
             case .fail, .expectedTo, .expectedActualValueTo, .expectedCustomValueTo:
@@ -124,6 +126,7 @@ public indirect enum ExpectationMessage {
         return visitLeafs(walk)
     }
 
+    // swiftlint:disable:next todo
     // TODO: test & verify correct behavior
     internal func prepended(message: String) -> ExpectationMessage {
         return .prepends(message, self)
@@ -183,32 +186,32 @@ public indirect enum ExpectationMessage {
 
 extension FailureMessage {
     internal func toExpectationMessage() -> ExpectationMessage {
-        let defaultMsg = FailureMessage()
-        if expected != defaultMsg.expected || _stringValueOverride != nil {
+        let defaultMessage = FailureMessage()
+        if expected != defaultMessage.expected || _stringValueOverride != nil {
             return .fail(stringValue)
         }
 
-        var msg: ExpectationMessage = .fail(userDescription ?? "")
+        var message: ExpectationMessage = .fail(userDescription ?? "")
         if actualValue != "" && actualValue != nil {
-            msg = .expectedCustomValueTo(postfixMessage, actualValue ?? "")
-        } else if postfixMessage != defaultMsg.postfixMessage {
+            message = .expectedCustomValueTo(postfixMessage, actualValue ?? "")
+        } else if postfixMessage != defaultMessage.postfixMessage {
             if actualValue == nil {
-                msg = .expectedTo(postfixMessage)
+                message = .expectedTo(postfixMessage)
             } else {
-                msg = .expectedActualValueTo(postfixMessage)
+                message = .expectedActualValueTo(postfixMessage)
             }
         }
-        if postfixActual != defaultMsg.postfixActual {
-            msg = .appends(msg, postfixActual)
+        if postfixActual != defaultMessage.postfixActual {
+            message = .appends(message, postfixActual)
         }
-        if let m = extendedMessage {
-            msg = .details(msg, m)
+        if let extended = extendedMessage {
+            message = .details(message, extended)
         }
-        return msg
+        return message
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 
 public class NMBExpectationMessage: NSObject {
     private let msg: ExpectationMessage

--- a/Pods/Nimble/Sources/Nimble/Expression.swift
+++ b/Pods/Nimble/Sources/Nimble/Expression.swift
@@ -24,8 +24,10 @@ internal func memoizedClosure<T>(_ closure: @escaping () throws -> T) -> (Bool) 
 /// This provides a common consumable API for matchers to utilize to allow
 /// Nimble to change internals to how the captured closure is managed.
 public struct Expression<T> {
+    // swiftlint:disable identifier_name
     internal let _expression: (Bool) throws -> T?
     internal let _withoutCaching: Bool
+    // swiftlint:enable identifier_name
     public let location: SourceLocation
     public let isClosure: Bool
 

--- a/Pods/Nimble/Sources/Nimble/FailureMessage.swift
+++ b/Pods/Nimble/Sources/Nimble/FailureMessage.swift
@@ -28,6 +28,7 @@ public class FailureMessage: NSObject {
         }
     }
 
+    // swiftlint:disable:next identifier_name
     internal var _stringValueOverride: String?
     internal var hasOverriddenStringValue: Bool {
         return _stringValueOverride != nil

--- a/Pods/Nimble/Sources/Nimble/Matchers/AllPass.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/AllPass.swift
@@ -63,7 +63,7 @@ private func createPredicate<S>(_ elementMatcher: Predicate<S.Iterator.Element>)
         }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
     @objc public class func allPassMatcher(_ matcher: NMBMatcher) -> NMBPredicate {
         return NMBPredicate { actualExpression in
@@ -103,6 +103,7 @@ extension NMBObjCMatcher {
                 } else {
                     let failureMessage = FailureMessage()
                     let result = matcher.matches(
+                        // swiftlint:disable:next force_try
                         ({ try! expr.evaluate() }),
                         failureMessage: failureMessage,
                         location: expr.location

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -29,7 +29,7 @@ public func beAKindOf<T>(_ expectedType: T.Type) -> Predicate<Any> {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 
 /// A Nimble matcher that succeeds when the actual value is an instance of the given class.
 /// @see beAnInstanceOf if you want to match against the exact class

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -33,7 +33,7 @@ public func beAnInstanceOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
         } else {
             actualString = "<nil>"
         }
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if canImport(Darwin)
             let matches = instance != nil && instance!.isMember(of: expectedClass)
         #else
             let matches = instance != nil && type(of: instance!) == expectedClass
@@ -45,7 +45,7 @@ public func beAnInstanceOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
     @objc public class func beAnInstanceOfMatcher(_ expected: AnyClass) -> NMBMatcher {
         return NMBPredicate { actualExpression in

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// swiftlint:disable:next identifier_name
 public let DefaultDelta = 0.0001
 
 internal func isCloseTo(_ actualValue: NMBDoubleConvertible?,
@@ -34,10 +35,12 @@ public func beCloseTo(_ expectedValue: NMBDoubleConvertible, within delta: Doubl
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 public class NMBObjCBeCloseToMatcher: NSObject, NMBMatcher {
+    // swiftlint:disable identifier_name
     var _expected: NSNumber
     var _delta: CDouble
+    // swiftlint:enable identifier_name
     init(expected: NSNumber, within: CDouble) {
         _expected = expected
         _delta = within
@@ -110,14 +113,17 @@ public func beCloseTo(_ expectedValues: [Double], within delta: Double = Default
 
 infix operator ≈ : ComparisonPrecedence
 
+// swiftlint:disable:next identifier_name
 public func ≈(lhs: Expectation<[Double]>, rhs: [Double]) {
     lhs.to(beCloseTo(rhs))
 }
 
+// swiftlint:disable:next identifier_name
 public func ≈(lhs: Expectation<NMBDoubleConvertible>, rhs: NMBDoubleConvertible) {
     lhs.to(beCloseTo(rhs))
 }
 
+// swiftlint:disable:next identifier_name
 public func ≈(lhs: Expectation<NMBDoubleConvertible>, rhs: (expected: NMBDoubleConvertible, delta: Double)) {
     lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
 }
@@ -133,6 +139,7 @@ precedencegroup PlusMinusOperatorPrecedence {
 }
 
 infix operator ± : PlusMinusOperatorPrecedence
+// swiftlint:disable:next identifier_name
 public func ±(lhs: NMBDoubleConvertible, rhs: Double) -> (expected: NMBDoubleConvertible, delta: Double) {
     return (expected: lhs, delta: rhs)
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeEmpty.swift
@@ -4,12 +4,33 @@ import Foundation
 /// means the are no items in that collection. For strings, it is an empty string.
 public func beEmpty<S: Sequence>() -> Predicate<S> {
     return Predicate.simple("be empty") { actualExpression in
-        let actualSeq = try actualExpression.evaluate()
-        if actualSeq == nil {
+        guard let actual = try actualExpression.evaluate() else {
             return .fail
         }
-        var generator = actualSeq!.makeIterator()
+        var generator = actual.makeIterator()
         return PredicateStatus(bool: generator.next() == nil)
+    }
+}
+
+/// A Nimble matcher that succeeds when a value is "empty". For collections, this
+/// means the are no items in that collection. For strings, it is an empty string.
+public func beEmpty<S: SetAlgebra>() -> Predicate<S> {
+    return Predicate.simple("be empty") { actualExpression in
+        guard let actual = try actualExpression.evaluate() else {
+            return .fail
+        }
+        return PredicateStatus(bool: actual.isEmpty)
+    }
+}
+
+/// A Nimble matcher that succeeds when a value is "empty". For collections, this
+/// means the are no items in that collection. For strings, it is an empty string.
+public func beEmpty<S: Sequence & SetAlgebra>() -> Predicate<S> {
+    return Predicate.simple("be empty") { actualExpression in
+        guard let actual = try actualExpression.evaluate() else {
+            return .fail
+        }
+        return PredicateStatus(bool: actual.isEmpty)
     }
 }
 
@@ -61,7 +82,7 @@ public func beEmpty() -> Predicate<NMBCollection> {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
     @objc public class func beEmptyMatcher() -> NMBPredicate {
         return NMBPredicate { actualExpression in

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -30,12 +30,12 @@ public func > (lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
     lhs.to(beGreaterThan(rhs))
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func beGreaterThanMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func beGreaterThanMatcher(_ expected: NMBComparable?) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { $0 as? NMBComparable }
-            return try beGreaterThan(expected).matches(expr, failureMessage: failureMessage)
+            return try beGreaterThan(expected).satisfies(expr).toObjectiveC()
         }
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -32,12 +32,12 @@ public func >=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beGreaterThanOrEqualTo(rhs))
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func beGreaterThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func beGreaterThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { $0 as? NMBComparable }
-            return try beGreaterThanOrEqualTo(expected).matches(expr, failureMessage: failureMessage)
+            return try beGreaterThanOrEqualTo(expected).satisfies(expr).toObjectiveC()
         }
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -4,14 +4,14 @@ import Foundation
 /// as the expected instance.
 public func beIdenticalTo(_ expected: Any?) -> Predicate<Any> {
     return Predicate.define { actualExpression in
-        #if os(Linux)
+        #if os(Linux) && !swift(>=4.1.50)
             let actual = try actualExpression.evaluate() as? AnyObject
         #else
             let actual = try actualExpression.evaluate() as AnyObject?
         #endif
 
         let bool: Bool
-        #if os(Linux)
+        #if os(Linux) && !swift(>=4.1.50)
             bool = actual === (expected as? AnyObject) && actual !== nil
         #else
             bool = actual === (expected as AnyObject?) && actual !== nil
@@ -41,12 +41,12 @@ public func be(_ expected: Any?) -> Predicate<Any> {
     return beIdenticalTo(expected)
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func beIdenticalToMatcher(_ expected: NSObject?) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func beIdenticalToMatcher(_ expected: NSObject?) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let aExpr = actualExpression.cast { $0 as Any? }
-            return try beIdenticalTo(expected).matches(aExpr, failureMessage: failureMessage)
+            return try beIdenticalTo(expected).satisfies(aExpr).toObjectiveC()
         }
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeLessThan.swift
@@ -29,12 +29,12 @@ public func < (lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
     lhs.to(beLessThan(rhs))
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func beLessThanMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func beLessThanMatcher(_ expected: NMBComparable?) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { $0 as? NMBComparable }
-            return try beLessThan(expected).matches(expr, failureMessage: failureMessage)
+            return try beLessThan(expected).satisfies(expr).toObjectiveC()
         }
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -29,12 +29,12 @@ public func <=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beLessThanOrEqualTo(rhs))
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func beLessThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func beLessThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { $0 as? NMBComparable }
-            return try beLessThanOrEqualTo(expected).matches(expr, failureMessage: failureMessage)
+            return try beLessThanOrEqualTo(expected).satisfies(expr).toObjectiveC()
         }
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeNil.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeNil.swift
@@ -8,11 +8,11 @@ public func beNil<T>() -> Predicate<T> {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func beNilMatcher() -> NMBObjCMatcher {
-        return NMBObjCMatcher { actualExpression, failureMessage in
-            return try beNil().matches(actualExpression, failureMessage: failureMessage)
+    @objc public class func beNilMatcher() -> NMBMatcher {
+        return NMBPredicate { actualExpression in
+            return try beNil().satisfies(actualExpression).toObjectiveC()
         }
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeVoid.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeVoid.swift
@@ -8,10 +8,12 @@ public func beVoid() -> Predicate<()> {
     }
 }
 
-public func == (lhs: Expectation<()>, rhs: ()) {
-    lhs.to(beVoid())
-}
+extension Expectation where T == () {
+    public static func == (lhs: Expectation<()>, rhs: ()) {
+        lhs.to(beVoid())
+    }
 
-public func != (lhs: Expectation<()>, rhs: ()) {
-    lhs.toNot(beVoid())
+    public static func != (lhs: Expectation<()>, rhs: ()) {
+        lhs.toNot(beVoid())
+    }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/BeginWith.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/BeginWith.swift
@@ -35,24 +35,24 @@ public func beginWith(_ startingElement: Any) -> Predicate<NMBOrderedCollection>
 public func beginWith(_ startingSubstring: String) -> Predicate<String> {
     return Predicate.simple("begin with <\(startingSubstring)>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
-            let range = actual.range(of: startingSubstring)
-            return PredicateStatus(bool: range != nil && range!.lowerBound == actual.startIndex)
+            return PredicateStatus(bool: actual.hasPrefix(startingSubstring))
         }
         return .fail
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func beginWithMatcher(_ expected: Any) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func beginWithMatcher(_ expected: Any) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let actual = try actualExpression.evaluate()
-            if (actual as? String) != nil {
+            if actual is String {
                 let expr = actualExpression.cast { $0 as? String }
-                return try beginWith(expected as! String).matches(expr, failureMessage: failureMessage)
+                // swiftlint:disable:next force_cast
+                return try beginWith(expected as! String).satisfies(expr).toObjectiveC()
             } else {
                 let expr = actualExpression.cast { $0 as? NMBOrderedCollection }
-                return try beginWith(expected).matches(expr, failureMessage: failureMessage)
+                return try beginWith(expected).satisfies(expr).toObjectiveC()
             }
         }
     }

--- a/Pods/Nimble/Sources/Nimble/Matchers/Contain.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/Contain.swift
@@ -1,22 +1,63 @@
 import Foundation
 
-/// A Nimble matcher that succeeds when the actual sequence contains the expected value.
+/// A Nimble matcher that succeeds when the actual sequence contains the expected values.
 public func contain<S: Sequence, T: Equatable>(_ items: T...) -> Predicate<S>
-    where S.Iterator.Element == T {
+    where S.Element == T {
     return contain(items)
 }
 
+/// A Nimble matcher that succeeds when the actual sequence contains the expected values.
 public func contain<S: Sequence, T: Equatable>(_ items: [T]) -> Predicate<S>
-    where S.Iterator.Element == T {
+    where S.Element == T {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
-            let matches = items.all {
+            let matches = items.allSatisfy {
                 return actual.contains($0)
             }
             return PredicateStatus(bool: matches)
         }
         return .fail
     }
+}
+
+/// A Nimble matcher that succeeds when the actual set contains the expected values.
+public func contain<S: SetAlgebra, T: Equatable>(_ items: T...) -> Predicate<S>
+    where S.Element == T {
+        return contain(items)
+}
+
+/// A Nimble matcher that succeeds when the actual set contains the expected values.
+public func contain<S: SetAlgebra, T: Equatable>(_ items: [T]) -> Predicate<S>
+    where S.Element == T {
+        return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
+            if let actual = try actualExpression.evaluate() {
+                let matches = items.allSatisfy {
+                    return actual.contains($0)
+                }
+                return PredicateStatus(bool: matches)
+            }
+            return .fail
+        }
+}
+
+/// A Nimble matcher that succeeds when the actual set contains the expected values.
+public func contain<S: Sequence & SetAlgebra, T: Equatable>(_ items: T...) -> Predicate<S>
+    where S.Element == T {
+        return contain(items)
+}
+
+/// A Nimble matcher that succeeds when the actual set contains the expected values.
+public func contain<S: Sequence & SetAlgebra, T: Equatable>(_ items: [T]) -> Predicate<S>
+    where S.Element == T {
+        return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
+            if let actual = try actualExpression.evaluate() {
+                let matches = items.allSatisfy {
+                    return actual.contains($0)
+                }
+                return PredicateStatus(bool: matches)
+            }
+            return .fail
+        }
 }
 
 /// A Nimble matcher that succeeds when the actual string contains the expected substring.
@@ -27,7 +68,7 @@ public func contain(_ substrings: String...) -> Predicate<String> {
 public func contain(_ substrings: [String]) -> Predicate<String> {
     return Predicate.simple("contain <\(arrayAsString(substrings))>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
-            let matches = substrings.all {
+            let matches = substrings.allSatisfy {
                 let range = actual.range(of: $0)
                 return range != nil && !range!.isEmpty
             }
@@ -45,7 +86,7 @@ public func contain(_ substrings: NSString...) -> Predicate<NSString> {
 public func contain(_ substrings: [NSString]) -> Predicate<NSString> {
     return Predicate.simple("contain <\(arrayAsString(substrings))>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
-            let matches = substrings.all { actual.range(of: $0.description).length != 0 }
+            let matches = substrings.allSatisfy { actual.range(of: $0.description).length != 0 }
             return PredicateStatus(bool: matches)
         }
         return .fail
@@ -60,17 +101,17 @@ public func contain(_ items: Any?...) -> Predicate<NMBContainer> {
 public func contain(_ items: [Any?]) -> Predicate<NMBContainer> {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-        let matches = items.all { item in
+        let matches = items.allSatisfy { item in
             return item.map { actual.contains($0) } ?? false
         }
         return PredicateStatus(bool: matches)
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func containMatcher(_ expected: [NSObject]) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func containMatcher(_ expected: [NSObject]) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let location = actualExpression.location
             let actualValue = try actualExpression.evaluate()
             if let value = actualValue as? NMBContainer {
@@ -78,17 +119,25 @@ extension NMBObjCMatcher {
 
                 // A straightforward cast on the array causes this to crash, so we have to cast the individual items
                 let expectedOptionals: [Any?] = expected.map({ $0 as Any? })
-                return try contain(expectedOptionals).matches(expr, failureMessage: failureMessage)
+                return try contain(expectedOptionals).satisfies(expr).toObjectiveC()
             } else if let value = actualValue as? NSString {
                 let expr = Expression(expression: ({ value as String }), location: location)
-                return try contain(expected as! [String]).matches(expr, failureMessage: failureMessage)
-            } else if actualValue != nil {
-                // swiftlint:disable:next line_length
-                failureMessage.postfixMessage = "contain <\(arrayAsString(expected))> (only works for NSArrays, NSSets, NSHashTables, and NSStrings)"
-            } else {
-                failureMessage.postfixMessage = "contain <\(arrayAsString(expected))>"
+                // swiftlint:disable:next force_cast
+                return try contain(expected as! [String]).satisfies(expr).toObjectiveC()
             }
-            return false
+
+            let message: ExpectationMessage
+            if actualValue != nil {
+                message = ExpectationMessage.expectedActualValueTo(
+                    // swiftlint:disable:next line_length
+                    "contain <\(arrayAsString(expected))> (only works for NSArrays, NSSets, NSHashTables, and NSStrings)"
+                )
+            } else {
+                message = ExpectationMessage
+                    .expectedActualValueTo("contain <\(arrayAsString(expected))>")
+                    .appendedBeNilHint()
+            }
+            return NMBPredicateResult(status: .fail, message: message.toObjectiveC())
         }
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/ElementsEqual.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/ElementsEqual.swift
@@ -1,0 +1,16 @@
+/// A Nimble matcher that succeeds when the actual sequence contain the same elements in the same order to the exepected sequence.
+public func elementsEqual<S: Sequence>(_ expectedValue: S?) -> Predicate<S> where S.Element: Equatable {
+    // A matcher abstraction for https://developer.apple.com/documentation/swift/sequence/2949668-elementsequal
+    return Predicate.define("elementsEqual <\(stringify(expectedValue))>") { (actualExpression, msg) in
+        let actualValue = try actualExpression.evaluate()
+        switch (expectedValue, actualValue) {
+        case (nil, _?):
+            return PredicateResult(status: .fail, message: msg.appendedBeNilHint())
+        case (nil, nil), (_, nil):
+            return PredicateResult(status: .fail, message: msg)
+        case (let expected?, let actual?):
+            let matches = expected.elementsEqual(actual)
+            return PredicateResult(bool: matches, message: msg)
+        }
+    }
+}

--- a/Pods/Nimble/Sources/Nimble/Matchers/EndWith.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/EndWith.swift
@@ -50,17 +50,18 @@ public func endWith(_ endingSubstring: String) -> Predicate<String> {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func endWithMatcher(_ expected: Any) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func endWithMatcher(_ expected: Any) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let actual = try actualExpression.evaluate()
-            if (actual as? String) != nil {
+            if actual is String {
                 let expr = actualExpression.cast { $0 as? String }
-                return try endWith(expected as! String).matches(expr, failureMessage: failureMessage)
+                // swiftlint:disable:next force_cast
+                return try endWith(expected as! String).satisfies(expr).toObjectiveC()
             } else {
                 let expr = actualExpression.cast { $0 as? NMBOrderedCollection }
-                return try endWith(expected).matches(expr, failureMessage: failureMessage)
+                return try endWith(expected).satisfies(expr).toObjectiveC()
             }
         }
     }

--- a/Pods/Nimble/Sources/Nimble/Matchers/Equal.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/Equal.swift
@@ -7,103 +7,30 @@ import Foundation
 public func equal<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
-        let matches = actualValue == expectedValue && expectedValue != nil
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil && actualValue != nil {
-                return PredicateResult(
-                    status: .fail,
-                    message: msg.appendedBeNilHint()
-                )
-            }
+        switch (expectedValue, actualValue) {
+        case (nil, _?):
+            return PredicateResult(status: .fail, message: msg.appendedBeNilHint())
+        case (nil, nil), (_, nil):
             return PredicateResult(status: .fail, message: msg)
+        case (let expected?, let actual?):
+            let matches = expected == actual
+            return PredicateResult(bool: matches, message: msg)
         }
-        return PredicateResult(status: PredicateStatus(bool: matches), message: msg)
-    }
-}
-
-/// A Nimble matcher that succeeds when the actual value is equal to the expected value.
-/// Values can support equal by supporting the Equatable protocol.
-///
-/// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
-public func equal<T, C: Equatable>(_ expectedValue: [T: C]?) -> Predicate<[T: C]> {
-    return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
-        let actualValue = try actualExpression.evaluate()
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil && actualValue != nil {
-                return PredicateResult(
-                    status: .fail,
-                    message: msg.appendedBeNilHint()
-                )
-            }
-            return PredicateResult(status: .fail, message: msg)
-        }
-        return PredicateResult(
-            status: PredicateStatus(bool: expectedValue! == actualValue!),
-            message: msg
-        )
-    }
-}
-
-/// A Nimble matcher that succeeds when the actual collection is equal to the expected collection.
-/// Items must implement the Equatable protocol.
-public func equal<T: Equatable>(_ expectedValue: [T]?) -> Predicate<[T]> {
-    return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
-        let actualValue = try actualExpression.evaluate()
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil && actualValue != nil {
-                return PredicateResult(
-                    status: .fail,
-                    message: msg.appendedBeNilHint()
-                )
-            }
-            return PredicateResult(
-                status: .fail,
-                message: msg
-            )
-        }
-        return PredicateResult(
-            bool: expectedValue! == actualValue!,
-            message: msg
-        )
     }
 }
 
 /// A Nimble matcher allowing comparison of collection with optional type
 public func equal<T: Equatable>(_ expectedValue: [T?]) -> Predicate<[T?]> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
-        if let actualValue = try actualExpression.evaluate() {
-            let doesNotMatch = PredicateResult(
-                status: .doesNotMatch,
-                message: msg
-            )
-
-            if expectedValue.count != actualValue.count {
-                return doesNotMatch
-            }
-
-            for (index, item) in actualValue.enumerated() {
-                let otherItem = expectedValue[index]
-                if item == nil && otherItem == nil {
-                    continue
-                } else if item == nil && otherItem != nil {
-                    return doesNotMatch
-                } else if item != nil && otherItem == nil {
-                    return doesNotMatch
-                } else if item! != otherItem! {
-                    return doesNotMatch
-                }
-            }
-
-            return PredicateResult(
-                status: .matches,
-                message: msg
-            )
-        } else {
+        guard let actualValue = try actualExpression.evaluate() else {
             return PredicateResult(
                 status: .fail,
                 message: msg.appendedBeNilHint()
             )
         }
+
+        let matches = expectedValue == actualValue
+        return PredicateResult(bool: matches, message: msg)
     }
 }
 
@@ -128,44 +55,45 @@ private func equal<T>(_ expectedValue: Set<T>?, stringify: @escaping (Set<T>?) -
         var errorMessage: ExpectationMessage =
             .expectedActualValueTo("equal <\(stringify(expectedValue))>")
 
-        if let expectedValue = expectedValue {
-            if let actualValue = try actualExpression.evaluate() {
-                errorMessage = .expectedCustomValueTo(
-                    "equal <\(stringify(expectedValue))>",
-                    "<\(stringify(actualValue))>"
-                )
-
-                if expectedValue == actualValue {
-                    return PredicateResult(
-                        status: .matches,
-                        message: errorMessage
-                    )
-                }
-
-                let missing = expectedValue.subtracting(actualValue)
-                if missing.count > 0 {
-                    errorMessage = errorMessage.appended(message: ", missing <\(stringify(missing))>")
-                }
-
-                let extra = actualValue.subtracting(expectedValue)
-                if extra.count > 0 {
-                    errorMessage = errorMessage.appended(message: ", extra <\(stringify(extra))>")
-                }
-                return  PredicateResult(
-                    status: .doesNotMatch,
-                    message: errorMessage
-                )
-            }
-            return PredicateResult(
-                status: .fail,
-                message: errorMessage.appendedBeNilHint()
-            )
-        } else {
+        guard let expectedValue = expectedValue else {
             return PredicateResult(
                 status: .fail,
                 message: errorMessage.appendedBeNilHint()
             )
         }
+
+        guard let actualValue = try actualExpression.evaluate() else {
+            return PredicateResult(
+                status: .fail,
+                message: errorMessage.appendedBeNilHint()
+            )
+        }
+
+        errorMessage = .expectedCustomValueTo(
+            "equal <\(stringify(expectedValue))>",
+            "<\(stringify(actualValue))>"
+        )
+
+        if expectedValue == actualValue {
+            return PredicateResult(
+                status: .matches,
+                message: errorMessage
+            )
+        }
+
+        let missing = expectedValue.subtracting(actualValue)
+        if missing.count > 0 {
+            errorMessage = errorMessage.appended(message: ", missing <\(stringify(missing))>")
+        }
+
+        let extra = actualValue.subtracting(expectedValue)
+        if extra.count > 0 {
+            errorMessage = errorMessage.appended(message: ", extra <\(stringify(extra))>")
+        }
+        return  PredicateResult(
+            status: .doesNotMatch,
+            message: errorMessage
+        )
     }
 }
 
@@ -209,7 +137,7 @@ public func !=<T, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
     lhs.toNot(equal(rhs))
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
     @objc public class func equalMatcher(_ expected: NSObject) -> NMBMatcher {
         return NMBPredicate { actualExpression in

--- a/Pods/Nimble/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/HaveCount.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// A Nimble matcher that succeeds when the actual Collection's count equals
 /// the expected value
-public func haveCount<T: Collection>(_ expectedValue: T.IndexDistance) -> Predicate<T> {
+public func haveCount<T: Collection>(_ expectedValue: Int) -> Predicate<T> {
     return Predicate.define { actualExpression in
         if let actualValue = try actualExpression.evaluate() {
             let message = ExpectationMessage
@@ -45,20 +45,29 @@ public func haveCount(_ expectedValue: Int) -> Predicate<NMBCollection> {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
-    @objc public class func haveCountMatcher(_ expected: NSNumber) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    @objc public class func haveCountMatcher(_ expected: NSNumber) -> NMBMatcher {
+        return NMBPredicate { actualExpression in
             let location = actualExpression.location
             let actualValue = try actualExpression.evaluate()
             if let value = actualValue as? NMBCollection {
                 let expr = Expression(expression: ({ value as NMBCollection}), location: location)
-                return try haveCount(expected.intValue).matches(expr, failureMessage: failureMessage)
-            } else if let actualValue = actualValue {
-                failureMessage.postfixMessage = "get type of NSArray, NSSet, NSDictionary, or NSHashTable"
-                failureMessage.actualValue = "\(String(describing: type(of: actualValue)))"
+                return try haveCount(expected.intValue).satisfies(expr).toObjectiveC()
             }
-            return false
+
+            let message: ExpectationMessage
+            if let actualValue = actualValue {
+                message = ExpectationMessage.expectedCustomValueTo(
+                    "get type of NSArray, NSSet, NSDictionary, or NSHashTable",
+                    "\(String(describing: type(of: actualValue)))"
+                )
+            } else {
+                message = ExpectationMessage
+                    .expectedActualValueTo("have a collection with count \(stringify(expected.intValue))")
+                    .appendedBeNilHint()
+            }
+            return NMBPredicateResult(status: .fail, message: message.toObjectiveC())
         }
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/Match.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/Match.swift
@@ -15,7 +15,7 @@ public func match(_ expectedValue: String?) -> Predicate<String> {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 
 extension NMBObjCMatcher {
     @objc public class func matchMatcher(_ expected: NSString) -> NMBMatcher {

--- a/Pods/Nimble/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -1,6 +1,6 @@
 import Foundation
 // `CGFloat` is in Foundation (swift-corelibs-foundation) on Linux.
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
     import CoreGraphics
 #endif
 
@@ -28,7 +28,7 @@ extension Matcher {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 /// Objective-C interface to the Swift variant of Matcher.
 @objc public protocol NMBMatcher {
     func matches(_ actualBlock: @escaping () -> NSObject?, failureMessage: FailureMessage, location: SourceLocation) -> Bool
@@ -41,7 +41,8 @@ public protocol NMBContainer {
     func contains(_ anObject: Any) -> Bool
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
+// swiftlint:disable:next todo
 // FIXME: NSHashTable can not conform to NMBContainer since swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a
 //extension NSHashTable : NMBContainer {} // Corelibs Foundation does not include this class yet
 #endif
@@ -54,7 +55,7 @@ public protocol NMBCollection {
     var count: Int { get }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NSHashTable: NMBCollection {} // Corelibs Foundation does not include these classes yet
 extension NSMapTable: NMBCollection {}
 #endif
@@ -131,7 +132,7 @@ extension NSDate: TestOutputStringConvertible {
 ///  beGreaterThan(), beGreaterThanOrEqualTo(), and equal() matchers.
 ///
 /// Types that conform to Swift's Comparable protocol will work implicitly too
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 @objc public protocol NMBComparable {
     func NMB_compare(_ otherObject: NMBComparable!) -> ComparisonResult
 }
@@ -144,11 +145,13 @@ public protocol NMBComparable {
 
 extension NSNumber: NMBComparable {
     public func NMB_compare(_ otherObject: NMBComparable!) -> ComparisonResult {
+        // swiftlint:disable:next force_cast
         return compare(otherObject as! NSNumber)
     }
 }
 extension NSString: NMBComparable {
     public func NMB_compare(_ otherObject: NMBComparable!) -> ComparisonResult {
+        // swiftlint:disable:next force_cast
         return compare(otherObject as! String)
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/PostNotification.swift
@@ -1,36 +1,9 @@
 import Foundation
 
-// A workaround to SR-6419.
-extension NotificationCenter {
-#if !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
-    #if swift(>=4.0)
-        #if swift(>=4.0.2)
-        #else
-            func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, using block: @escaping (Notification) -> Void) -> NSObjectProtocol {
-                return addObserver(forName: name, object: obj, queue: queue, usingBlock: block)
-            }
-        #endif
-    #elseif swift(>=3.2)
-        #if swift(>=3.2.2)
-        #else
-            // swiftlint:disable:next line_length
-            func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, using block: @escaping (Notification) -> Void) -> NSObjectProtocol {
-                return addObserver(forName: name, object: obj, queue: queue, usingBlock: block)
-            }
-        #endif
-    #else
-        // swiftlint:disable:next line_length
-        func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, using block: @escaping (Notification) -> Void) -> NSObjectProtocol {
-            return addObserver(forName: name, object: obj, queue: queue, usingBlock: block)
-        }
-    #endif
-#endif
-}
-
 internal class NotificationCollector {
     private(set) var observedNotifications: [Notification]
     private let notificationCenter: NotificationCenter
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    #if canImport(Darwin)
     private var token: AnyObject?
     #else
     private var token: NSObjectProtocol?
@@ -43,14 +16,14 @@ internal class NotificationCollector {
 
     func startObserving() {
         // swiftlint:disable:next line_length
-        self.token = self.notificationCenter.addObserver(forName: nil, object: nil, queue: nil, using: { [weak self] n in
+        self.token = self.notificationCenter.addObserver(forName: nil, object: nil, queue: nil) { [weak self] notification in
             // linux-swift gets confused by .append(n)
-            self?.observedNotifications.append(n)
-        })
+            self?.observedNotifications.append(notification)
+        }
     }
 
     deinit {
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if canImport(Darwin)
             if let token = self.token {
                 self.notificationCenter.removeObserver(token)
             }

--- a/Pods/Nimble/Sources/Nimble/Matchers/Predicate.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/Predicate.swift
@@ -218,6 +218,7 @@ extension Predicate: Matcher {
 extension Predicate {
     // Someday, make this public? Needs documentation
     internal func after(f: @escaping (Expression<T>, PredicateResult) throws -> PredicateResult) -> Predicate<T> {
+        // swiftlint:disable:previous identifier_name
         return Predicate { actual -> PredicateResult in
             let result = try self.satisfies(actual)
             return try f(actual, result)
@@ -241,7 +242,7 @@ extension Predicate {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 public typealias PredicateBlock = (_ actualExpression: Expression<NSObject>) throws -> NMBPredicateResult
 
 public class NMBPredicate: NSObject {
@@ -311,7 +312,7 @@ final public class NMBPredicateStatus: NSObject {
     public static let doesNotMatch: NMBPredicateStatus = NMBPredicateStatus(status: 1)
     public static let fail: NMBPredicateStatus = NMBPredicateStatus(status: 2)
 
-    public override var hashValue: Int { return self.status.hashValue }
+    public override var hash: Int { return self.status.hashValue }
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let otherPredicate = object as? NMBPredicateStatus else {

--- a/Pods/Nimble/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/RaisesException.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // This matcher requires the Objective-C, and being built by Xcode rather than the Swift Package Manager 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 
 /// A Nimble matcher that succeeds when the actual expression raises an
 /// exception with the specified name, reason, and/or userInfo.
@@ -23,8 +23,12 @@ public func raiseException(
                 exception = e
             }), finally: nil)
 
-            capture.tryBlock {
-                _ = try! actualExpression.evaluate()
+            do {
+                try capture.tryBlockThrows {
+                    _ = try actualExpression.evaluate()
+                }
+            } catch {
+                return PredicateResult(status: .fail, message: .fail("unexpected error thrown: <\(error)>"))
             }
 
             let failureMessage = FailureMessage()
@@ -118,10 +122,12 @@ internal func exceptionMatchesNonNilFieldsOrClosure(
 }
 
 public class NMBObjCRaiseExceptionMatcher: NSObject, NMBMatcher {
+    // swiftlint:disable identifier_name
     internal var _name: String?
     internal var _reason: String?
     internal var _userInfo: NSDictionary?
     internal var _block: ((NSException) -> Void)?
+    // swiftlint:enable identifier_name
 
     internal init(name: String?, reason: String?, userInfo: NSDictionary?, block: ((NSException) -> Void)?) {
         _name = name

--- a/Pods/Nimble/Sources/Nimble/Matchers/SatisfyAllOf.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/SatisfyAllOf.swift
@@ -39,7 +39,7 @@ public func && <T>(left: Predicate<T>, right: Predicate<T>) -> Predicate<T> {
     return satisfyAllOf(left, right)
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
     @objc public class func satisfyAllOfMatcher(_ matchers: [NMBMatcher]) -> NMBPredicate {
         return NMBPredicate { actualExpression in
@@ -60,8 +60,12 @@ extension NMBObjCMatcher {
                         return predicate.satisfies({ try expression.evaluate() }, location: actualExpression.location).toSwift()
                     } else {
                         let failureMessage = FailureMessage()
-                        // swiftlint:disable:next line_length
-                        let success = matcher.matches({ try! expression.evaluate() }, failureMessage: failureMessage, location: actualExpression.location)
+                        let success = matcher.matches(
+                            // swiftlint:disable:next force_try
+                            { try! expression.evaluate() },
+                            failureMessage: failureMessage,
+                            location: actualExpression.location
+                        )
                         return PredicateResult(bool: success, message: failureMessage.toExpectationMessage())
                     }
                 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -47,7 +47,7 @@ public func || <T>(left: MatcherFunc<T>, right: MatcherFunc<T>) -> Predicate<T> 
     return satisfyAnyOf(left, right)
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 extension NMBObjCMatcher {
     @objc public class func satisfyAnyOfMatcher(_ matchers: [NMBMatcher]) -> NMBPredicate {
         return NMBPredicate { actualExpression in
@@ -68,8 +68,12 @@ extension NMBObjCMatcher {
                         return predicate.satisfies({ try expression.evaluate() }, location: actualExpression.location).toSwift()
                     } else {
                         let failureMessage = FailureMessage()
-                        // swiftlint:disable:next line_length
-                        let success = matcher.matches({ try! expression.evaluate() }, failureMessage: failureMessage, location: actualExpression.location)
+                        let success = matcher.matches(
+                            // swiftlint:disable:next force_try
+                            { try! expression.evaluate() },
+                            failureMessage: failureMessage,
+                            location: actualExpression.location
+                        )
                         return PredicateResult(bool: success, message: failureMessage.toExpectationMessage())
                     }
                 }

--- a/Pods/Nimble/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Pods/Nimble/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public func throwAssertion() -> Predicate<Void> {
     return Predicate { actualExpression in
-    #if arch(x86_64) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+    #if arch(x86_64) && canImport(Darwin) && !SWIFT_PACKAGE
         let message = ExpectationMessage.expectedTo("throw an assertion")
 
         var actualError: Error?
@@ -44,9 +44,8 @@ public func throwAssertion() -> Predicate<Void> {
             " conditional statement")
     #else
         fatalError("The throwAssertion Nimble matcher can only run on x86_64 platforms with " +
-            "Objective-C (e.g. Mac, iPhone 5s or later simulators). You can silence this error " +
-            "by placing the test case inside an #if arch(x86_64) or (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) conditional statement")
-        // swiftlint:disable:previous line_length
+            "Objective-C (e.g. macOS, iPhone 5s or later simulators). You can silence this error " +
+            "by placing the test case inside an #if arch(x86_64) or canImport(Darwin) conditional statement")
     #endif
     }
 }

--- a/Pods/Nimble/Sources/Nimble/Utils/Await.swift
+++ b/Pods/Nimble/Sources/Nimble/Utils/Await.swift
@@ -2,7 +2,7 @@ import CoreFoundation
 import Dispatch
 import Foundation
 
-#if !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+#if canImport(CDispatch)
     import CDispatch
 #endif
 
@@ -32,7 +32,7 @@ internal class AssertionWaitLock: WaitLock {
 
     func acquireWaitingLock(_ fnName: String, file: FileString, line: UInt) {
         let info = WaitingInfo(name: fnName, file: file, lineNumber: line)
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if canImport(Darwin)
             let isMainThread = Thread.isMainThread
         #else
             let isMainThread = _CFIsMainThread()
@@ -45,10 +45,15 @@ internal class AssertionWaitLock: WaitLock {
         nimblePrecondition(
             currentWaiter == nil,
             "InvalidNimbleAPIUsage",
-            "Nested async expectations are not allowed to avoid creating flaky tests.\n\n" +
-            "The call to\n\t\(info)\n" +
-            "triggered this exception because\n\t\(currentWaiter!)\n" +
-            "is currently managing the main run loop."
+            """
+            Nested async expectations are not allowed to avoid creating flaky tests.
+
+            The call to
+            \t\(info)
+            triggered this exception because
+            \t\(currentWaiter!)
+            is currently managing the main run loop.
+            """
         )
         currentWaiter = info
     }
@@ -180,25 +185,18 @@ internal class AwaitPromiseBuilder<T> {
         // checked.
         //
         // In addition, stopping the run loop is used to halt code executed on the main run loop.
-        #if swift(>=4.0)
         trigger.timeoutSource.schedule(
             deadline: DispatchTime.now() + timeoutInterval,
             repeating: .never,
             leeway: timeoutLeeway
         )
-        #else
-        trigger.timeoutSource.scheduleOneshot(
-            deadline: DispatchTime.now() + timeoutInterval,
-            leeway: timeoutLeeway
-        )
-        #endif
         trigger.timeoutSource.setEventHandler {
             guard self.promise.asyncResult.isIncomplete() else { return }
             let timedOutSem = DispatchSemaphore(value: 0)
             let semTimedOutOrBlocked = DispatchSemaphore(value: 0)
             semTimedOutOrBlocked.signal()
             let runLoop = CFRunLoopGetMain()
-            #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            #if canImport(Darwin)
                 let runLoopMode = CFRunLoopMode.defaultMode.rawValue
             #else
                 let runLoopMode = kCFRunLoopDefaultMode
@@ -263,7 +261,7 @@ internal class AwaitPromiseBuilder<T> {
             self.trigger.timeoutSource.resume()
             while self.promise.asyncResult.isIncomplete() {
                 // Stopping the run loop does not work unless we run only 1 mode
-                #if swift(>=4.2)
+                #if (swift(>=4.2) && canImport(Darwin)) || compiler(>=5.0)
                 _ = RunLoop.current.run(mode: .default, before: .distantFuture)
                 #else
                 _ = RunLoop.current.run(mode: .defaultRunLoopMode, before: .distantFuture)
@@ -333,11 +331,7 @@ internal class Awaiter {
         let asyncSource = createTimerSource(asyncQueue)
         let trigger = AwaitTrigger(timeoutSource: timeoutSource, actionSource: asyncSource) {
             let interval = DispatchTimeInterval.nanoseconds(Int(pollInterval * TimeInterval(NSEC_PER_SEC)))
-            #if swift(>=4.0)
             asyncSource.schedule(deadline: .now(), repeating: interval, leeway: pollLeeway)
-            #else
-            asyncSource.scheduleRepeating(deadline: .now(), interval: interval, leeway: pollLeeway)
-            #endif
             asyncSource.setEventHandler {
                 do {
                     if let result = try closure() {

--- a/Pods/Nimble/Sources/Nimble/Utils/Functional.swift
+++ b/Pods/Nimble/Sources/Nimble/Utils/Functional.swift
@@ -1,12 +1,14 @@
 import Foundation
 
+#if !swift(>=4.2)
 extension Sequence {
-    internal func all(_ fn: (Iterator.Element) -> Bool) -> Bool {
+    internal func allSatisfy(_ predicate: (Element) throws -> Bool) rethrows -> Bool {
         for item in self {
-            if !fn(item) {
+            if try !predicate(item) {
                 return false
             }
         }
         return true
     }
 }
+#endif

--- a/Pods/Nimble/Sources/Nimble/Utils/Stringers.swift
+++ b/Pods/Nimble/Sources/Nimble/Utils/Stringers.swift
@@ -2,7 +2,7 @@ import Foundation
 
 internal func identityAsString(_ value: Any?) -> String {
     let anyObject: AnyObject?
-#if os(Linux)
+#if os(Linux) && !swift(>=4.1.50)
     anyObject = value as? AnyObject
 #else
     anyObject = value as AnyObject?
@@ -122,6 +122,7 @@ extension String: TestOutputStringConvertible {
 extension Data: TestOutputStringConvertible {
     public var testDescription: String {
         #if os(Linux)
+            // swiftlint:disable:next todo
             // FIXME: Swift on Linux triggers a segfault when calling NSData's hash() (last checked on 03-11-16)
             return "Data<length=\(count)>"
         #else
@@ -158,7 +159,7 @@ public func stringify<T>(_ value: T?) -> String {
     return String(describing: value)
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 @objc public class NMBStringer: NSObject {
     @objc public class func stringify(_ obj: Any?) -> String {
         return Nimble.stringify(obj)

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 			dependencies = (
 			);
 			name = SwiftLint;
+			productName = SwiftLint;
 		};
 /* End PBXAggregateTarget section */
 
@@ -603,7 +604,7 @@
 		05F79EC5DB98C61ECC761E8DBD3B7F22 /* Yams-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Yams-prefix.pch"; sourceTree = "<group>"; };
 		0696E69C82BB1CD491EBCF282E81B846 /* Documentation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Documentation.h; path = Source/Clang_C/include/Documentation.h; sourceTree = "<group>"; };
 		06F514801346F8E0DB83F7C06222C4EA /* Element.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Element.swift; path = Sources/AEXML/Element.swift; sourceTree = "<group>"; };
-		06FFD82A9F6A8F2146299B38B084EEA1 /* Pods_SourcerySwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourcerySwift.framework; path = "Pods-SourcerySwift.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		06FFD82A9F6A8F2146299B38B084EEA1 /* Pods_SourcerySwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourcerySwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		072760713591AC981C004DC576FE1D09 /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
 		07AA80A72F470DD549A4C193F55B825B /* PBXVariantGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXVariantGroup.swift; path = Sources/xcproj/PBXVariantGroup.swift; sourceTree = "<group>"; };
 		08E4F00F202414474386E1B939A0309A /* XCWorkspaceDataElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataElement.swift; path = Sources/xcproj/XCWorkspaceDataElement.swift; sourceTree = "<group>"; };
@@ -611,7 +612,7 @@
 		0E60EC0AAD2C47DC2435552165EBBA20 /* Pods-SourceryJS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SourceryJS-acknowledgements.markdown"; sourceTree = "<group>"; };
 		0F2B872B0B8A7E30B0030F220EA8F46F /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
 		106390DFAAF8781C28401D3809A1EF64 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
-		10787C2541B7AFBA94FDA14B1D13740C /* scanner.c */ = {isa = PBXFileReference; includeInIndex = 1; name = scanner.c; path = Sources/CYaml/src/scanner.c; sourceTree = "<group>"; };
+		10787C2541B7AFBA94FDA14B1D13740C /* scanner.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = scanner.c; path = Sources/CYaml/src/scanner.c; sourceTree = "<group>"; };
 		107F0C0381FF2D0AB3A27CCA54726050 /* PBXCopyFilesBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXCopyFilesBuildPhase.swift; path = Sources/xcproj/PBXCopyFilesBuildPhase.swift; sourceTree = "<group>"; };
 		10D5DF88B8C1A49FA7B107427B7CED9C /* Xcode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Xcode.swift; path = Source/SourceKittenFramework/Xcode.swift; sourceTree = "<group>"; };
 		11ABD7F41EBC38F328BDAFA65B420D47 /* Tokenizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Tokenizer.swift; path = Sources/Tokenizer.swift; sourceTree = "<group>"; };
@@ -622,8 +623,8 @@
 		136F67492999DFCAB1C063183E2574C8 /* AEXML-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AEXML-umbrella.h"; sourceTree = "<group>"; };
 		137C2B26F2D821B29C8BEF8F6F0AA9B4 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Source/SourceKittenFramework/SourceLocation.swift; sourceTree = "<group>"; };
 		13E87ED98D88F15CD9B87A7E4854AA2F /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
-		145176E1E87474A247B803F419110293 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		146A7254A290B5DD0EF8E1CBADB69FA4 /* xcproj.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = xcproj.framework; path = xcproj.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		145176E1E87474A247B803F419110293 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		146A7254A290B5DD0EF8E1CBADB69FA4 /* xcproj.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = xcproj.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		14C97C49B08170813210BDA75D9CFBFD /* Version.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Version.swift; path = Source/SourceKittenFramework/Version.swift; sourceTree = "<group>"; };
 		1573E277C875F0BE7907B5EBE406D32C /* Pods-SourceryFramework-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourceryFramework-umbrella.h"; sourceTree = "<group>"; };
 		15D760C84B7E14997427B57A70E60FEB /* Environment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Environment.swift; path = Sources/Environment.swift; sourceTree = "<group>"; };
@@ -659,7 +660,7 @@
 		239D0A65FC9B182DCEE20B0737E8466E /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
 		24335BB778E4E8FABAE840F11DCA3E36 /* PBXProductType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProductType.swift; path = Sources/xcproj/PBXProductType.swift; sourceTree = "<group>"; };
 		25C998DE3D118A49170680221ADBF128 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		269CD577304C27A75B14AF9D3478FF99 /* reader.c */ = {isa = PBXFileReference; includeInIndex = 1; name = reader.c; path = Sources/CYaml/src/reader.c; sourceTree = "<group>"; };
+		269CD577304C27A75B14AF9D3478FF99 /* reader.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = reader.c; path = Sources/CYaml/src/reader.c; sourceTree = "<group>"; };
 		26E1B3CD7904BE5C5911926F0E5181ED /* CYaml.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CYaml.h; path = Sources/CYaml/include/CYaml.h; sourceTree = "<group>"; };
 		2865EDFA8AF22FF4356704BB42B65AB9 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
 		2867E36381ECD8DC94C8E693004E23CF /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
@@ -667,13 +668,13 @@
 		2980E467EF143EFF9BD13B0C9162417E /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
 		2983D1149015A22169081FF1DCCD005E /* ObjectReference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjectReference.swift; path = Sources/xcproj/ObjectReference.swift; sourceTree = "<group>"; };
 		2A21BB8DF46FA32B549339B5353AD265 /* Lexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Lexer.swift; path = Sources/Lexer.swift; sourceTree = "<group>"; };
-		2A82F33BD74B26F82C16EF3D42A7C32E /* Yams.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Yams.framework; path = Yams.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A82F33BD74B26F82C16EF3D42A7C32E /* Yams.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Yams.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B4B5233E9B7923DFD3424CE70510B65 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
 		2BABB0B365E5BDF6E7DD4DBC5AFF23CF /* Pods-TemplatesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TemplatesTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2BE139E45B399B01C03FFD70E66A97BE /* Pods-TemplatesTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TemplatesTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		2BFC915222FDE94F799EE89F9EDACF74 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		2BFC915222FDE94F799EE89F9EDACF74 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
 		2C112658D3B3F622CE76A34F5A224F8C /* Clang+SourceKitten.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Clang+SourceKitten.swift"; path = "Source/SourceKittenFramework/Clang+SourceKitten.swift"; sourceTree = "<group>"; };
-		2C2EFC5FEBB2CB2A0251DC0AF71473F1 /* emitter.c */ = {isa = PBXFileReference; includeInIndex = 1; name = emitter.c; path = Sources/CYaml/src/emitter.c; sourceTree = "<group>"; };
+		2C2EFC5FEBB2CB2A0251DC0AF71473F1 /* emitter.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = emitter.c; path = Sources/CYaml/src/emitter.c; sourceTree = "<group>"; };
 		2C56F5C0F6431C173581048848D671BC /* StatementKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatementKind.swift; path = Source/SourceKittenFramework/StatementKind.swift; sourceTree = "<group>"; };
 		2C9CAC44A9FA5EE5D17A5FC973EE32C4 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
 		2CA9372044B55C8D12C2B322C7F9E2F0 /* SyntaxToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyntaxToken.swift; path = Source/SourceKittenFramework/SyntaxToken.swift; sourceTree = "<group>"; };
@@ -718,7 +719,7 @@
 		4047D221191414162B1F9F39B84F988D /* Pods-SourceryFramework.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryFramework.release.xcconfig"; sourceTree = "<group>"; };
 		405EF9A0D4830C181F450993D574880A /* XCBreakpointList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCBreakpointList.swift; path = Sources/xcproj/XCBreakpointList.swift; sourceTree = "<group>"; };
 		40E63A7EFE884499B9EB364D83DF59D9 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
-		40F6AEA6F2463D0584AC6D61489A0A69 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		40F6AEA6F2463D0584AC6D61489A0A69 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		410CAE8B34014F1E379F7C87CEB95E92 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
 		419F20D5F7FA9CC8D26C251258CF3B1B /* Dictionary+Merge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Merge.swift"; path = "Source/SourceKittenFramework/Dictionary+Merge.swift"; sourceTree = "<group>"; };
 		428CEBBC652516B043D1FED31EF1B276 /* Stencil-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Stencil-dummy.m"; sourceTree = "<group>"; };
@@ -757,13 +758,13 @@
 		56850663058480438E9EBFC2FD14867F /* Pods-SourcerySwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourcerySwift-umbrella.h"; sourceTree = "<group>"; };
 		5728998ADA4872819707DD8319F0C5B4 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
 		588735FCF590A1586ACE1D1F75BA4BD5 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
-		58DE866F82C26C389C8D7C1336BADCBF /* Pods_CodableContextTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CodableContextTests.framework; path = "Pods-CodableContextTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		58DE866F82C26C389C8D7C1336BADCBF /* Pods_CodableContextTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CodableContextTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		59A6888E3FD8334345910158E5C23EEC /* String+Extras.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extras.swift"; path = "Sources/xcproj/String+Extras.swift"; sourceTree = "<group>"; };
 		59B71BCD94A4F7837FAF3FC5ED502484 /* AEXML-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AEXML-Info.plist"; sourceTree = "<group>"; };
 		59D05F4B45D5A8CB4F78E699EBC29657 /* Filters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filters.swift; path = Sources/Filters.swift; sourceTree = "<group>"; };
 		5B60F153D0565B5C9C1F8EEC11AD0B11 /* CommandType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandType.swift; path = Sources/Commander/CommandType.swift; sourceTree = "<group>"; };
 		5CA4B24251E95BB75042F53183CA51BD /* sourcekitd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sourcekitd.h; path = Source/SourceKit/include/sourcekitd.h; sourceTree = "<group>"; };
-		5CA7357EAEE8ACD683B18AFCB507CBF9 /* Pods_SourceryUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourceryUtils.framework; path = "Pods-SourceryUtils.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CA7357EAEE8ACD683B18AFCB507CBF9 /* Pods_SourceryUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourceryUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CD858DF0844E498E56EDB0CA6AE8D97 /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
 		5D9B1CE464521550EFE378654965963A /* Nimble-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-Info.plist"; sourceTree = "<group>"; };
 		5E4E4B7F3A5C09246A57155846635A1F /* Pods-SourceryFramework-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryFramework-Info.plist"; sourceTree = "<group>"; };
@@ -781,9 +782,9 @@
 		674ECE5BD6529F599786246514CF77DF /* Pods-CodableContextTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CodableContextTests.release.xcconfig"; sourceTree = "<group>"; };
 		678B8FE171235792C83D131DB8383D44 /* PBXProjError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProjError.swift; path = Sources/xcproj/PBXProjError.swift; sourceTree = "<group>"; };
 		68ED56E961C40490163B0C2B5F2C6448 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
-		69632434F3112F733F8A87FA795F8753 /* writer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = writer.c; path = Sources/CYaml/src/writer.c; sourceTree = "<group>"; };
+		69632434F3112F733F8A87FA795F8753 /* writer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = writer.c; path = Sources/CYaml/src/writer.c; sourceTree = "<group>"; };
 		69B71A8D3ECA5543E9021731E04C9EBC /* PBXFileReference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXFileReference.swift; path = Sources/xcproj/PBXFileReference.swift; sourceTree = "<group>"; };
-		69CE06279246EC77C9980B88D70814B9 /* parser.c */ = {isa = PBXFileReference; includeInIndex = 1; name = parser.c; path = Sources/CYaml/src/parser.c; sourceTree = "<group>"; };
+		69CE06279246EC77C9980B88D70814B9 /* parser.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = parser.c; path = Sources/CYaml/src/parser.c; sourceTree = "<group>"; };
 		6B745302A893C3C9EAF87439AC84F002 /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6CBCB28D2F10375D61703A9733DE444A /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
 		6CFE302FEA83EF711FEB3842743F7D24 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
@@ -793,7 +794,7 @@
 		6FC55DDC3190A083979C051D1FDD2166 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Sources/Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
 		703E12109416B70D40F4802DA2D70108 /* PBXSourcesBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXSourcesBuildPhase.swift; path = Sources/xcproj/PBXSourcesBuildPhase.swift; sourceTree = "<group>"; };
 		71313AE80A30431A02EB459A3A642DF7 /* AEXML-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AEXML-dummy.m"; sourceTree = "<group>"; };
-		71C57F7EE59EE7846C41FF4DC26FB779 /* Pods_SourceryFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourceryFramework.framework; path = "Pods-SourceryFramework.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		71C57F7EE59EE7846C41FF4DC26FB779 /* Pods_SourceryFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourceryFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		724CD53C96E3A5066A5CBBA124A23F74 /* library_wrapper_sourcekitd.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_sourcekitd.swift; path = Source/SourceKittenFramework/library_wrapper_sourcekitd.swift; sourceTree = "<group>"; };
 		724CDE81D5A9A0D37CDC47265C72502B /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
 		73AC51682E5204ECAF44C61C6D227AE4 /* CXErrorCode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CXErrorCode.h; path = Source/Clang_C/include/CXErrorCode.h; sourceTree = "<group>"; };
@@ -802,7 +803,7 @@
 		75CC526A9B66BD89B6A1EC926EC6A5EF /* shim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = shim.swift; path = Sources/Yams/shim.swift; sourceTree = "<group>"; };
 		76294F8D74C2D7376B9EC996D9131596 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
 		76337E3F50337CB8E301F09E989DE4A1 /* PBXProjEncoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProjEncoder.swift; path = Sources/xcproj/PBXProjEncoder.swift; sourceTree = "<group>"; };
-		7704ADF037A1D12F4BEBF1A04B5B47E4 /* Commander.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Commander.framework; path = Commander.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7704ADF037A1D12F4BEBF1A04B5B47E4 /* Commander.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Commander.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		776214A053BBF81117AEF49F94714BD8 /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
 		784C42C8B774EBB778FB0F8041D5892C /* xcproj-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "xcproj-umbrella.h"; sourceTree = "<group>"; };
 		78CF2129AB9AC3574CC2E29CECC392DD /* ClangTranslationUnit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClangTranslationUnit.swift; path = Source/SourceKittenFramework/ClangTranslationUnit.swift; sourceTree = "<group>"; };
@@ -814,7 +815,7 @@
 		7F44C93EE89CBD00E32817E141E99058 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
 		7FFBE3D95C1012EC1619FD97268BD17C /* Pods-Sourcery.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Sourcery.modulemap"; sourceTree = "<group>"; };
 		806E866705CE5BA9A15CFF2D6DB9A048 /* Module.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Module.swift; path = Source/SourceKittenFramework/Module.swift; sourceTree = "<group>"; };
-		80B105969A02697FCF2AD637049A030C /* Pods_SourceryJS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourceryJS.framework; path = "Pods-SourceryJS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		80B105969A02697FCF2AD637049A030C /* Pods_SourceryJS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourceryJS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		80C21296EF982928752977E0C3AF373E /* UID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UID.swift; path = Source/SourceKittenFramework/UID.swift; sourceTree = "<group>"; };
 		80E425D80CDF87F037D294E37642B048 /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81E585B7ED9B07124CA32E112FF8AB92 /* Pods-CodableContextTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CodableContextTests-Info.plist"; sourceTree = "<group>"; };
@@ -843,9 +844,9 @@
 		91A001B32BFF90791FE414183A62E633 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
 		9256BF91D068CBBFEAC4245578DDBC99 /* Commander-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Commander-dummy.m"; sourceTree = "<group>"; };
 		92602C4E1DF04F0B4FB5ABEB64354C92 /* Commander.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Commander.xcconfig; sourceTree = "<group>"; };
-		928332349FEE256A24658E6B5B5EF979 /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SWXMLHash.framework; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		928332349FEE256A24658E6B5B5EF979 /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		92B2629C742F046972BA51DBEA11EABA /* IfTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IfTag.swift; path = Sources/IfTag.swift; sourceTree = "<group>"; };
-		9308CBEC7BD5EE4EC03EE042089062FC /* Pods_Sourcery.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Sourcery.framework; path = "Pods-Sourcery.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9308CBEC7BD5EE4EC03EE042089062FC /* Pods_Sourcery.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sourcery.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9337F8EC7F37E67B0EB7C5AC854172AB /* CommentedString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommentedString.swift; path = Sources/xcproj/CommentedString.swift; sourceTree = "<group>"; };
 		94E0948E7E9E0DDAC3AFCBA13E647A0E /* SourceKittenFramework-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SourceKittenFramework-dummy.m"; sourceTree = "<group>"; };
 		9646D60E4888A57E32E05DF58D9AAF5F /* XcodeProj.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XcodeProj.swift; path = Sources/xcproj/XcodeProj.swift; sourceTree = "<group>"; };
@@ -860,7 +861,7 @@
 		9C8338743B57A2D4C2844A2679D32DBF /* PBXGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXGroup.swift; path = Sources/xcproj/PBXGroup.swift; sourceTree = "<group>"; };
 		9CEA086E8BD8006B28AA9FA1A7BE0ECF /* shim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = shim.swift; path = Source/SourceKittenFramework/shim.swift; sourceTree = "<group>"; };
 		9D7914CA125394D8F1EA05CCDFC2D30B /* PBXTargetDependency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXTargetDependency.swift; path = Sources/xcproj/PBXTargetDependency.swift; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9D9AB9DBA14ED1725777745F484592E8 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/Yams/Parser.swift; sourceTree = "<group>"; };
 		9ECB41E90854ABC0D5EFF0192768A7FD /* PBXBuildFile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXBuildFile.swift; path = Sources/xcproj/PBXBuildFile.swift; sourceTree = "<group>"; };
 		9F4F329A9345D1A9604411CBCBC64878 /* Pods-CodableContextTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CodableContextTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -868,7 +869,7 @@
 		A05B1D669D1907D83F96CAFE21A9C4AC /* Commander-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Commander-prefix.pch"; sourceTree = "<group>"; };
 		A18F155424176FDF82BF07B5BF89E328 /* Yams-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Yams-Info.plist"; sourceTree = "<group>"; };
 		A1F2B921FD32145CB67DFE1E9A25D8E0 /* JSONDecoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONDecoding.swift; path = Sources/xcproj/JSONDecoding.swift; sourceTree = "<group>"; };
-		A2143E4AEEFC39243F548F86B3FC8611 /* SourceKittenFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SourceKittenFramework.framework; path = SourceKittenFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2143E4AEEFC39243F548F86B3FC8611 /* SourceKittenFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SourceKittenFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A244D68C6A77215A9C29A658F5FA7259 /* Pods-SourceryTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SourceryTests-frameworks.sh"; sourceTree = "<group>"; };
 		A2A0C466F7866E0322F7546EEE3FFCA5 /* FilterTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FilterTag.swift; path = Sources/FilterTag.swift; sourceTree = "<group>"; };
 		A3415853B20AD79A6FC57A3A85CA67CA /* AEXML.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AEXML.xcconfig; sourceTree = "<group>"; };
@@ -890,7 +891,7 @@
 		B0100A7298EFB4FC02D8F8DCA0CD74CA /* Pods-CodableContextTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-CodableContextTests.modulemap"; sourceTree = "<group>"; };
 		B01FE6CA5E93266827963FE245EC5C89 /* StencilSwiftKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "StencilSwiftKit-prefix.pch"; sourceTree = "<group>"; };
 		B0A96B81F5168E3DC7FF81A91600035A /* Referenceable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Referenceable.swift; path = Sources/xcproj/Referenceable.swift; sourceTree = "<group>"; };
-		B0AF22A2C0194990E2C3726CABB664A9 /* api.c */ = {isa = PBXFileReference; includeInIndex = 1; name = api.c; path = Sources/CYaml/src/api.c; sourceTree = "<group>"; };
+		B0AF22A2C0194990E2C3726CABB664A9 /* api.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = api.c; path = Sources/CYaml/src/api.c; sourceTree = "<group>"; };
 		B0EDFDBE7AF483B2B00EA1C29149159C /* Pods-SourceryTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		B1185262182BF8C2904E1C94E00CBEE0 /* PathKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PathKit.modulemap; sourceTree = "<group>"; };
 		B156B9A00C759C4FFBAC0D7886C7C9BB /* CXString.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CXString.h; path = Source/Clang_C/include/CXString.h; sourceTree = "<group>"; };
@@ -924,7 +925,7 @@
 		BCC7EEB4CBDA235AF20A2F4E3292FCD7 /* library_wrapper_Index.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_Index.swift; path = Source/SourceKittenFramework/library_wrapper_Index.swift; sourceTree = "<group>"; };
 		BD20E9F784FAB05697C736E9B6AA86D6 /* StencilSwiftTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StencilSwiftTemplate.swift; path = Sources/StencilSwiftKit/StencilSwiftTemplate.swift; sourceTree = "<group>"; };
 		BE149041B5CC5E87E47F7749849813E2 /* SWXMLHash-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SWXMLHash-umbrella.h"; sourceTree = "<group>"; };
-		BE758E818711B442EC7672ED9FFB2763 /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AEXML.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE758E818711B442EC7672ED9FFB2763 /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF00D49AE0D754ACDD15BF373709A4E2 /* Emitter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Emitter.swift; path = Sources/Yams/Emitter.swift; sourceTree = "<group>"; };
 		BF478A83FC7AE0123B5D03B9BB10782F /* Pods-TemplatesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TemplatesTests.release.xcconfig"; sourceTree = "<group>"; };
 		BF7E9F1177F9C9DE785CCBA2AAD834B7 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
@@ -932,8 +933,8 @@
 		C002B9239503CBC411AA7C16286DFF69 /* Pods-SourceryFramework.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SourceryFramework.modulemap"; sourceTree = "<group>"; };
 		C151C096DF67A7ABF7D345102DD85489 /* Loader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Loader.swift; path = Sources/Loader.swift; sourceTree = "<group>"; };
 		C1C43D41C41B4487C24BFA10EFADD820 /* Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.swift; path = Sources/Yams/Node.swift; sourceTree = "<group>"; };
-		C35DB1B1D9D40464466C8F0DD55B12B6 /* Pods_TemplatesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_TemplatesTests.framework; path = "Pods-TemplatesTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C3EA4FE39B408EC4C2B7C4BB0722E04C /* StencilSwiftKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = StencilSwiftKit.framework; path = StencilSwiftKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C35DB1B1D9D40464466C8F0DD55B12B6 /* Pods_TemplatesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TemplatesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C3EA4FE39B408EC4C2B7C4BB0722E04C /* StencilSwiftKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StencilSwiftKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C43F84DD01888A6303A8C3C2056209A9 /* String+SourceKitten.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+SourceKitten.swift"; path = "Source/SourceKittenFramework/String+SourceKitten.swift"; sourceTree = "<group>"; };
 		C4675108A8CCBD654FBC27C4AB7054C2 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
 		C4D2CCE82E1834F02896039E01A68C6B /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
@@ -966,7 +967,7 @@
 		D1F1960B83B53A9E3DC7EB808A65ACBD /* BuildSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildSettings.swift; path = Sources/xcproj/BuildSettings.swift; sourceTree = "<group>"; };
 		D20C035F391F5A4BBEF2E37DB2215FD4 /* XCWorkspace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspace.swift; path = Sources/xcproj/XCWorkspace.swift; sourceTree = "<group>"; };
 		D2E669B1637A0F53943635C746AB5706 /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
-		D399F73A316B61034A5C05FBC0AD9AF6 /* Stencil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Stencil.framework; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D399F73A316B61034A5C05FBC0AD9AF6 /* Stencil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D548406E39D0C950B3148E9689318412 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
 		D57DD1A559732BAF33B0751F859838C2 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
 		D5BD296CA0134DA85EADBB14155AB85D /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
@@ -989,7 +990,7 @@
 		E234C5490AF52AC1EBB9598C8CF1A3AD /* Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Extension.swift; path = Sources/Extension.swift; sourceTree = "<group>"; };
 		E2685F20E55B0CBB29554B433A6B067A /* yaml.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yaml.h; path = Sources/CYaml/include/yaml.h; sourceTree = "<group>"; };
 		E285FF83213CB9F241956FDD95032375 /* Pods-SourcerySwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourcerySwift.release.xcconfig"; sourceTree = "<group>"; };
-		E2CC4B2024D96FD77C8EE85163FDB388 /* Pods_SourceryTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourceryTests.framework; path = "Pods-SourceryTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2CC4B2024D96FD77C8EE85163FDB388 /* Pods_SourceryTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourceryTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2D643202F781CF3B4801F9E9770CC3E /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/AEXML/Error.swift; sourceTree = "<group>"; };
 		E30C396EAA660FA5BB5720BAE611D83C /* MatcherFunc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherFunc.swift; path = Sources/Nimble/Matchers/MatcherFunc.swift; sourceTree = "<group>"; };
 		E396312C669D85CFB73C073295DD1B2A /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Decodable+Dictionary.swift"; path = "Sources/xcproj/Decodable+Dictionary.swift"; sourceTree = "<group>"; };
@@ -1007,7 +1008,7 @@
 		E93D7B4B53B6DB72A04217820C2DC1EA /* xcproj-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "xcproj-dummy.m"; sourceTree = "<group>"; };
 		ED25C511E54A20108EA2153859BA9094 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
 		EE3F8D2F517630E4E38ACAAF7557256C /* SourceKitObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceKitObject.swift; path = Source/SourceKittenFramework/SourceKitObject.swift; sourceTree = "<group>"; };
-		F0274C88F3C23370C32398E304619505 /* PathKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PathKit.framework; path = PathKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F0274C88F3C23370C32398E304619505 /* PathKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PathKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F0DA4D7D26C640FE21EA0CA8C84DD9CC /* Node.Scalar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.Scalar.swift; path = Sources/Yams/Node.Scalar.swift; sourceTree = "<group>"; };
 		F0E6E8C6D9E278CC973E855B38529B8D /* StencilSwiftKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "StencilSwiftKit-dummy.m"; sourceTree = "<group>"; };
 		F1044C484AE4C092BF0DC41D762F2C0C /* Pods-SourceryUtils.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryUtils.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1290,7 +1291,6 @@
 			children = (
 				A4FABE42BC7E6108F92CD4A0773E6BF4 /* Support Files */,
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -1357,7 +1357,6 @@
 				6CFE302FEA83EF711FEB3842743F7D24 /* XCTestSuite+QuickTestSuiteBuilder.m */,
 				7A848A6E9FC1BD2FB39928B30A09BB8D /* Support Files */,
 			);
-			name = Quick;
 			path = Quick;
 			sourceTree = "<group>";
 		};
@@ -1392,7 +1391,6 @@
 				FA4FA4043FB75E62C84F49D5950697AE /* Group.swift */,
 				94FD991E5F0F7F8F6E92328FAE80697A /* Support Files */,
 			);
-			name = Commander;
 			path = Commander;
 			sourceTree = "<group>";
 		};
@@ -1485,7 +1483,6 @@
 				19F0FEE218FB7A3E78C8E514B4D75900 /* XCTestObservationCenter+Register.m */,
 				AB88B226F20FC67F7969B0B100A97D1D /* Support Files */,
 			);
-			name = Nimble;
 			path = Nimble;
 			sourceTree = "<group>";
 		};
@@ -1514,7 +1511,6 @@
 				C71AE4A4EEE20E5A2FC29E20B24C0BC3 /* Variable.swift */,
 				189861EDC6128DFFA899256FFF38BABB /* Support Files */,
 			);
-			name = Stencil;
 			path = Stencil;
 			sourceTree = "<group>";
 		};
@@ -1621,7 +1617,6 @@
 				3138AEB665E9549ED3FE04A9409C59D1 /* Yams.h */,
 				E8DB3849090719B056B8CBBC081F17EF /* Support Files */,
 			);
-			name = Yams;
 			path = Yams;
 			sourceTree = "<group>";
 		};
@@ -1641,7 +1636,6 @@
 				CC0EA486EBFC79426031555D128D5FD3 /* SwiftIdentifier.swift */,
 				8EB53A2DD7053D4826BF664F033821F8 /* Support Files */,
 			);
-			name = StencilSwiftKit;
 			path = StencilSwiftKit;
 			sourceTree = "<group>";
 		};
@@ -1751,7 +1745,6 @@
 				10D5DF88B8C1A49FA7B107427B7CED9C /* Xcode.swift */,
 				98E364A28FFE6FCA1E4E8103F3E3240A /* Support Files */,
 			);
-			name = SourceKittenFramework;
 			path = SourceKittenFramework;
 			sourceTree = "<group>";
 		};
@@ -1838,7 +1831,6 @@
 				492A9A9BBE8346B8633EF900EA90B6E0 /* PathKit.swift */,
 				75C180F4B0F861B5967C790C762F532A /* Support Files */,
 			);
-			name = PathKit;
 			path = PathKit;
 			sourceTree = "<group>";
 		};
@@ -1863,7 +1855,6 @@
 				3E16C746C798A5EB431E7FCE153C73E1 /* Parser.swift */,
 				57F3AF41CCD6BCA33388E7D8F62D0ADE /* Support Files */,
 			);
-			name = AEXML;
 			path = AEXML;
 			sourceTree = "<group>";
 		};
@@ -1966,7 +1957,6 @@
 				CB141316ECEC7EF5C2DEBA446C671A35 /* XCWorkspaceDataGroup.swift */,
 				424665A961E4459DB062A8BD6D7C0E03 /* Support Files */,
 			);
-			name = xcproj;
 			path = xcproj;
 			sourceTree = "<group>";
 		};
@@ -1978,7 +1968,6 @@
 				F44719B431957647278C9C274C0CEE58 /* SWXMLHash+TypeConversion.swift */,
 				43147FE3CC74FE4AA87E3F49FAF4A089 /* Support Files */,
 			);
-			name = SWXMLHash;
 			path = SWXMLHash;
 			sourceTree = "<group>";
 		};
@@ -2547,13 +2536,14 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
@@ -3327,7 +3317,6 @@
 			baseConfigurationReference = F1044C484AE4C092BF0DC41D762F2C0C /* Pods-SourceryUtils.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3362,7 +3351,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5EB2C6BA52D2F9008F424BF707BD705D /* Nimble.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3397,7 +3385,6 @@
 			baseConfigurationReference = 9F4F329A9345D1A9604411CBCBC64878 /* Pods-CodableContextTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3432,7 +3419,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5E691F87F3E6C35990223C9C2A8E054B /* xcproj.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3466,7 +3452,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC9482A58E11515F5A26F5163AB05522 /* SWXMLHash.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3499,7 +3484,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FC5CB58922C0843CF71F3DB93AD04081 /* Yams.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3533,7 +3517,6 @@
 			baseConfigurationReference = 2BABB0B365E5BDF6E7DD4DBC5AFF23CF /* Pods-TemplatesTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3569,7 +3552,6 @@
 			baseConfigurationReference = E285FF83213CB9F241956FDD95032375 /* Pods-SourcerySwift.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3604,7 +3586,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5EB2C6BA52D2F9008F424BF707BD705D /* Nimble.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3638,7 +3619,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C56F3EDBF4E0080BD8DE0B6888C89B0F /* SourceKittenFramework.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3671,7 +3651,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 65C3F00E6F232CFAC24CCF450769DBBE /* SwiftLint.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "-";
@@ -3687,7 +3666,6 @@
 			baseConfigurationReference = 674ECE5BD6529F599786246514CF77DF /* Pods-CodableContextTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3722,7 +3700,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 92602C4E1DF04F0B4FB5ABEB64354C92 /* Commander.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3756,7 +3733,6 @@
 			baseConfigurationReference = C75E6707D21847CB10B82A5B60CCDDA1 /* Pods-SourceryJS.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3791,7 +3767,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1D6374ABF00E854BE449B574663DBA42 /* PathKit.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3824,7 +3799,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 624AC30FE642D0BFA4427760733ADF42 /* Quick.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3858,7 +3832,6 @@
 			baseConfigurationReference = DAF8B317DFDF016F29860E4549E7AE90 /* Pods-SourceryJS.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3893,7 +3866,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C56F3EDBF4E0080BD8DE0B6888C89B0F /* SourceKittenFramework.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3926,7 +3898,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 92602C4E1DF04F0B4FB5ABEB64354C92 /* Commander.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3959,7 +3930,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC9482A58E11515F5A26F5163AB05522 /* SWXMLHash.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3992,7 +3962,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7B66B070F558C8D96591917995D5090C /* Stencil.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4025,7 +3994,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A3415853B20AD79A6FC57A3A85CA67CA /* AEXML.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4058,7 +4026,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 399DBC4458FA35BA737E37460B40A91E /* StencilSwiftKit.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4091,7 +4058,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FC5CB58922C0843CF71F3DB93AD04081 /* Yams.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4124,7 +4090,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5E691F87F3E6C35990223C9C2A8E054B /* xcproj.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4158,7 +4123,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7B66B070F558C8D96591917995D5090C /* Stencil.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4192,7 +4156,6 @@
 			baseConfigurationReference = B42F3ED60B26C5E4A92E21E2D5B963D1 /* Pods-Sourcery.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4228,7 +4191,6 @@
 			baseConfigurationReference = B88F9C5B5BCB9C94564A44D1EF814189 /* Pods-SourceryTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4264,7 +4226,6 @@
 			baseConfigurationReference = 19E4195784A6309491416D61BA6E25B5 /* Pods-SourceryTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4300,7 +4261,6 @@
 			baseConfigurationReference = 33F53E54B95B73557E1FAFF34D5ECB4E /* Pods-SourceryUtils.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4336,7 +4296,6 @@
 			baseConfigurationReference = BF478A83FC7AE0123B5D03B9BB10782F /* Pods-TemplatesTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4371,6 +4330,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -4435,7 +4395,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 624AC30FE642D0BFA4427760733ADF42 /* Quick.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4469,7 +4428,6 @@
 			baseConfigurationReference = 359E46F10C0853E5B4BD8BC7E4E202F3 /* Pods-SourceryFramework.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4504,6 +4462,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -4553,8 +4512,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				SYMROOT = "${SRCROOT}/../build";
 			};
@@ -4565,7 +4523,6 @@
 			baseConfigurationReference = 4047D221191414162B1F9F39B84F988D /* Pods-SourceryFramework.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4600,7 +4557,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 399DBC4458FA35BA737E37460B40A91E /* StencilSwiftKit.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4634,7 +4590,6 @@
 			baseConfigurationReference = CEFBB7466778E06C1BFC53FC5B67A0A4 /* Pods-SourcerySwift.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4669,7 +4624,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A3415853B20AD79A6FC57A3A85CA67CA /* AEXML.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4702,7 +4656,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1D6374ABF00E854BE449B574663DBA42 /* PathKit.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -4736,7 +4689,6 @@
 			baseConfigurationReference = 4D9FEA1C52A7900B43B13BF3EFD4B449 /* Pods-Sourcery.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4771,7 +4723,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 65C3F00E6F232CFAC24CCF450769DBBE /* SwiftLint.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "-";

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -19,352 +19,353 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		00A781B7B30D48C473C1BF11DF836843 /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD41892E8810AA35A18488D700A85A8 /* PBXContainerItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		00B05A68D74018E471BF5559F8506135 /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89F9DB55352C44062C786AA4734D2C5 /* PBXProjEncoder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		00B39117050BC8678D606FB20A00C91F /* ArgumentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF31B6091EC0F6CF1052688292E3572C /* ArgumentParser.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		026FD80ABF4A2E76CFC01778737E56A2 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE275577630A5584534B7E7C643D9835 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		028DF0FD8A2D44D80EB0313263408364 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = B8C9839DEE4610A4DB3CA2F137C28774 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00A781B7B30D48C473C1BF11DF836843 /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF4357BB240F1789713BB70B06818909 /* PBXContainerItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		00B05A68D74018E471BF5559F8506135 /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76337E3F50337CB8E301F09E989DE4A1 /* PBXProjEncoder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		00B39117050BC8678D606FB20A00C91F /* ArgumentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2E9D0B5B33B0ADC1D7DFC1169C0EE1 /* ArgumentParser.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		01FD062E2941F8EE7EBC958B4A4C65A7 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 91A001B32BFF90791FE414183A62E633 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		02A1CE956A99C0345CE34B546BD1D4F4 /* Pods-SourceryFramework-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CAD70781ECBFDA2794B309661F2CEE57 /* Pods-SourceryFramework-dummy.m */; };
-		033C48B69E87C2313D5CCAFF61A69845 /* SWXMLHash-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E99239F198074863873476B7D14412AC /* SWXMLHash-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0350C72CD0BE7EF8B15415DF66C2CAFC /* Representer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D46AC0283D38F2BDEA972AD1E845119 /* Representer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		03B3E2CD5723D8959B54EA992BEC9A79 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E17333EC12616FEE1DCC33CC1325743 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		033C48B69E87C2313D5CCAFF61A69845 /* SWXMLHash-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BE149041B5CC5E87E47F7749849813E2 /* SWXMLHash-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0350C72CD0BE7EF8B15415DF66C2CAFC /* Representer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B2A1C4BD8288C33F2110140B638F39 /* Representer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		03CB243DD6AF20C86EF40850BB43182A /* Pods-SourceryJS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 616232DB10AF687A8F697D05DF9AA95B /* Pods-SourceryJS-dummy.m */; };
-		03CE5D6323138E0BE87DF186A0870344 /* BuildSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 49820084B215591A9C4812447F86C33E /* BuildSystem.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		045B7953EC9D2224787B2786CE8B5661 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DC357A14C7A15C85E4BDF56E9FD41BA /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		093AE557B84C9356316BFDB448AA1867 /* ObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECFF68AD5008800603D332189159D63 /* ObjectReference.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		03CE5D6323138E0BE87DF186A0870344 /* BuildSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = C87A9B0633680E89DAAB3758DEA40C9D /* BuildSystem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		045B7953EC9D2224787B2786CE8B5661 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E591F7FB4DFCB4B84C9E0D1661120A87 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05171847AE0AD245A8FB7E198CB37F67 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2980E467EF143EFF9BD13B0C9162417E /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		05D6872E1E4C28423550C859B6E03820 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E9F1177F9C9DE785CCBA2AAD834B7 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		093AE557B84C9356316BFDB448AA1867 /* ObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2983D1149015A22169081FF1DCCD005E /* ObjectReference.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		095D007AAA897D908C3FAA2C1DAE69AD /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E425D80CDF87F037D294E37642B048 /* SWXMLHash.framework */; };
-		09BB31A8E28EB7BF8DFAC13746121F5A /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = BE767B0372B41ADBAF7D353693F9FE96 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0A224328A5BBFDDF878CEBA62A5DE6D5 /* AEXML-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FE1188F1B061BB0BD4350E0F7AD88B5 /* AEXML-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0A58CF6BD6BE9E11AD62B09B5EA36E6B /* String+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06D0ECE52B3FBD54BE68F9966526A3B /* String+Extras.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0BFF4C92F0E58375B594BA9137B52051 /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29D92F82B778344AF35BBE23B6DE521 /* PBXCopyFilesBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0DD3BDCEE2383983174A64734D6A07CA /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED55F1819BE802F721A4215C3B5A755 /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0DE40D7C9194C933FCE0B4B58BCC7F70 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECC71F7DED24BF46E1F384A08BE6A20 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0DEEED00DEFFA1B5BBA40AD1E3B405B5 /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F14BF5E4B3082D8035D802DD81DA41 /* Decodable+Dictionary.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0E345BE21C8C4C27D0773EA0660D0341 /* SourceDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A204C09542A5FC0C1A2F7CFA5D487030 /* SourceDeclaration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0F0393BCA7713BF9993901FFB2D1AEA4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F2BB0DF0447B28C112C7F7DDE0416DC /* Node.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0F43FEC5DC808D8093302B22755CBB77 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 75BC3789FD43653C8FBA28B958FCC5AB /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		10BAF5F5D4B630453811E08E94C574DB /* Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CD334BA0A54B2AAB1293E0BDBB0692 /* Documentation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		10D772422D8E6057D5A365EAD8A47449 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F7BBC72F0154D4CE641A89094DE603 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		118E878B21170FA7ACFB37104B7F05C1 /* PBXProject+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56373777FB1C28FA39AAA792711F0931 /* PBXProject+Deprecations.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1195182A229DA5D7E1B2BBF4235AB942 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15AF46B1EE374DBDC6FD146C694052C /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		11EC633EE1BF29C6D8D2016513F72A6F /* scanner.c in Sources */ = {isa = PBXBuildFile; fileRef = 918C549C317298F3E4C16B5603662316 /* scanner.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		12179C8968E7520215D1C0540BB3CD72 /* writer.c in Sources */ = {isa = PBXBuildFile; fileRef = DCB2AB2E90E9E28D76F238AAF0938CCF /* writer.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		122BC73D085A65D5F584DD61F1017B26 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06BB4BAB3185269CC71624E254968EB /* PBXFileReference.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		139B0564BC4324287557D1714FFB45E4 /* library_wrapper_sourcekitd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42490B13736FF3B5BF55BCB60C9411FC /* library_wrapper_sourcekitd.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		14447910B8452C11D2BAB907CD9DF833 /* SwiftDocKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A89AA45740EE5A54ACA07BF3E2F173D /* SwiftDocKey.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		15F417B90527BDC64E3739079C2B8295 /* PBXFrameworksBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30522199DBCF74F2160AF50C37CBBB8 /* PBXFrameworksBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		09BB31A8E28EB7BF8DFAC13746121F5A /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CFE302FEA83EF711FEB3842743F7D24 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0A224328A5BBFDDF878CEBA62A5DE6D5 /* AEXML-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 136F67492999DFCAB1C063183E2574C8 /* AEXML-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0A58CF6BD6BE9E11AD62B09B5EA36E6B /* String+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6888E3FD8334345910158E5C23EEC /* String+Extras.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0BFF4C92F0E58375B594BA9137B52051 /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107F0C0381FF2D0AB3A27CCA54726050 /* PBXCopyFilesBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0DD3BDCEE2383983174A64734D6A07CA /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73FD141C233CFDDA2496E400261789B /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0DEEED00DEFFA1B5BBA40AD1E3B405B5 /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = E396312C669D85CFB73C073295DD1B2A /* Decodable+Dictionary.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0E345BE21C8C4C27D0773EA0660D0341 /* SourceDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C603340285CA7C6CDEF084D3E2F8CA85 /* SourceDeclaration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0EE9B6EEBF5BB230595F217282D46032 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88127F8E25EF8B7FD7BDAAC30E5D93E7 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0F0393BCA7713BF9993901FFB2D1AEA4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C43D41C41B4487C24BFA10EFADD820 /* Node.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0F43FEC5DC808D8093302B22755CBB77 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B872B0B8A7E30B0030F220EA8F46F /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		10BAF5F5D4B630453811E08E94C574DB /* Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CACB53DABCAC94D559E6A3A52DAE29 /* Documentation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		118E878B21170FA7ACFB37104B7F05C1 /* PBXProject+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A792739B3AF780C10529B0333413DFF /* PBXProject+Deprecations.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1195182A229DA5D7E1B2BBF4235AB942 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB46165117F30DE74BF10C9A354E9F8 /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		11EB5752E9F8CD62E8032D0925F50FDD /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57DD1A559732BAF33B0751F859838C2 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		11EC633EE1BF29C6D8D2016513F72A6F /* scanner.c in Sources */ = {isa = PBXBuildFile; fileRef = 10787C2541B7AFBA94FDA14B1D13740C /* scanner.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		12179C8968E7520215D1C0540BB3CD72 /* writer.c in Sources */ = {isa = PBXBuildFile; fileRef = 69632434F3112F733F8A87FA795F8753 /* writer.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		122BC73D085A65D5F584DD61F1017B26 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B71A8D3ECA5543E9021731E04C9EBC /* PBXFileReference.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		12555CF44BDE2DCB3011CC2005A562E8 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
+		139B0564BC4324287557D1714FFB45E4 /* library_wrapper_sourcekitd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724CD53C96E3A5066A5CBBA124A23F74 /* library_wrapper_sourcekitd.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		14447910B8452C11D2BAB907CD9DF833 /* SwiftDocKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12005A3CC3291799984C711CE28C3169 /* SwiftDocKey.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1446EB860E8C0BB7A521E542276F128B /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AF4CF6B6AF701FB8654322CB441314 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		15F417B90527BDC64E3739079C2B8295 /* PBXFrameworksBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39439BF6BD56E03232A70EC58067AE6E /* PBXFrameworksBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		161E720928D40F7AFC6DFFEB74117DF0 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC55DDC3190A083979C051D1FDD2166 /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		16B45E021F3AF6C9185C0707BD5C1A90 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		16C667B7608B33930D3543C937B0E476 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545111DA9BF2D339E984FD2D86563BA6 /* Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		17397C4141BE2E769CCE4164E5ED4166 /* PathKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C1CCB1B732E1F1EADAD88B59225CE9 /* PathKit-dummy.m */; };
+		16C667B7608B33930D3543C937B0E476 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D643202F781CF3B4801F9E9770CC3E /* Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		16F88764F808DBF7426CA911136DF8BF /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BFC915222FDE94F799EE89F9EDACF74 /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		17397C4141BE2E769CCE4164E5ED4166 /* PathKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6101E623EF5C7724F5DB42E1D637A342 /* PathKit-dummy.m */; };
 		17CFF8C4A3471A19F6E3BBF973D44AB2 /* Pods-SourceryUtils-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A42956B878AC080F7C85E67F3443A69E /* Pods-SourceryUtils-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A3D3483ED3434DC12E86694EC473DE6 /* Structure.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF857CED27C511D9172CBBA428FD330C /* Structure.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1A7AF6875BC6A63AB6A241E3E92A63DC /* LinuxCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E044078E15CF9AC524696234B51E0637 /* LinuxCompatibility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1A7B44BCC2741A387A783F9FAA3F992A /* CXCompilationDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 48C4309650684E7D3FAFC1EC8FF34AA6 /* CXCompilationDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1C076B0EFB46B0F8D06A74EF67ABDCC9 /* XCBreakpointList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103533744DE5007DA2D31E812DCC64AF /* XCBreakpointList.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1C952FA8963307BA2AFAA8980011D379 /* StatementKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EDAE799F0B29969B1A72FE28C090FE /* StatementKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1E91DB8D36AECEA6AA03F69EA794D591 /* ArgumentDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B1542BF2F7A7DA7EF5AFE5493BAFDF /* ArgumentDescription.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2006080D69B7075E41F584FE91CCC29E /* Index.h in Headers */ = {isa = PBXBuildFile; fileRef = 56F70CC5B4785850C7DADFB797FAD33E /* Index.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		207221CA31980F2A248AE79677F8379A /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE42F8B397AB7CDE5F0E6A3BF4F0E3 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		231CE0B11598E5C241E260A1DE2F1687 /* PBXVariantGroup+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2EE40DC06775538A74A9613C2DB9AA /* PBXVariantGroup+Deprecations.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		244443752A42A5AD96C563A5D1C85DCD /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84142A76513C17533CB6F6C04AEB0A /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		24A987C08842B0D6710D151E84C177A3 /* Node.Scalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5301904B0430880CF863DC1D754BE28B /* Node.Scalar.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		24BD981C560FD8E42A233DC9225F15B2 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46BBC6D42701827772C10C342891F00 /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		25B039740714531479585AE7BCA64078 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B665D10CA3739672253EE7BAAC75E7 /* shim.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		269CD5365072BEA2EBE531B5541EB580 /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05CC6E6A995325E9D386E3B2FDE0FC7 /* PBXSourcesBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		270982656D24DD681EAF6E17A91641A8 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2AFD8C82D28185EFC76414D217BD9C /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		273217649975E97EC963D00A635794DA /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701453889D728B9BB5100F9B15B09730 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		27BD92381FD24A00895861C639AECE21 /* IfTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC87F667C36C105F9A93C51DAAEB1CA4 /* IfTag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		18780E4AAD9D40AAF8578D2EAB598F61 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B526E6D1095B48CFD04B52224C6DD /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1A085E4176BC047190EEA91CD2476BF5 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72C0F08AC5739D484DDE83DDFB6879E /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1A3D3483ED3434DC12E86694EC473DE6 /* Structure.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACF398DB7DF863AAC927F36E4CE0329 /* Structure.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1A7AF6875BC6A63AB6A241E3E92A63DC /* LinuxCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54C552319DB529ACEA317D82ED3A4CC /* LinuxCompatibility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1A7B44BCC2741A387A783F9FAA3F992A /* CXCompilationDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D8B424315307D4BF57359C5BD8409E1 /* CXCompilationDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1ABE5B9FB33BB082AFF902EA8340B2C3 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0430F1956BC5D453B60A6DC6476C3445 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1C076B0EFB46B0F8D06A74EF67ABDCC9 /* XCBreakpointList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405EF9A0D4830C181F450993D574880A /* XCBreakpointList.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1C952FA8963307BA2AFAA8980011D379 /* StatementKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C56F5C0F6431C173581048848D671BC /* StatementKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1E91DB8D36AECEA6AA03F69EA794D591 /* ArgumentDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00134483696AC1CDE67EFA7F2F84EC5F /* ArgumentDescription.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1FA0DEC9E883929115DD91352F570F3B /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = D6CADF5D9D71EA3DC8035961AC1222EB /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2006080D69B7075E41F584FE91CCC29E /* Index.h in Headers */ = {isa = PBXBuildFile; fileRef = E691BC0943758341AEC4E0B9E8206091 /* Index.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		207221CA31980F2A248AE79677F8379A /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2312777891D060B3CE48B394196A6156 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		214D14BFA83B93F6D848C9326FC0D726 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3E72BB8C9B109AE543B59B72B61EC7 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		231CE0B11598E5C241E260A1DE2F1687 /* PBXVariantGroup+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD63A54B176B6B2034FB4AAC38FF5E1 /* PBXVariantGroup+Deprecations.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		244443752A42A5AD96C563A5D1C85DCD /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53A1FF8052C6F70BCA344624C6015F /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		24A987C08842B0D6710D151E84C177A3 /* Node.Scalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DA4D7D26C640FE21EA0CA8C84DD9CC /* Node.Scalar.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		25B039740714531479585AE7BCA64078 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEA086E8BD8006B28AA9FA1A7BE0ECF /* shim.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		269CD5365072BEA2EBE531B5541EB580 /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703E12109416B70D40F4802DA2D70108 /* PBXSourcesBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		273217649975E97EC963D00A635794DA /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBBA263EE53B2C94366E441A22CB4D4 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		27BD92381FD24A00895861C639AECE21 /* IfTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B2629C742F046972BA51DBEA11EABA /* IfTag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2910F4A2F2712331AACB9A23C395149A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		2B08F81AAAD3EFBB2278AE86000B1CEB /* Include.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049EDB5FB01A5CD8A0BE7A93A46B91AD /* Include.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2B53456A071A2F00B3D1DF5F58E248E4 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A5A10FE91A9D3DB3AEF2CF52976BE04 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D64EA350202D30246166CEF489895B2 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE483A1BE7235E4C11CCD9D132AF093F /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2DE60126ECE8E3343B78BC2508EACC95 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78348A371E1D2833CE251DF5EF58052E /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3213BCA3F1681716187C729AFB68D2BB /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F8B81DEBDBDB660D7D778BEDA07D09 /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		32772C7727AEA9FCDADC9795B9F8CA82 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763CEC8B6B1D48223EA3A489E9CCF731 /* Version.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		32C9D2F8154805035431BEAC969D82FB /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA41B5B8D4900AF2DEE39860A5F7A67 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		345BBDEB32900120BD13A40FFB9029DC /* MapNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8264855112B3E35985270903400F81F /* MapNode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		365510D76D31CBD7904F4A19BF3F4AE1 /* FilterTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F2791B89C94B8A2D27E9EB37864733 /* FilterTag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		366886F4DA0AEF498ABE49CDB6E99616 /* Filters+Numbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121825A360455D76E9D30380D46078C4 /* Filters+Numbers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		36E0290F25FB727BFD009FAA52D46882 /* library_wrapper_CXString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1055BC4F1F58345A01804B36DF4D7FC4 /* library_wrapper_CXString.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		36E330910686C9C7CDA517454C2A3728 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24241FFE39B64EE82D70ABFDF38D91A /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		370D4C112D01AFFAB92BFF7F19B2774E /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B544727DAB6079C1B87855A79F2390E /* PBXRezBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		37242BD6EE62166CF2692CA27E737543 /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = 47C1E0158700AFAA9E7BEF3DE84D6EE0 /* api.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3836DDC3ACFE1D2C265BF78605E6DC5E /* UID.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3B91A3A38F895FC38532700B223815 /* UID.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2A12704AB9BB5CC0A6F8770F5232AEAD /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BBFD4D71EDE1BC59DF0A878A3CDFAB /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2B08F81AAAD3EFBB2278AE86000B1CEB /* Include.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28FDC0C5809EDF7D5867823B3D4689B /* Include.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2B9F53611E87A6D73DE9E431483C3879 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497E72084DCDC4548A9372874A9C4C0E /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2D64EA350202D30246166CEF489895B2 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410CAE8B34014F1E379F7C87CEB95E92 /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		30966E26266F62432C8E914340871113 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 31BC4029B5BF718BCC013880C3B7D0B8 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32772C7727AEA9FCDADC9795B9F8CA82 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C97C49B08170813210BDA75D9CFBFD /* Version.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		32C9D2F8154805035431BEAC969D82FB /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E63A7EFE884499B9EB364D83DF59D9 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		345BBDEB32900120BD13A40FFB9029DC /* MapNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C853BDABAA1D07FA565A179F97970FD /* MapNode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		365510D76D31CBD7904F4A19BF3F4AE1 /* FilterTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2A0C466F7866E0322F7546EEE3FFCA5 /* FilterTag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		366886F4DA0AEF498ABE49CDB6E99616 /* Filters+Numbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A35880D1DD3BDB561569AF13E64B9A /* Filters+Numbers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3682F92CE2B1E6090151458EC19A66CB /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAACEA64D9724241826D6BA5594566E8 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		36E0290F25FB727BFD009FAA52D46882 /* library_wrapper_CXString.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8D8CD2E7354236099415D4C75247FD /* library_wrapper_CXString.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		36E330910686C9C7CDA517454C2A3728 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137C2B26F2D821B29C8BEF8F6F0AA9B4 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		370D4C112D01AFFAB92BFF7F19B2774E /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D39AF047186A4E80625CF64060E2E42 /* PBXRezBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		37242BD6EE62166CF2692CA27E737543 /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = B0AF22A2C0194990E2C3726CABB664A9 /* api.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3836DDC3ACFE1D2C265BF78605E6DC5E /* UID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C21296EF982928752977E0C3AF373E /* UID.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		38FEA25D16ACC1E6F5C696CD95B41A69 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F74AF8F8400AE4D6A2816F90520629 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3944CFF682E0E0D190BACE0030F2F688 /* ElementsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6802EBAB5F9B43D0FCDBF0D85C122 /* ElementsEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3982233B7DF8174DBFD2A7B6EE2D6F38 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		399F2A0A9C9ED1812D9AA38BFD985884 /* CYaml.h in Headers */ = {isa = PBXBuildFile; fileRef = E84D33BAF0F491D5AEFE97B53AB18454 /* CYaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		39BBDD636CC467DBE0DFCBDD75E427F1 /* ArgumentConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372D038E60EEF4F3260D111C1FA93221 /* ArgumentConvertible.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3D372633FBE021B83EF004F7B0B2EF7A /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2812327BBDB24640DF1C3A4AF3AFBE3B /* Decoder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3DC71586B9A2CA6AC42E01F8F652BBBB /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = C922F01C57C683504FABB2D63E6E0A0E /* Dictionary+Extras.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3DCB06D05475D77D3FD4CC14DF90723D /* PBXReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0C4697704B1853B1E47DB94A1BBB89 /* PBXReferenceProxy.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3F14099A8E8249B6D4DB2D6CA4EB8E36 /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = EEDC60111B661A45F613AE63CDBD6C78 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3F86AC29797CD19C2FAF637FAB8924ED /* Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15127D3B993D223E4402D112A406DAB9 /* Parameters.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3F96CC3C5BAF701E71FF45662C2D68C6 /* PBXProj+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908E4BA247C8BED71D9A14CEAEEEB327 /* PBXProj+Helpers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3FF0B57025B95786F46D2346D13BED1A /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 458589868B4454B760A68D39CBC6922A /* Quick-dummy.m */; };
-		4052560ED934EDA2BC58C22A40C7FED4 /* Yams-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 35ECBC25D0413090C8137AD74907DCBC /* Yams-dummy.m */; };
-		4095F1E3CC2937A9AE6BFB9BE01CCC76 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14525739EB13CBB5CDA70AB08AA1B68 /* Lexer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		411280B2B83FCA12F11F0A2148F3BAC8 /* Parameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D6C6177DBAC24C74A589CAE871EC376 /* Parameter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		415B3693083E4CA27E1A244EF7B69C0F /* emitter.c in Sources */ = {isa = PBXBuildFile; fileRef = F699C6B7A3515AEEB8B048C8C44F5AAA /* emitter.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		421A2A3E96F0A2EF0FCF230BF4FE0075 /* CXErrorCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 3762261094607EBF716EE3E89399F2E2 /* CXErrorCode.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4301C742FE4B509A8DC1504F367EEB99 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FDD578CB1A0530161F0746FF3F65BC0E /* Nimble-dummy.m */; };
-		446DECB091B51ED30D4DDE9508C2A023 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A204386D6FF280726EB1FABE9D15541 /* shim.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		45B25D082BF52A41858126CE82885AD3 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = AAA52AA7D10C2DB34B157CB99590BCCC /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		463ED6E2579BC198295EC896EEA2F0FA /* SwiftDeclarationAttributeKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F358757C92386AFCE20D3329EFD8FC /* SwiftDeclarationAttributeKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4665CD97BE0CF6A9F2A14A3F1AE74C36 /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86766CFDB30423496E2278A6471B9AE1 /* Dictionary+Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		486EB484B25E6C552D1E6A95307BC121 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E19AF940019148F45F7D8F7B53C373D /* Context.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		488933CDC3A98BFB85325587F8032F4D /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5EE1FB9C62B41AA2C101167340B4B6 /* Node.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		496AA4210A5DEF4B4A687574E7A8E953 /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 930614056B1E73896FC3334A2A5893B4 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		399F2A0A9C9ED1812D9AA38BFD985884 /* CYaml.h in Headers */ = {isa = PBXBuildFile; fileRef = 26E1B3CD7904BE5C5911926F0E5181ED /* CYaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39BBDD636CC467DBE0DFCBDD75E427F1 /* ArgumentConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8681C5C69A18640B47D67D8E0F0857F /* ArgumentConvertible.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3CDF952F696CDAC9C3CAB48C46DB70D6 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCDDD5CD23B1383A2607C12F5933F62 /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3D372633FBE021B83EF004F7B0B2EF7A /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C4D2EBCFD4619585436A7FAAC11F49 /* Decoder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3DC71586B9A2CA6AC42E01F8F652BBBB /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6194EF134E0C05224BD731E84371A1A /* Dictionary+Extras.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3DCB06D05475D77D3FD4CC14DF90723D /* PBXReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538B7D357DDE54A1EA611132E162F50A /* PBXReferenceProxy.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3F86AC29797CD19C2FAF637FAB8924ED /* Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9367BDCE37CFBC7778DA94E5F0A4F4F /* Parameters.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3F96CC3C5BAF701E71FF45662C2D68C6 /* PBXProj+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BB19424349984E1DD28537762814BAE /* PBXProj+Helpers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3FF0B57025B95786F46D2346D13BED1A /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 68ED56E961C40490163B0C2B5F2C6448 /* Quick-dummy.m */; };
+		4052560ED934EDA2BC58C22A40C7FED4 /* Yams-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A8270EE942DB4D0FEE7B27BC88C5E218 /* Yams-dummy.m */; };
+		4095F1E3CC2937A9AE6BFB9BE01CCC76 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A21BB8DF46FA32B549339B5353AD265 /* Lexer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		411280B2B83FCA12F11F0A2148F3BAC8 /* Parameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2BE1B627A2E002EBE37BC5C0FA9C20 /* Parameter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		415B3693083E4CA27E1A244EF7B69C0F /* emitter.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C2EFC5FEBB2CB2A0251DC0AF71473F1 /* emitter.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		41C7A7F1651FD1258E4C9D785F587A5F /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77896CE8A81F314E78F3A8B620A4385 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		41DF10875D30076DBDC6DEC735432991 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB430B1ABD157C3B664036F5BD6A2E0 /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		421A2A3E96F0A2EF0FCF230BF4FE0075 /* CXErrorCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 73AC51682E5204ECAF44C61C6D227AE4 /* CXErrorCode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		446DECB091B51ED30D4DDE9508C2A023 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CC526A9B66BD89B6A1EC926EC6A5EF /* shim.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4558F28C6C47E32E514A383C573950B8 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 4521BE920C2B762DF0422FAD2A2D254C /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		463ED6E2579BC198295EC896EEA2F0FA /* SwiftDeclarationAttributeKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48917552ED6ABA0DEAFB263114A60C8A /* SwiftDeclarationAttributeKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4665CD97BE0CF6A9F2A14A3F1AE74C36 /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419F20D5F7FA9CC8D26C251258CF3B1B /* Dictionary+Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		486EB484B25E6C552D1E6A95307BC121 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34A607D23E520311D5FB2AA94A4A4AD /* Context.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		488933CDC3A98BFB85325587F8032F4D /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E9C034674D21790244D9460A160663 /* Node.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4A025895F5DE50D25228632297337261 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBBEEEC02002438012A01646CE86409C /* Yams.framework */; };
-		4A5FA58F15831E265C46FB10208440DB /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 6C651386D5A6F392BE0C580DAC94A51B /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4A6FBE120532A8F011A35FA4196A50F0 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEEA040ADC36DED371505E82B97E0B9 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4AEF46148A608F44D8CA01A0D8E4675E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
 		4B60DCD0541DE9B5D6609F90B56E5937 /* Pods-CodableContextTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E9FF9267FAE9B8C8F6B7A7B26598111 /* Pods-CodableContextTests-dummy.m */; };
-		4B690E1DAC69C98F3D13C3EA418AD37C /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C0A5280E31C8437E25B1687FD612E3 /* Filters.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4B690E1DAC69C98F3D13C3EA418AD37C /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D05F4B45D5A8CB4F78E699EBC29657 /* Filters.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4BD2ADE2BC4A13523C0BFA8AFDBA8E59 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3E398D6F221DC29D748F3E0E117164 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4BD911A2A7B3E67726EC7F9ED37AA039 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED25C511E54A20108EA2153859BA9094 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4CD69033ADC4E38ACA55501CF1B35EFA /* AEXML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B745302A893C3C9EAF87439AC84F002 /* AEXML.framework */; };
 		4EAB6116CDC9354F8461084DD51EF5E7 /* Pods-TemplatesTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 03595947B6D6A4F4DCF7F346CB83F378 /* Pods-TemplatesTests-dummy.m */; };
-		509A11E46FC4BA03FD5E87D17A07CAF0 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B994AA2115476FFB2EC30EAED7BD1B63 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		528F51F00FF610F2ED6385C139776359 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		5350EEF45AA0B9D9DCA8045864712E30 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313D84E0A5BC3FB5EAD5BCCA503F8AF8 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5402BB5DC6F491715E6637FA81856663 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32234EFEF3A56F70B97A7AB03DEDA9B9 /* PBXHeadersBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		541F56D664219C5A5FB5B4C4AE8B5390 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = FC180E84CAD74CEDF65751E028D42C1B /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		548CA657CED0FA8C68BF710475E9761E /* Commander-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C53AFDB65DB8537F74FF1D4B5D0E7CAF /* Commander-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5350EEF45AA0B9D9DCA8045864712E30 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225E0FAAF998C5CE3841B4566C428E02 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		538E4ED22D36FFD1337A7188062363EA /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0004644435F94BB20CA0B57DB34D76 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5402BB5DC6F491715E6637FA81856663 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C0BFAC05B9A7242C4FAC4FC03EDFBB /* PBXHeadersBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		541F56D664219C5A5FB5B4C4AE8B5390 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 5728998ADA4872819707DD8319F0C5B4 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		548CA657CED0FA8C68BF710475E9761E /* Commander-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = CCE82CB6DD2CCB8C890A2B58613340C3 /* Commander-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55B64504D931D7B5875E1E0B6BB7C9B9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		56259829C11BF2F63A331B91BD166973 /* XCWorkspaceDataElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F1E7057742CED3E437901DF8D17E23 /* XCWorkspaceDataElement.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		56D8291E4203BA9B03FD001B252A8D66 /* Constructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9589331403E4DEBD9A7703CC8EBB399E /* Constructor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5775F504D2CFDB698FE0F51213BB233B /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002E04E0B6468B698ABF80D96DB0EB60 /* PBXObject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		57B2EE351263FFADF20988F2F4793E40 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E1962A587D8F2DF0332E485886E945 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		57C7681015D85B714B80B17AA950840C /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82337671DE84A5CDB73CE67D6808A2B /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		588A51D30421E419F273D9A95F097532 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F619B455A59CD9A00A0E71CF454DFB /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		59E843A7E787B4629448DE165F90A171 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3891F76F0BF44385AC30B6C1129DB9 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5AA6D6F56B81C3336970B0D2587821D4 /* Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33479BE1FE58E94688F5EE54E6EFAB6 /* Encoder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		55E956B71E193B56CD0A991D90A3ECD4 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C572DA952DEE0E505E17354B16ED43 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		56259829C11BF2F63A331B91BD166973 /* XCWorkspaceDataElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E4F00F202414474386E1B939A0309A /* XCWorkspaceDataElement.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		56D8291E4203BA9B03FD001B252A8D66 /* Constructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7E0172FBA325347D373E18B52EB1CE /* Constructor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5743FF7329B56548D14D7B2A1AFBF7F6 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C2B3703304D4EF5B7455ADEE207E72 /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5775F504D2CFDB698FE0F51213BB233B /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA86889C80EF4E033C9C848E7B1B65B /* PBXObject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		57C7681015D85B714B80B17AA950840C /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF157A94145675FCAB9B84EC03A01DBE /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5AA6D6F56B81C3336970B0D2587821D4 /* Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9703595520BF6F070F6A9850BCA3547B /* Encoder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5BD5B1A44C955DB888B08093B679DCD6 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		5CB1024520B48AB9E6424232871A608F /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86657F955ED624F632751451403157CD /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5EB4F766FC94565E6AF001F480B01182 /* sourcekitd.h in Headers */ = {isa = PBXBuildFile; fileRef = 677B4B130BA10A6366A88349BBAAA3F5 /* sourcekitd.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5ECBCAD56ED639E481ECFFA4B7DC2EDD /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8409F1B4B1B8BC1C2E34C5E349134 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5EB4F766FC94565E6AF001F480B01182 /* sourcekitd.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA4B24251E95BB75042F53183CA51BD /* sourcekitd.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5F50D8471985D433D90589104969392D /* Pods-SourceryTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 84B8B1842A5234759AC4CF12DDB9B4A0 /* Pods-SourceryTests-dummy.m */; };
-		5F87E477F619EF32FC644136B3FACCD4 /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE40819D1CE69A0C7B59ED67948FF45 /* CommentedString.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		607A0DB22946E8F4871B0233F50A22A1 /* ClangTranslationUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BD0A0E134B61D2458372804651C782 /* ClangTranslationUnit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6193AAE31B8DDFE2B4FD667055CAE810 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = A6EB0E53947D176E894C5B2D1CA7EE9D /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		62C2DA5D592126B29F53E0A8214F576D /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96519D90DBC67540EBD84E74F92E0C9B /* shim.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6320D30C52EFACA22F17F33DECB6D0F9 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E4793FDD9B7EF8E09E839FA82DF04C /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5F87E477F619EF32FC644136B3FACCD4 /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9337F8EC7F37E67B0EB7C5AC854172AB /* CommentedString.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		607A0DB22946E8F4871B0233F50A22A1 /* ClangTranslationUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78CF2129AB9AC3574CC2E29CECC392DD /* ClangTranslationUnit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		62C2DA5D592126B29F53E0A8214F576D /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFDF969A7F032C33E684E67454FE92 /* shim.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6320D30C52EFACA22F17F33DECB6D0F9 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F44C93EE89CBD00E32817E141E99058 /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		63F87F9B38D9218AD40CA0EF7FB3A2C8 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		64601AF2795A8956EF11860BC1C9A319 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0631987778343A27B02CBEA909528F3F /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		65C489AC4103B1BA17415338BA7510FD /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D49F4649317E86B0BF5806DFA59773 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		662A27937EEB5CAF0F79418AD351641E /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13079FF13CE7BD8D8102F9B516FF7CD7 /* XCScheme.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		663957B68257450CEDF19426A79BD8B4 /* SwiftDeclarationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE633EA1200B10C2AE81161F5B2372EE /* SwiftDeclarationKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		66D6D19BF2480543100C60E5F15644F8 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FCFE50C0FFC83F542D8CB5B32321DD9 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		69280C4BDE5FFAC1F4504EBD9E6DDC5D /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE6D72119440C7F729857E02A35F2EF /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6945052A1CE5DDB542B9033135257713 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE2479EF39C7D1551F41F553DEA07A /* Expression.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		699205F6FB01B30FA5AEF675C6D24D43 /* Emitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E035CAE40FE5642B42CD21C080BD86B /* Emitter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		69A0A85096B1E61DBC0C33B8DF3AA26F /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9D897FA60D583E597EB8FDA7A01148 /* Element.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		69BFB3199ECFE9CBFB250D9C5376723B /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D3D92F70A685B232ABC6781DC52726 /* PBXBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6DE41E67C51DB8BE6DB1CD805AA2F506 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA81100C5C01A43937190C2615F121F /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6E163B6E9A6D007DDB1268E3A37760E4 /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B437058791C226D47D3FC34F915545 /* XCBuildConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6EBE4FE8A7C01EA25B6C2065E87CA053 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E255670EBB9991D10652D6E8E3001F7 /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6F059B6B2F141941040BC637FFEB01D9 /* Documentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DFEAE3EEBE4AAB0F46CA502F6D7A6EF /* Documentation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		70058D089C2C13D857078DFD85D3DB2B /* xcproj-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A361C9DFD03C42D3C2B14CFF0E37E44 /* xcproj-dummy.m */; };
-		71500A07C1D29858F706C35165C5FB75 /* PathKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E9E2DB7A5042619D513D7DC103CF2FF /* PathKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		71A359492249495B1E67CA105ECC31FB /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD06437C20B04A8D508E39EF1FB79BC /* KeyedDecodingContainer+Additions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7285940C7EB529CAD206DD53AB6406A6 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD552233B9B5503D1F989CE3AB06BDE /* PBXNativeTarget.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		736DDB52F78FDFBA00553334642A01B2 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DBB5AB0439D4E5124A15479732A19F /* Environment.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		739F8BD0AB6962A762B83E397A6039CC /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915235F4B5593FE8CB345F8894173B /* PathKit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		73F2875FCF5C082BF9203818E0F85096 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6459435DBB72829839607EB712F1337 /* Request.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		74C4336360B1E11916DD302492F43FAF /* CommandType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EEE670C2712D66E4C9EA652AC8239AD /* CommandType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		751692BD47A5089D9AAAD94F9120607D /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = A409EEED1D16F55CCC3ECFC826D6DF55 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		758827540E69A346C532CDF179ADC2B8 /* Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502188CB5D01AFC592E9546FBF708413 /* Commands.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		75F889AC0EDB4563E381FE1016CEC80C /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = E265DDAEF41849BFBFEA3429F4D255AA /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		760E576486726B5745BA595D89DF3523 /* YamlError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79BB67C8F1276973939340AACB6591A /* YamlError.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7783B8C6274F5AF8CE7BA32CAD9FF78A /* reader.c in Sources */ = {isa = PBXBuildFile; fileRef = 7084B7BFF3FCF57B87E018FE057A1CF8 /* reader.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		77A0C071248147C59F2AD9EDE5D9025E /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 3845CCC21459E679A858FBF5D7EC1501 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		783F73EFE33073D6B186725651005A99 /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F073EE38FCAC3AFE15FE8F5BAD6585 /* PBXSourceTree.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		78FE010E74F4E1762636942837B00DC0 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2874AF9DF818105E8416A160FD5113 /* Options.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		792CB03FB37C080169B14139C3757C0E /* CommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2427229E4492A722B7247F958D5EF4B2 /* CommandRunner.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		79C420EADB146922351C7744C8389770 /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8904C6ACC3569C21F951874EF301C037 /* PBXLegacyTarget.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		79F514934CA4B464AF0D30BE9EF1568C /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 737D0EE3EC612F9D3DB132F72D59D8FC /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7A27EE4D1BB9A7789D9ED4773465BB7C /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89261071D4DF90CD5B0610CA2F515A42 /* Text.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7A99B708A6763D4E989EB70F114BC005 /* PBXFileElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1966DF340DFC3C39CBACF2830E2F0150 /* PBXFileElement.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7AB52BAA28E0CF687EFBE3B57F86CBC8 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F189BA4D1A62680E4B1B69193F002 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7CB6B67A453209FB2BBDCAE515216110 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B25C0463A934A6315CE00A44B9009E /* Tag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7DAC07ABF58D46F67EDFAB1F20804ADA /* yaml_private.h in Headers */ = {isa = PBXBuildFile; fileRef = 49E11AAAA532F08C143C144FBC897663 /* yaml_private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7E0E1424AD34CEEEB4AACF5AB446F487 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BFCB717681FABCD52E7E521A8885BF /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7E58F2316F98881CC648D2DB983B4AAE /* yaml.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D5E76231D541B6BDBD0694A75971BC6 /* yaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		64B068AB5DE63BD37523623C9DF7D660 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B42AD7D47626559CDB07DB7D4E566D4 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		662A27937EEB5CAF0F79418AD351641E /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F342B0918ABA45D405009CF98D78FB7B /* XCScheme.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		663957B68257450CEDF19426A79BD8B4 /* SwiftDeclarationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D0636E24B7E22B7A8B37E7A848E0E8 /* SwiftDeclarationKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		66D6D19BF2480543100C60E5F15644F8 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 106390DFAAF8781C28401D3809A1EF64 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6945052A1CE5DDB542B9033135257713 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34A74ACAB20DD9A3B8AB87F3EB6C970B /* Expression.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		699205F6FB01B30FA5AEF675C6D24D43 /* Emitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF00D49AE0D754ACDD15BF373709A4E2 /* Emitter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		69A0A85096B1E61DBC0C33B8DF3AA26F /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F514801346F8E0DB83F7C06222C4EA /* Element.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		69BFB3199ECFE9CBFB250D9C5376723B /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F507997DE78AA048FB013D8C035C6382 /* PBXBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6A461D3D320E07CB0D716B63A4C011F3 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072760713591AC981C004DC576FE1D09 /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6DE41E67C51DB8BE6DB1CD805AA2F506 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88B10C73D26CCCF76D5E1DAF34570F /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6E163B6E9A6D007DDB1268E3A37760E4 /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82B20DCED350CF321B30A93A67A9245 /* XCBuildConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6EBE4FE8A7C01EA25B6C2065E87CA053 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 60FA9671E8D8BCA97E5521E50EEA91BA /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6ED8AF0AA71FEE9673E2416A84819113 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 724CDE81D5A9A0D37CDC47265C72502B /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6F059B6B2F141941040BC637FFEB01D9 /* Documentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0696E69C82BB1CD491EBCF282E81B846 /* Documentation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6FC59CBB360B3EF8E45D151D945BCA54 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = D5BD296CA0134DA85EADBB14155AB85D /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6FCC1ADC65EDCFCD92DBDC767A0A4CB3 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8F43A5788E6DF310C17CC1CA0B12FA /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		70058D089C2C13D857078DFD85D3DB2B /* xcproj-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E93D7B4B53B6DB72A04217820C2DC1EA /* xcproj-dummy.m */; };
+		71500A07C1D29858F706C35165C5FB75 /* PathKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E9FEFA07FC5D171461675B2F26F250A /* PathKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71A359492249495B1E67CA105ECC31FB /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208F2AC1B3EEC8E298972FC244A869D4 /* KeyedDecodingContainer+Additions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7285940C7EB529CAD206DD53AB6406A6 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007B06C2452F605FD1357159F8638EC9 /* PBXNativeTarget.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		736DDB52F78FDFBA00553334642A01B2 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90143D33F5F43B2AC844E8027C2B9A58 /* Environment.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		739F8BD0AB6962A762B83E397A6039CC /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492A9A9BBE8346B8633EF900EA90B6E0 /* PathKit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		73F2875FCF5C082BF9203818E0F85096 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371BE6C7228D3E554420678816CDA4E7 /* Request.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		74C4336360B1E11916DD302492F43FAF /* CommandType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B60F153D0565B5C9C1F8EEC11AD0B11 /* CommandType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		74C4A30A55AC7DB057CE14BCA15299C4 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = B69786045B50248334DDBB789A2B6F0C /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		751692BD47A5089D9AAAD94F9120607D /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 38BD862A4D423A3A857F29E53891EFF6 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		758827540E69A346C532CDF179ADC2B8 /* Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8339F41335DEEBCCCAD28A8FDA440E /* Commands.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		760E576486726B5745BA595D89DF3523 /* YamlError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CFF005F442276AFE6D3CC0EC4C9186 /* YamlError.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7783B8C6274F5AF8CE7BA32CAD9FF78A /* reader.c in Sources */ = {isa = PBXBuildFile; fileRef = 269CD577304C27A75B14AF9D3478FF99 /* reader.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		783F73EFE33073D6B186725651005A99 /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F9FE6422C2C76783DDEC35FD918D6F /* PBXSourceTree.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		785AD96A96C1FC1B38BF9A12F14D12B1 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D20F25FD6B17C7D7EBC7E99DBD45D88 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		78FE010E74F4E1762636942837B00DC0 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CE6DBDC1B219FF9BD3C599980C3189 /* Options.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		792CB03FB37C080169B14139C3757C0E /* CommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46E34D9803715249741363C105AEBBF /* CommandRunner.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		79C420EADB146922351C7744C8389770 /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3C8037776850A97A97A642B8C0DB80 /* PBXLegacyTarget.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7A27EE4D1BB9A7789D9ED4773465BB7C /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0CD2970F06D4831A45FE0CB37B49E1 /* Text.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7A99B708A6763D4E989EB70F114BC005 /* PBXFileElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2AAC4A83087615D20A1842737DFF5 /* PBXFileElement.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7BFDEE03EF96D7D10E8EFF5AEFD37141 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39641AC72362CE48B2C7100C3548E365 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7CB6B67A453209FB2BBDCAE515216110 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177D9E3CA9F3EA76C7FE0DB16389C6FB /* Tag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7DAC07ABF58D46F67EDFAB1F20804ADA /* yaml_private.h in Headers */ = {isa = PBXBuildFile; fileRef = 12F46044D788C3589179FCD80081946E /* yaml_private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E58F2316F98881CC648D2DB983B4AAE /* yaml.h in Headers */ = {isa = PBXBuildFile; fileRef = E2685F20E55B0CBB29554B433A6B067A /* yaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7ECF1F6EDEC4C7354B0C6D5B2DCE5B7E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		7F720DDA2603DD37F026757DBE1C025F /* library_wrapper_Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86E786690D5CA5323D9D057B88B8BCA /* library_wrapper_Documentation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7FDBB1572BBD954506E90349986673BD /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B283A8568909F9D09FAB2E0C0A30DDBF /* Parser.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		800C7A9A7A23A732BFC022F4575254C8 /* StencilSwiftKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 90F7E82F109A2232E1166802EAD00C06 /* StencilSwiftKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		808556B6CCC23C8F84682655FC0DBDFD /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7EF8E3FD503FAE5D5068418202B38B /* Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8157D8D7E8517F8A38B131A28B41049C /* library_wrapper_Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A80CDE43BED2CE02D0C9E9DAD69AAA /* library_wrapper_Index.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		817C33C41AD56ADDB5A9B3EAF8BB5144 /* SyntaxMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2CE84D54458AB23908FA1CAFEE70AF /* SyntaxMap.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7F720DDA2603DD37F026757DBE1C025F /* library_wrapper_Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F20050C1512B68623E7193D35460A2 /* library_wrapper_Documentation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7FDBB1572BBD954506E90349986673BD /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BCC55BB7938F3643E28832C88F19CB7 /* Parser.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		800C7A9A7A23A732BFC022F4575254C8 /* StencilSwiftKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 55BDF279F8BB2B1A13B06D529A9FAFB3 /* StencilSwiftKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		808556B6CCC23C8F84682655FC0DBDFD /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E234C5490AF52AC1EBB9598C8CF1A3AD /* Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8157D8D7E8517F8A38B131A28B41049C /* library_wrapper_Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC7EEB4CBDA235AF20A2F4E3292FCD7 /* library_wrapper_Index.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		817C33C41AD56ADDB5A9B3EAF8BB5144 /* SyntaxMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DEBB1340ABF4AF30057BC605D9C931 /* SyntaxMap.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		81B622D4826002DAA41DF74C76F13F1A /* Pods-TemplatesTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F156B8C4EA48BD576F334B6313D5519E /* Pods-TemplatesTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		83B3EF5667BA6B9B3CE6184CA031B578 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = E121DDBE119662141438479A7AB91AFA /* XCWorkspaceDataFileRef.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		841E8232F5BDB5B986313A19FC26D9ED /* Stencil-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E8F5E4DA24732B6AD19F6DE8D6882A52 /* Stencil-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83B3EF5667BA6B9B3CE6184CA031B578 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E8353831309132DB8AD563989192C8 /* XCWorkspaceDataFileRef.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		83D013225B8F78F6BDC290367C5CF602 /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 19F0FEE218FB7A3E78C8E514B4D75900 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		841E8232F5BDB5B986313A19FC26D9ED /* Stencil-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A42E3E0B61C0DE2C5799AD4BC054AC1 /* Stencil-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84D1B8705B39A4409A24C9A87B7F8A9F /* Pods-SourceryJS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FDD9E9CDCFE937FF2C8EAB27F50C6AC0 /* Pods-SourceryJS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8577682CAC26B165F10F90F71AB088F9 /* JSONOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A93D1F2356F47D1B4541A8D2F2E4C /* JSONOutput.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		85A4019248D92500E641D01E1AD85724 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = CD8EF75B2223937F2DDE31B173227623 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8627B06B8FCAACE5B054077C39EF669B /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B606BC63FB1111DFEE6181CA112C8BE /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8577682CAC26B165F10F90F71AB088F9 /* JSONOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC327897196E329B6427C375FBF2C039 /* JSONOutput.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8627B06B8FCAACE5B054077C39EF669B /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = B3DC89DFE06119563E55378C1581D5A2 /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		87BFC49694061998BE1F92F7F0EC9359 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0211CB52469DB3DE38DDF2935B957CF /* XCTest.framework */; };
-		884262B798A24363E3AA0C5EF548355D /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C428DA4D589EF21D6CFCFB9D6F2E43 /* PBXContainerItemProxy.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		88D550C72CB2D7278C3710B6087FAD66 /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56787D29D44834F3B2F2B0767D9093F9 /* BuildSettings.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8972078BE79C8B7642FCAC5279D4A501 /* PBXProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = B190854AFDC66912D57A546D3F5C0B14 /* PBXProj.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		89AD12601BEC4F7AF6B7937C48AB36DB /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C11694083C15CAC1DBF387D858BD3B7 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8A960844A9E3899D482D5DE6AE58ED8B /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6ABD7DF77635B8EB76DBCD540ACD8A7 /* Command.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		88357E2D0529CDAC8F4ABECD38806698 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5E2B63AE98B21AFAD74258C2620F36 /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		884262B798A24363E3AA0C5EF548355D /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7986044B4C2171879E1A3278AAA1C58 /* PBXContainerItemProxy.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		88D550C72CB2D7278C3710B6087FAD66 /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F1960B83B53A9E3DC7EB808A65ACBD /* BuildSettings.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8972078BE79C8B7642FCAC5279D4A501 /* PBXProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32EA9241C6B88939BA00B98DBA1453F /* PBXProj.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8A960844A9E3899D482D5DE6AE58ED8B /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7167F0F96B5E16E0446666685305B0 /* Command.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		8B1D3EDB4A95BFB2BB49BFF97B078B5D /* Pods-Sourcery-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18E57C92D8755434DBF78AC2FC1D8BB5 /* Pods-Sourcery-dummy.m */; };
-		8B3A01655C9E7B48C7A989E6D7733944 /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90556615C47011E9D9BD379B34EB2D8 /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8D08ED8746D7D37DE10B1CA9FFE3DD8F /* NowTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7249B16A82DD696BFA3C7C70B59E3A /* NowTag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8E7037DBC1DF5F5EA9D6B98A1CFCCFAF /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1282F8D5254839B2545FBD3406476CE /* Writable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8F04FC586BC9AAB8FD9A10E5DCA2A07F /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C89315E1EF04A0808A3DB4742DEB3D6 /* Parser.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		90D255CAD59F138EF8D4944BBF4A9C3F /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EEA18E28CE549A4A778F719637A351 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		91AAFB5DFD1D7BA7FB00AF36F8EC5A8E /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6545BF4A41DEFC6135774D20FB96260 /* PBXVariantGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		91C08A92BB6B9349CA09D018C7D7A62F /* PBXBuildFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6669B5EC13B9CB5848658465DC782680 /* PBXBuildFile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8B3A01655C9E7B48C7A989E6D7733944 /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C5EEFAD2574DC009FF7DC65A90F3F1A /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8D08ED8746D7D37DE10B1CA9FFE3DD8F /* NowTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC841FA257A928A8870849338198F5DA /* NowTag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8E7037DBC1DF5F5EA9D6B98A1CFCCFAF /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7883F44838153A966BB457DFBE865A /* Writable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8F04FC586BC9AAB8FD9A10E5DCA2A07F /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E16C746C798A5EB431E7FCE153C73E1 /* Parser.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		91AAFB5DFD1D7BA7FB00AF36F8EC5A8E /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AA80A72F470DD549A4C193F55B825B /* PBXVariantGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		91C08A92BB6B9349CA09D018C7D7A62F /* PBXBuildFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECB41E90854ABC0D5EFF0192768A7FD /* PBXBuildFile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		922C5F6A03B0CB287BA0D9119D2B2471 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		92BAF81392C3461E0F3F2E49CB35AB26 /* XCWorkspaceDataGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039B28B0AD3B8FEEDAA82F74C6E6E434 /* XCWorkspaceDataGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		93995EDDF53DC86413E25F3A2952B409 /* AEXML-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DF9AE190591194C88B74C31BFE071AE3 /* AEXML-dummy.m */; };
-		93E481CBA2A9DDE543B4D7D1D432153D /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B22DDBD2F986098454F0B048603572 /* Bool+Extras.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		93F1C460215829F7447B6A8F8B35D626 /* Node.Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C13932E3FD00DC6C06FA2809950BE3A /* Node.Sequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		956BD6F642668715480D71D355533A71 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0C214947B910E1811148FEB33BF85C /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		95869510789CB32F5DA06F80372A705D /* SwiftDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C15CCBFB5DF55D7C24C4E8C11C7C312 /* SwiftDocs.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		95C84E684F6E110EE3ADEA7568B9A50B /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D92EEE91BAC1523C1482EA09C63021 /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9612E4D38F562B21CFE4F5EF65A2DA56 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC98B0092E4E82396DD4B76FD39712B6 /* PBXResourcesBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		97C070460B238F807583ADA1854971BD /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C53E013FAC2D9ADE1E9A094E02A908 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		97EC73BEBF92F232966939DE9B62399E /* SWXMLHash+TypeConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8549DCEEA3EB5F3E62810186AC48ED /* SWXMLHash+TypeConversion.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		97ED16105333401020F03477C6A95392 /* SetNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE2760C6D9487BA6DF67EF3F27551CB /* SetNode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		981CDDBBD5032667D1AEFA3B5A4E5225 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A01C37F8242E71819A97E11B6F0294E /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9866C4456A7C531334553D518ED7C10F /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A58584447AD7CF6234686646644836 /* JSONDecoding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9A23E38ABCC91B8DE80EABF78189917B /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402F261F96EF3BFAD7E7718CAE1B5AB0 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9A68699F4DB3351CBB2DBCEBE20AB4AC /* CallMacroNodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A999F8A82D861064F2044A0698B64C /* CallMacroNodes.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9B7CCBBC5676D57FCC9E5AE0F0F2FF8D /* SourceKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A0FD9BE14D163B58F2FF9FCEB937E6EF /* SourceKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92BAF81392C3461E0F3F2E49CB35AB26 /* XCWorkspaceDataGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB141316ECEC7EF5C2DEBA446C671A35 /* XCWorkspaceDataGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		93995EDDF53DC86413E25F3A2952B409 /* AEXML-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 71313AE80A30431A02EB459A3A642DF7 /* AEXML-dummy.m */; };
+		93E481CBA2A9DDE543B4D7D1D432153D /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD84D7615FBFA926D4817684600C668 /* Bool+Extras.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		93F1C460215829F7447B6A8F8B35D626 /* Node.Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969139ED9A9F94B35C1C8EDE8B2ED1D0 /* Node.Sequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		956BD6F642668715480D71D355533A71 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4675108A8CCBD654FBC27C4AB7054C2 /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9580243E28D41834AB029756CC3A6DB5 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E669B1637A0F53943635C746AB5706 /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		95869510789CB32F5DA06F80372A705D /* SwiftDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5109351B112682BDE28A756394713AB /* SwiftDocs.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		95C84E684F6E110EE3ADEA7568B9A50B /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73A303C46F3F862C25F7F261EA36A4D /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9612E4D38F562B21CFE4F5EF65A2DA56 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B2A0588079756EDA937C1209E642B6 /* PBXResourcesBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		97C070460B238F807583ADA1854971BD /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC5DCE812314A9FCCCF5B1BDEE2564A /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		97EC73BEBF92F232966939DE9B62399E /* SWXMLHash+TypeConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44719B431957647278C9C274C0CEE58 /* SWXMLHash+TypeConversion.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		97ED16105333401020F03477C6A95392 /* SetNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86A917AFC624894FB49DCD2F9E5BD1C /* SetNode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9866C4456A7C531334553D518ED7C10F /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F2B921FD32145CB67DFE1E9A25D8E0 /* JSONDecoding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9A68699F4DB3351CBB2DBCEBE20AB4AC /* CallMacroNodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DDF557D7ADB4E46279A7721464D64F /* CallMacroNodes.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9B46353E3DA49638D67225C5C8252948 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C005BADA747082B9CCD06BFEF2F83 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9B7CCBBC5676D57FCC9E5AE0F0F2FF8D /* SourceKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB7ECE4B31F3818DCF9F372B651EF7D /* SourceKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B7DA83116104ACF22F3A08389106259 /* Pods-SourceryUtils-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B71469ECCCB0AE37079562EBF73B1E0D /* Pods-SourceryUtils-dummy.m */; };
-		9C25BC723ED8C3D2AD876B9CAC53B173 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = A8231D4EF1852B83481A2C35F3C85115 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9CF19004782EF08ADBBED65D074A0497 /* PBXGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469A589CA2F94AE60393A5DB21FFA5F0 /* PBXGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9DAF3208FFA993D3C2DDDACD495496F8 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E96AF77221F5589CE93229D97E5EB4 /* XCConfig.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9DE8DCDAD06D8264809B02E52B1F551F /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E3D33954C5BC9890F78A2B4B79D942 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9E8BF60EB518F71A146A7E0BA1898B75 /* String+Yams.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B46E0B6F9986A48ED38C876BFBEB63 /* String+Yams.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9EA2055AF46C7D60C37EDA35B2A16881 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B313ECCDB14FD79AC6BFB415BB0F959F /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A08B9A0D997DD9FB8B926EE503F8692E /* Stencil-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 048D5F5BEEB35FD533102D34FB65E476 /* Stencil-dummy.m */; };
+		9CF19004782EF08ADBBED65D074A0497 /* PBXGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8338743B57A2D4C2844A2679D32DBF /* PBXGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9DAF3208FFA993D3C2DDDACD495496F8 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D12D4009D505025D09CB822ECF53B04 /* XCConfig.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9E8BF60EB518F71A146A7E0BA1898B75 /* String+Yams.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D58E8E3711D7F3BD2E8F1FCAED1C86 /* String+Yams.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9EEF9E84E580920E11E06170D25F65C3 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 76294F8D74C2D7376B9EC996D9131596 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F6DF89F9DA63348B4C3C1007855C280 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4338CD47D14F6D47BDE7FE08DB5C53 /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A08B9A0D997DD9FB8B926EE503F8692E /* Stencil-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 428CEBBC652516B043D1FED31EF1B276 /* Stencil-dummy.m */; };
 		A0DBB6E4781CC40FF4484AC96159B94F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		A2E5CCC9C6B21BDEF81F7A606A0C052A /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1877A03BCF290C780ECD69377D38E651 /* PlistValue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A31005E39356DB35F489285201BB7787 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB43CC6B8961A67EB7228452C71BCA92 /* XCVersionGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A37E2B9A2211FC7A25C94A50CA8CBD16 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BAEAB0C6CBF439D69467E09A01AA6 /* Errors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A2E5CCC9C6B21BDEF81F7A606A0C052A /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5749A684FD4A16EF0D0EA5D8E321985 /* PlistValue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A31005E39356DB35F489285201BB7787 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A630E9B19712F4E441412E4781FD66A6 /* XCVersionGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A37E2B9A2211FC7A25C94A50CA8CBD16 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5225920B0BCC69D1F01F8307C648EB /* Errors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A3A7DA99F3721DBDEF9882648B76DEE2 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A545F434570A63FD5E1141F57691970 /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A3AC6A3331A7C69F3774FAA9F108F8F0 /* Pods-SourcerySwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 56850663058480438E9EBFC2FD14867F /* Pods-SourcerySwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A68DA95AA783F14C4C71F60915FF7230 /* parser.c in Sources */ = {isa = PBXBuildFile; fileRef = A2B51A6BC636B1115C5A162A9588B9B7 /* parser.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A7C40DD472FEDE062062BD1140C2E3D5 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215F87888AB476DEA27760112E4476BA /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A5BC618B300BCFF8B7EBEDBF5E3F4D13 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2867E36381ECD8DC94C8E693004E23CF /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A68DA95AA783F14C4C71F60915FF7230 /* parser.c in Sources */ = {isa = PBXBuildFile; fileRef = 69CE06279246EC77C9980B88D70814B9 /* parser.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A745D105633763CF3E84DE4C1266EBB0 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239D0A65FC9B182DCEE20B0737E8466E /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A83985E07C2B0B2543A6E81075CB2E7F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		A8EF0A40FC0177E52AC6A8D8F33DEA56 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EFC7BC26C574A7C25CDFC86A281AD39 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A98149D61BFCA4F446CCCD848FE44509 /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA285345A5B858D1BA50A4C747EF933 /* Group.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A8C022B0964489356E7C55DD10B9275F /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776214A053BBF81117AEF49F94714BD8 /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A8EF0A40FC0177E52AC6A8D8F33DEA56 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAE2E7630397E1B0D00C761D0B58B6C /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A92EA151E2D101A25C90284BF4C42D17 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A23FD40CECDD9C445EA86F236AC8CF /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A98149D61BFCA4F446CCCD848FE44509 /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4FA4043FB75E62C84F49D5950697AE /* Group.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		AB6DA6A56EC37E11BD4F77460C2AC910 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6ED07CC4BCA7552E8860349A48D278 /* PathKit.framework */; };
-		AB9683609906CBA41910EBE0B492A30A /* SWXMLHash-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 96E70641FF5262B79101656AE2878B6B /* SWXMLHash-dummy.m */; };
-		ABF53A761CBFFA2ACFCAE559FFAC2E44 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590E2D58A86A0596AFB572EC4E16ED3B /* Module.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AD4C4274D5F9351FEB8A57C834317A85 /* xcproj-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8269C7AEC9E678BD76F3A3B0988DABA8 /* xcproj-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AEA6B63C1084680EF74D0C299DC3A484 /* StencilSwiftTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41B4237BC69B6EF17DB486776767990 /* StencilSwiftTemplate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		AB9683609906CBA41910EBE0B492A30A /* SWXMLHash-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A0359557D6F9E4B6E5C82E48488CC8E6 /* SWXMLHash-dummy.m */; };
+		ABF53A761CBFFA2ACFCAE559FFAC2E44 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E866705CE5BA9A15CFF2D6DB9A048 /* Module.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		AD4C4274D5F9351FEB8A57C834317A85 /* xcproj-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 784C42C8B774EBB778FB0F8041D5892C /* xcproj-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEA6B63C1084680EF74D0C299DC3A484 /* StencilSwiftTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD20E9F784FAB05697C736E9B6AA86D6 /* StencilSwiftTemplate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		AFE49E44F6FF8DCA7158EFBEAD4BD903 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30C396EAA660FA5BB5720BAE611D83C /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B0B59C0EE722EF7D55EEE608CF9E7EAC /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B4B5233E9B7923DFD3424CE70510B65 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B1B58147AC889E65DA84EE094D28EF71 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		B419964606930231BBB3C7E3415D7FA8 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCA4105AC7D57E92315742675842F15 /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B47E0F659EC19F6E400D7F8ACFB66BC9 /* CXString.h in Headers */ = {isa = PBXBuildFile; fileRef = 6268A034E876AE813B4D04882A6BAC78 /* CXString.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B50447FBC666A1A594F28CE0D0C03E7C /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2691BD03039318ABF565B350BCF7FDAB /* Xcode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B509CDD01C4F86746BBDBAEDF47343EF /* SourceKitObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7336EEF50F41578E607ABB7379D35029 /* SourceKitObject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B59DCF84D55FF966686D3668816A90A8 /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9C560172035696B66B86D4D0D8C27B /* XCSharedData.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B5F56FD514193D7D9CEA4BCDC15341A9 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7609175A5C8067D4BF812B6E986F9C /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B5FB0AA346179F1FE0CB0129A05F0837 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = F573901AF13F0E0EF143310AC7F5D9F9 /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B668C90155CB7148D81121859024A5C6 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 743DE2C453FC27A0D319CCCB7613743F /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B68FD3B9738F0CBAD83BACE4DB1EC20C /* OffsetMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687CC506A3442B0111E960B4B2D6C597 /* OffsetMap.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B6E97441D637CA2573C00129B4F2F41A /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3510FD7EE673AFF1DD4938BAAE99E5B /* PBXShellScriptBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B75B3A84CA2964056CB81372F60AFCFA /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2595AEAC3BCC5B1F193B53860D9DE182 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B85BEFCC88734159BDBEDAB7D78516F4 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAEF487A8F518B2554778FF0112ADBF /* Context.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B8FAD3858F0D624E3E00B36B126D70DA /* ObjCDeclarationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9734EA8E9FAC9D97FD0CFC957B268FE6 /* ObjCDeclarationKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B9DE8A6720B0844D1F4D90AF9925D783 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A24E557109A736FAE3D8E3386937BB /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B475D60EF423CD72EF0313769B13F827 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9CAC44A9FA5EE5D17A5FC973EE32C4 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B47E0F659EC19F6E400D7F8ACFB66BC9 /* CXString.h in Headers */ = {isa = PBXBuildFile; fileRef = B156B9A00C759C4FFBAC0D7886C7C9BB /* CXString.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B50447FBC666A1A594F28CE0D0C03E7C /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5DF88B8C1A49FA7B107427B7CED9C /* Xcode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B509CDD01C4F86746BBDBAEDF47343EF /* SourceKitObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3F8D2F517630E4E38ACAAF7557256C /* SourceKitObject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B59DCF84D55FF966686D3668816A90A8 /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0088E7AC0A863675177030D8A555B855 /* XCSharedData.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B5FB0AA346179F1FE0CB0129A05F0837 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA404C525F5E3D6A8016BD7475C4DD0 /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B68FD3B9738F0CBAD83BACE4DB1EC20C /* OffsetMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC119E25152D883EA65D7F20991B383 /* OffsetMap.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B6E97441D637CA2573C00129B4F2F41A /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B641481219EB1331EA9C9B440306F66B /* PBXShellScriptBuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B85BEFCC88734159BDBEDAB7D78516F4 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DAB2299B625C88F883A97FB72237DF /* Context.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B88DBB55F98657F499C04004AB1779F8 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E199270F45434E40032A42DB68D234B4 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B8FAD3858F0D624E3E00B36B126D70DA /* ObjCDeclarationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4489EA2029BA75698245FEF0391A3F1 /* ObjCDeclarationKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B99015D3DD07794A7BBE0CC5DECAFB6F /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = D548406E39D0C950B3148E9689318412 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BB0ECD83B36AF27DABACD37C49B9DB3D /* Pods-SourcerySwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DA537602DB30DAFF92104C21702B8B3 /* Pods-SourcerySwift-dummy.m */; };
-		BB5DB37481529FC60A3A88C684480AAA /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051EB1331381FD568472DB8DC67F3BEF /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BBCB12505BA11A080EE3C7A5E45300B2 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 28D2A11AA14EC190F3B24856BCB57D2A /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BC95C8E5A29172BD62F38370F92723EA /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAE2596144518B71925CF66DE01102B /* BuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BBCB12505BA11A080EE3C7A5E45300B2 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE0DF62AC40ADD7624A0368F23C18B1 /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BC313B6D421A1582B26D7DC93716C764 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC536B7ED5C3A1B78F5F23AD0A2975D2 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BC95C8E5A29172BD62F38370F92723EA /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796BD1961FD3BBC2E779361F39420484 /* BuildPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BCAF975668F8C5FE049FD281586029B9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		BCCD16D79CCF757BE1D31F83F8C1B858 /* CodeCompletionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77DAA13055ECF12D9BE59C7F962EEC9 /* CodeCompletionItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BCDEC9A6917BBEEB52E292F1D0529A56 /* AEXML+XcodeFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FBDEF172CE4AEC4591A23B451771C6 /* AEXML+XcodeFormat.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BE18A18ADC276555403066AD5AF25C1E /* library_wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE43F487478A99E4B5F6F69E26B11B17 /* library_wrapper.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BE31ADD6646CB595A0C125517B0CB682 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5AB8A585BCB8D9DA75014B18941F05 /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BE9631B3CFF5881B6C29BBA43FD8B81E /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BD2DB45369BE988EB5E3290A29AB381A /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BCCD16D79CCF757BE1D31F83F8C1B858 /* CodeCompletionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9C71B219C77CB709319D25FFEC89A5 /* CodeCompletionItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BCDEC9A6917BBEEB52E292F1D0529A56 /* AEXML+XcodeFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B50811A8539F4000B8902F066F142C0 /* AEXML+XcodeFormat.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BE18A18ADC276555403066AD5AF25C1E /* library_wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3324DCFC9DAAE9217CF425C3FD56CEE3 /* library_wrapper.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BE31ADD6646CB595A0C125517B0CB682 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E87ED98D88F15CD9B87A7E4854AA2F /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BFE47105B37CFE575785C00B6840BF98 /* Pods-Sourcery-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F72ED6A8311FA14760E026F1CD586A /* Pods-Sourcery-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C0FB459DF79D0F76DD07319553A23F2F /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A1DBA8FEA298575651AA7C04EC4E382 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C2EC54E7E305A136F6667BF3DE94049E /* SourceKittenFramework-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 33072464A22946EF064FCF85100D1935 /* SourceKittenFramework-dummy.m */; };
-		C55DC46B5D25E5E6C99BFD1A01478831 /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E939CF1BC6C22024EDF6DE626596C44 /* Template.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C67AEBD682DFEF1D6EA4E35916FFF125 /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58A1287295B6B911238BFAF4CFB529B /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C6C6118D29F38E60D4092F0576BB8D8C /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319EDECE568D42A1979073BAED5E28D0 /* XCWorkspaceData.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C749E93CDF96527DCFDEFC50A73390AB /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F799158A78693CE3DDB056F1C9DFD5B9 /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C78F8C0997E22AC93D8C81914125534E /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBC2DABCB8CBBA98357EB57930FBA78 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C8234C3E5FB0B352983AF48C340FD5F6 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9F20F354004D3DCD2B94F7BB88CED8 /* XcodeProj.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C88E333DD412A34523C13BCD29C72D76 /* ForTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC5E0B5C0AEE1F4AD6DCC77A8C6B186 /* ForTag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CA4E2FFB9416C92E10D2919C9E5236E0 /* Filters+Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEF742C448CFA02719FF525409C7764 /* Filters+Strings.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CAC04F7ABB34BA633376E24D40854B35 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69AA80704FE1E390E7E6EAD1C23DA8BA /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CED266743A510BD36EDA58FBCC5B00A5 /* PBXTargetDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FDB2F5242C6AD138ABFC3B4571EB3C /* PBXTargetDependency.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CF95120F42CF91ED4418A05A666216ED /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA6DA2739C00AE8AAB56B2B4B6BE41D /* Environment.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CFD2F6002CF76BC111C86DC0890DE2CB /* SourceKittenFramework-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FB52B2EA57047A2E09B1828AA240F29 /* SourceKittenFramework-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CFDB28D1D2A64F7ADAB6885ABA4AA202 /* StencilSwiftKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA94081B5833FD432108861C88B65E2 /* StencilSwiftKit-dummy.m */; };
+		C0367D0510CE9E409A33E9B356422017 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A0857F9532A5F5578C3A9B43ADC720A /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C19575820B7C050B2C5D9157959A2FB5 /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EE83E22B4E14DE7B80206A906343756 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C2EC54E7E305A136F6667BF3DE94049E /* SourceKittenFramework-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 94E0948E7E9E0DDAC3AFCBA13E647A0E /* SourceKittenFramework-dummy.m */; };
+		C3A770BF7DD23F88BC2D3AD4D353F056 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = E5E7F55A7F9EA55D4CDFC942B8C552B1 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C55DC46B5D25E5E6C99BFD1A01478831 /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE60519AF5071B1F75B32146E6C45F9 /* Template.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C6896BE181783C3F8E851E7F00DA94DC /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50989DDB7F65C9CB250FCAB54809DA7D /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C6B35E7096035752B869D402FF356F8A /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2075DC4B09A0F15576EA6C347DAEAC3 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C6C6118D29F38E60D4092F0576BB8D8C /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6854B654588CAE315C2957FFDA593BD /* XCWorkspaceData.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C749E93CDF96527DCFDEFC50A73390AB /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EB84D7064384AA64D3BF638BB44B58 /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C8234C3E5FB0B352983AF48C340FD5F6 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9646D60E4888A57E32E05DF58D9AAF5F /* XcodeProj.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C88E333DD412A34523C13BCD29C72D76 /* ForTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE094C28A56B2166361BC09BF4040E6D /* ForTag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C8F2AAC9FE9B6CF714AE4DC59C7DA89C /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B06BC11AA25C779382CEEC38844ABD /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CA4E2FFB9416C92E10D2919C9E5236E0 /* Filters+Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0E96B1AEAAE2903E43628062F67A6E /* Filters+Strings.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CC3FEA1AF258FA1BFE636FC5E33832BE /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588735FCF590A1586ACE1D1F75BA4BD5 /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CED266743A510BD36EDA58FBCC5B00A5 /* PBXTargetDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7914CA125394D8F1EA05CCDFC2D30B /* PBXTargetDependency.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CF95120F42CF91ED4418A05A666216ED /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D760C84B7E14997427B57A70E60FEB /* Environment.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CFD2F6002CF76BC111C86DC0890DE2CB /* SourceKittenFramework-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = CE346E383BCE6F0117BDDEA5F008DFE6 /* SourceKittenFramework-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CFDB28D1D2A64F7ADAB6885ABA4AA202 /* StencilSwiftKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F0E6E8C6D9E278CC973E855B38529B8D /* StencilSwiftKit-dummy.m */; };
 		D1D73C4353B91F01DA2585A9573C46BC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		D1E868F0FC5669DB565FF8FB3DC6328B /* Clang+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A0D4145C9E1429398168DCEDCBAEB2 /* Clang+SourceKitten.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D2F1381219D456676D9B98B7CFB1780D /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61D38AF942509E9201C2AA77D850075 /* XCWorkspace.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D2F275508F0D49DE8CB55F688C42C6ED /* Inheritence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231EA63ACC19C9C449BB6963C75F5AE4 /* Inheritence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D427386A796DA46156663B48FF1BD6BF /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7392EE5BE7C9E6F293892057AD48657 /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D464A9E1758810E796EF0D7ED624DB2D /* Commander-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B0C186AB6A651C1AA36E1D4D4B72621C /* Commander-dummy.m */; };
-		D72E6C2DF451FBCC0BF40F00403BD53F /* PBXBuildRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD20DD4C565C9D58FA179D4F033F238C /* PBXBuildRule.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D746B27CDC670457783E1DE0BC99E4B8 /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471016ABCCA3820B513E285BCB3C1BF9 /* Variable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D7C454158BA609467D5388E02798CA50 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CF383036BF7BD1336D99F3DC75E11A /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D914112D548CAF1CDD162BBEF38919C9 /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83F42744F3811C0B8A341602F52F4AE /* XCWorkspaceDataElementLocationType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D9339CFE5B6DC3355A106735785532EB /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A9E730385794274DE40C9F1BAD543F /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D95876C8DD357CD8E8EC4F528F33A101 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330EBD708AE6DF6853E09121B6C3CB60 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D986CA4EA77D35CCD5A37DF662B1A362 /* Platform.h in Headers */ = {isa = PBXBuildFile; fileRef = 0103E4F62C4C612B4D03514043CDAC1E /* Platform.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA3B3750A69752C8DD3B0CCE43A40CC9 /* PBXProjError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9CDA6191946FBA1E9882F4A96E91FE /* PBXProjError.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DB752E6DB2AD2682F87FECE929FB5487 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5C198567D5DB0873403F58ED415A33 /* PBXProject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DCA08B3FC698527E21CE17FEE0F44045 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 434F9B69163B9B12F31B1869E76E8015 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DCC52607A3CBD3315A2246F238224A8A /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A610346F082C6EFC756FC490E66CB6B /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D1E868F0FC5669DB565FF8FB3DC6328B /* Clang+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C112658D3B3F622CE76A34F5A224F8C /* Clang+SourceKitten.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D2F1381219D456676D9B98B7CFB1780D /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20C035F391F5A4BBEF2E37DB2215FD4 /* XCWorkspace.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D2F275508F0D49DE8CB55F688C42C6ED /* Inheritence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37D12B5030FC2B6C84603464DB9FCA9 /* Inheritence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D464A9E1758810E796EF0D7ED624DB2D /* Commander-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9256BF91D068CBBFEAC4245578DDBC99 /* Commander-dummy.m */; };
+		D58E1282340D01DBD6484100AC9665E5 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = F573E2FE76FA8E3558ECDD3C19F2E453 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D72E6C2DF451FBCC0BF40F00403BD53F /* PBXBuildRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9FEDC5CF1150B66BE9C52C34B9356C2 /* PBXBuildRule.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D746B27CDC670457783E1DE0BC99E4B8 /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71AE4A4EEE20E5A2FC29E20B24C0BC3 /* Variable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D914112D548CAF1CDD162BBEF38919C9 /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3959265D13A13963BBA7A3AF015B6DB7 /* XCWorkspaceDataElementLocationType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D986CA4EA77D35CCD5A37DF662B1A362 /* Platform.h in Headers */ = {isa = PBXBuildFile; fileRef = 9688ED2F2B90D7B3D257CD99821A9EA0 /* Platform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA3B3750A69752C8DD3B0CCE43A40CC9 /* PBXProjError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 678B8FE171235792C83D131DB8383D44 /* PBXProjError.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DB752E6DB2AD2682F87FECE929FB5487 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70EA8900B945F212B11AEBC26B42506 /* PBXProject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DCA08B3FC698527E21CE17FEE0F44045 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = C948D65F9BF004850F65FDD9C1D55238 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DCD732B49592B7728947862726FDE3CE /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		DD154EF56D0E8175A848B7327A50C9F3 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC919B132CFD067415D999CBB690867A /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DE170038470E8DDDBC393195336A19B8 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BC9501038F61F601936078AF117C4A6 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DF181C699D119555C5F4209404D925A7 /* SyntaxToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC538D7DC72CE8B9C7A703B81464F2B /* SyntaxToken.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DF2563DA383BC806D0769D1D7E869304 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782AB024816388DFD9776DBBAB907741 /* File.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DF94164F94832716774040482864FCC1 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614CB9CC906E39FED732700FAA033F5E /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DFA921E207C666858CAEF0F04486EAA9 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349E0C80560F37F1B2A0F5C237E0BC41 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DE41036F5CDFE75D351DEAC46ECD9FA9 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A6E92D3E9A926DD127B0315FB36E2E01 /* Nimble-dummy.m */; };
+		DF181C699D119555C5F4209404D925A7 /* SyntaxToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA9372044B55C8D12C2B322C7F9E2F0 /* SyntaxToken.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DF2563DA383BC806D0769D1D7E869304 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F625142D03D5F687E400FF784CAA614 /* File.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E13F3F7E04250EDB99AFC4A6ED66F5BC /* Pods-SourceryTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 029F37452FE9D64C803F6D01EBB90FB7 /* Pods-SourceryTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E275CFAA752D401CD15B4E1C9BE01D9E /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B864172123704FCFAF3AAE755225CB /* Document.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E2ADA90B981BFD5EE98C5F90C236EAED /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217DFEAE385C8455D78C79581176947D /* SWXMLHash.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E1C5AE23F3288A2E8A13489165FD3FF2 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 876E69BB30C15D467257B58B41BD71EA /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E275CFAA752D401CD15B4E1C9BE01D9E /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B674F3A351455A18E9706BFA80A4FB /* Document.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E2ADA90B981BFD5EE98C5F90C236EAED /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1983ECE41D1BBE9C285E96C67BFC35A5 /* SWXMLHash.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E2FA7168D5FEDBB8327A9A3C891BF1C4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25C998DE3D118A49170680221ADBF128 /* Foundation.framework */; };
-		E460F757A8B8974F06EB73A7290440F8 /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086ADD308FBE51A4B27AE84423934070 /* PBXProductType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E48FADBC7C1C7D4341CCF7202913C1BD /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB22B278F84EA92C2A8988C226D2BAE /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E4E976F3E27D9EBBC8E5ECE4FD8A5B40 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F4B0D34F8E7EFD91FEA05E46E24EE5 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E7F0C3AAA7CA52549F532D6B0A70BA77 /* Referenceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C0B31794B1ABE28DD9180F32B201AF /* Referenceable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E84AE7555CD0016EC5E94B792A9535F2 /* Node.Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864A9F7795746FBA7C4EC7E67295C25 /* Node.Mapping.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E884AD4CF605E2F136526E238CD77B3F /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92D003728236DBB5E15F5D4C99D3DFD /* XCConfigurationList.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E89794D1E7E8CE80B8B5115F840426A9 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA9896D8C8B9DDC35A782E13DC30D57 /* Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E936EB41EC8B0C18C784F1B2B90EE5DC /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CECDBEA5625AFB00639CA391579D75 /* Parser.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E9D17C4F7EA6064BB2BD29EFF0DB924D /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C3AE8D17836380139E081732390885 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EA7B771D5F1E9C88577853CD3832CEE8 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FDE06C40D085B3213AC1F10A5243C33 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EADD20F2BF555C96AD467B5BAF79061E /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B741C0360D65D26B6443AC3E52D2D8B9 /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EB6BA9DA8883C795DBEBEECEA5DE8EC7 /* PBXProjObjects+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7645CB90A27AC2B00EB1E997010F57 /* PBXProjObjects+Helpers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EB717E0A75909214F85C0E4799B262D0 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DC6228F47860320F6F4C4DF312E6BD /* Language.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		ECF2A4C9FDE5520EB7FC4CC3305D6758 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A61E20043C98596109322663E3EBCA4 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		ED741EF5D0FCA261E049C2D3A46C8CA5 /* SwiftIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7748EDF5B0EFD7D513FB06EC2A6E9403 /* SwiftIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E460F757A8B8974F06EB73A7290440F8 /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24335BB778E4E8FABAE840F11DCA3E36 /* PBXProductType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E7C1643EEC872F0846C469C27F8F472F /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBB0808CDFB1454167D96C962FE70DB /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E7F0C3AAA7CA52549F532D6B0A70BA77 /* Referenceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A96B81F5168E3DC7FF81A91600035A /* Referenceable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E84AE7555CD0016EC5E94B792A9535F2 /* Node.Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8622D4B035F740661308D2ABC1D4C93D /* Node.Mapping.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E8646D84A32462D00B8B5CFD072B0A02 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B788BB33BFDAE79378AF1CC131FFFF72 /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E884AD4CF605E2F136526E238CD77B3F /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 393A8301D8B2EB031C1A57A2B9863488 /* XCConfigurationList.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E89794D1E7E8CE80B8B5115F840426A9 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9891F4608FA0A7B2C94F702189F80B31 /* Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E936EB41EC8B0C18C784F1B2B90EE5DC /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9AB9DBA14ED1725777745F484592E8 /* Parser.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EA7B771D5F1E9C88577853CD3832CEE8 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 1239DF8D5CAAD4C8DED858BB41DDECA3 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EADD20F2BF555C96AD467B5BAF79061E /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD858DF0844E498E56EDB0CA6AE8D97 /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EB6BA9DA8883C795DBEBEECEA5DE8EC7 /* PBXProjObjects+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1806E45C83E5F467B61754884CA3B6C9 /* PBXProjObjects+Helpers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EB717E0A75909214F85C0E4799B262D0 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EF76818FDE6DE138055468EE2D10A1 /* Language.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EC47C10B81E393C9FE8C9DBCB06EFDC2 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC9F608593256F496D2B634D1A4CDBE /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		ED741EF5D0FCA261E049C2D3A46C8CA5 /* SwiftIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0EA486EBFC79426031555D128D5FD3 /* SwiftIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EDF48AF6B8C43C468E32349B4FC86622 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6ED07CC4BCA7552E8860349A48D278 /* PathKit.framework */; };
-		EEF57934ED933977A042A29D5EDC7EEC /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2B1D4CD4103BAFAE3EA9B94C73ADC0 /* PBXTarget.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EF10779B25EF0204346E4579358F6FE0 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3832F6CA61EE011754BEABC4B20198CB /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EFD14B3F5294914794B5CBFAE068CA03 /* SyntaxKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26E3C20FE91C1E2648367DA27E82849 /* SyntaxKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F05AAB84722618B22EF1D5E399465130 /* Yams-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C2A681F9653588B23F16F9E26C3F907B /* Yams-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F0869F8049E2A6671E03CC9FCD2AF2DB /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = E474360C0B9B8FCD59FD41E27AA917CA /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EEF57934ED933977A042A29D5EDC7EEC /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BD6F629FF8501670E09ACA487A7E2B /* PBXTarget.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EF4992DF97F700CFB21A392BEB0CEBEE /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2CCE82E1834F02896039E01A68C6B /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EFC885EB354CF92ED473DD39D4F9EEBE /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFCC348C33BD5CFDEF0CFD4AEE6BAAB /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EFD14B3F5294914794B5CBFAE068CA03 /* SyntaxKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 851965D057C3408B376D869449761D45 /* SyntaxKind.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EFF004EE66DC9D90A6C6B9CFE15C3818 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906ED5AAC255184C2E301FEB22CC64B7 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F05AAB84722618B22EF1D5E399465130 /* Yams-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FB50CC17F9FD94FB51E0197CAF5CEFD /* Yams-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F1153959599567CC9CE39D55C6E56D09 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BED265C9690AF35FB3BE79DBFB6A3A /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F344C82193FD91E79073EC0C0ECBE87D /* Pods-SourceryFramework-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1573E277C875F0BE7907B5EBE406D32C /* Pods-SourceryFramework-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F522B6AAFF04AB43F08FB19BB93400AF /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E65D62CD2C21A669D961D5B68FAD71 /* Resolver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F522B6AAFF04AB43F08FB19BB93400AF /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E154FC4DD574CA54F8E375466873E9D4 /* Resolver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F58F63BF8F1232608E86760B0690969C /* Pods-CodableContextTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FCDB2AFFA3FA7CE667785C7012F1545 /* Pods-CodableContextTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F599F508EF6A9D61D4D4B3025830AA53 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5EC2D95A0468568F3D7EAA4EDE5D78 /* Loader.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F6B4295B0B90C2F50FA831F901A256B1 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5942E5427D88E187E66C1321C28773B8 /* KeyPath.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F6E3D19EC741BCCADB7337939E912D10 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B0A7421D12D76EF050348023C7D813 /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F7CE4B877915D10D87476BE7126CA018 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD233B046D1101ED9AC6F11964527700 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F7D9EA3149CC299C7F991E943F4C5969 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0C16B33DB1779E2885DD4CA756190B /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F599F508EF6A9D61D4D4B3025830AA53 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C151C096DF67A7ABF7D345102DD85489 /* Loader.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F5A05CFF71F2DC71BDEA235944F7B411 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B460BD9352B7E2010C46966FEE51F0 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F66C001C8423A79AFEC1AF3E6FD2B672 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A37DC2B51B6C077488D9F0AAFE54F4 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F6B4295B0B90C2F50FA831F901A256B1 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D093D987A5069F8351B900597275D09 /* KeyPath.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F84807E5AD7E0684286841750B0706EE /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		F85EEBAFF5D86D2084153B870C863929 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD06D865DFBCD695CF7BD134BFADD0B5 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F913D4920C2D7E37228969E59C2A9C0A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		F9416FA2F113EE4F46E655DA3B677EE3 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11932858CEB464498EF075B40D36564B /* Tokenizer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FA86098F72E26C0219DC9F83B315CBC3 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A797EA0A1A0CDE6F427B699A18241A /* PBXAggregateTarget.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FAD63D0FD7A7517216AE70002789919E /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E7458F33BE6B49E441EB99D1E66E41 /* Filters.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FAEA1AFF7A6E91B77E80236315BEACB2 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B01949076F1547B435472A14561555 /* Mark.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FAF1829CEB9F23B0A4947DD45218D53A /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E06747E57A600C09E53C52398349DAE /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FCEAC6DBAE6C34ED38C4FE8459498DCD /* Clang_C.h in Headers */ = {isa = PBXBuildFile; fileRef = BEA40B1D07DB53A8726B6086A76B3318 /* Clang_C.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FEEB847348F42E16569D138FE073364B /* String+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF460E890AA0D2EEB88FFA4F49A684E /* String+SourceKitten.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FF0AF8CB78A281A62CBFA7B696995C8D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */; };
-		FFBB2F575453EA3FE18C158EE13FE371 /* Yams.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3FA0A338C0953A617B33994C148CE6 /* Yams.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F9416FA2F113EE4F46E655DA3B677EE3 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ABD7F41EBC38F328BDAFA65B420D47 /* Tokenizer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FA86098F72E26C0219DC9F83B315CBC3 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F6D32F8C58ADC0F5CD438C94827E31 /* PBXAggregateTarget.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FAD63D0FD7A7517216AE70002789919E /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF904A7F46503A348ADDD6FE2677A895 /* Filters.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FAEA1AFF7A6E91B77E80236315BEACB2 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E38A67B9F3C203F7CB3447549D949C8 /* Mark.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FCEAC6DBAE6C34ED38C4FE8459498DCD /* Clang_C.h in Headers */ = {isa = PBXBuildFile; fileRef = 99EACE4455929BB6FA78B93E672D6317 /* Clang_C.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FEEB847348F42E16569D138FE073364B /* String+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43F84DD01888A6303A8C3C2056209A9 /* String+SourceKitten.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FFBB2F575453EA3FE18C158EE13FE371 /* Yams.h in Headers */ = {isa = PBXBuildFile; fileRef = 3138AEB665E9549ED3FE04A9409C59D1 /* Yams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FFE81D8E9A533A9000B4A6E6E424D6EF /* Stencil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84DF5AC545C2C0A6FAD0CA8155284808 /* Stencil.framework */; };
 /* End PBXBuildFile section */
 
@@ -457,7 +458,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D4352C8CA6EDC802E8D85D2E61BC6173;
+			remoteGlobalIDString = F554EA343D656E7FB0C1ACC045EB2666;
 			remoteInfo = Nimble;
 		};
 		7584D8CCBB7B77C9B14019D8B9BE883D /* PBXContainerItemProxy */ = {
@@ -492,7 +493,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D4352C8CA6EDC802E8D85D2E61BC6173;
+			remoteGlobalIDString = F554EA343D656E7FB0C1ACC045EB2666;
 			remoteInfo = Nimble;
 		};
 		CAF1D885F5DD9ED8EFA6B1D399543EE0 /* PBXContainerItemProxy */ = {
@@ -527,7 +528,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D4352C8CA6EDC802E8D85D2E61BC6173;
+			remoteGlobalIDString = F554EA343D656E7FB0C1ACC045EB2666;
 			remoteInfo = Nimble;
 		};
 		EE475BD38D2AE50C0BCA7BAA45F9111D /* PBXContainerItemProxy */ = {
@@ -589,451 +590,452 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		002E04E0B6468B698ABF80D96DB0EB60 /* PBXObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXObject.swift; path = Sources/xcproj/PBXObject.swift; sourceTree = "<group>"; };
-		00A24E557109A736FAE3D8E3386937BB /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
-		0103E4F62C4C612B4D03514043CDAC1E /* Platform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Platform.h; path = Source/Clang_C/include/Platform.h; sourceTree = "<group>"; };
+		00134483696AC1CDE67EFA7F2F84EC5F /* ArgumentDescription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArgumentDescription.swift; path = Sources/Commander/ArgumentDescription.swift; sourceTree = "<group>"; };
+		007B06C2452F605FD1357159F8638EC9 /* PBXNativeTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXNativeTarget.swift; path = Sources/xcproj/PBXNativeTarget.swift; sourceTree = "<group>"; };
+		0088E7AC0A863675177030D8A555B855 /* XCSharedData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCSharedData.swift; path = Sources/xcproj/XCSharedData.swift; sourceTree = "<group>"; };
 		0214CB88274E665C18F62AF60B0EA609 /* Pods-TemplatesTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TemplatesTests-Info.plist"; sourceTree = "<group>"; };
 		029F37452FE9D64C803F6D01EBB90FB7 /* Pods-SourceryTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourceryTests-umbrella.h"; sourceTree = "<group>"; };
 		0350E24C1E149F160DEBCEC7E2B3A362 /* Pods-CodableContextTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-CodableContextTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		03595947B6D6A4F4DCF7F346CB83F378 /* Pods-TemplatesTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TemplatesTests-dummy.m"; sourceTree = "<group>"; };
-		039B28B0AD3B8FEEDAA82F74C6E6E434 /* XCWorkspaceDataGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataGroup.swift; path = Sources/xcproj/XCWorkspaceDataGroup.swift; sourceTree = "<group>"; };
-		048D5F5BEEB35FD533102D34FB65E476 /* Stencil-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Stencil-dummy.m"; sourceTree = "<group>"; };
-		049EDB5FB01A5CD8A0BE7A93A46B91AD /* Include.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Include.swift; path = Sources/Include.swift; sourceTree = "<group>"; };
-		051EB1331381FD568472DB8DC67F3BEF /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
-		0631987778343A27B02CBEA909528F3F /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
+		0430F1956BC5D453B60A6DC6476C3445 /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
+		04DEBB1340ABF4AF30057BC605D9C931 /* SyntaxMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyntaxMap.swift; path = Source/SourceKittenFramework/SyntaxMap.swift; sourceTree = "<group>"; };
+		05D0636E24B7E22B7A8B37E7A848E0E8 /* SwiftDeclarationKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftDeclarationKind.swift; path = Source/SourceKittenFramework/SwiftDeclarationKind.swift; sourceTree = "<group>"; };
+		05F79EC5DB98C61ECC761E8DBD3B7F22 /* Yams-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Yams-prefix.pch"; sourceTree = "<group>"; };
+		0696E69C82BB1CD491EBCF282E81B846 /* Documentation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Documentation.h; path = Source/Clang_C/include/Documentation.h; sourceTree = "<group>"; };
+		06F514801346F8E0DB83F7C06222C4EA /* Element.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Element.swift; path = Sources/AEXML/Element.swift; sourceTree = "<group>"; };
 		06FFD82A9F6A8F2146299B38B084EEA1 /* Pods_SourcerySwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourcerySwift.framework; path = "Pods-SourcerySwift.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		086ADD308FBE51A4B27AE84423934070 /* PBXProductType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProductType.swift; path = Sources/xcproj/PBXProductType.swift; sourceTree = "<group>"; };
-		0A2CE84D54458AB23908FA1CAFEE70AF /* SyntaxMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyntaxMap.swift; path = Source/SourceKittenFramework/SyntaxMap.swift; sourceTree = "<group>"; };
-		0BCA4105AC7D57E92315742675842F15 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
-		0D6C6177DBAC24C74A589CAE871EC376 /* Parameter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parameter.swift; path = Source/SourceKittenFramework/Parameter.swift; sourceTree = "<group>"; };
-		0E035CAE40FE5642B42CD21C080BD86B /* Emitter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Emitter.swift; path = Sources/Yams/Emitter.swift; sourceTree = "<group>"; };
-		0E19AF940019148F45F7D8F7B53C373D /* Context.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Context.swift; path = Sources/Context.swift; sourceTree = "<group>"; };
+		072760713591AC981C004DC576FE1D09 /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
+		07AA80A72F470DD549A4C193F55B825B /* PBXVariantGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXVariantGroup.swift; path = Sources/xcproj/PBXVariantGroup.swift; sourceTree = "<group>"; };
+		08E4F00F202414474386E1B939A0309A /* XCWorkspaceDataElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataElement.swift; path = Sources/xcproj/XCWorkspaceDataElement.swift; sourceTree = "<group>"; };
+		0BE0DF62AC40ADD7624A0368F23C18B1 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
 		0E60EC0AAD2C47DC2435552165EBBA20 /* Pods-SourceryJS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SourceryJS-acknowledgements.markdown"; sourceTree = "<group>"; };
-		0EC538D7DC72CE8B9C7A703B81464F2B /* SyntaxToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyntaxToken.swift; path = Source/SourceKittenFramework/SyntaxToken.swift; sourceTree = "<group>"; };
-		0EEF742C448CFA02719FF525409C7764 /* Filters+Strings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Filters+Strings.swift"; path = "Sources/StencilSwiftKit/Filters+Strings.swift"; sourceTree = "<group>"; };
-		0F0C4697704B1853B1E47DB94A1BBB89 /* PBXReferenceProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXReferenceProxy.swift; path = Sources/xcproj/PBXReferenceProxy.swift; sourceTree = "<group>"; };
-		103533744DE5007DA2D31E812DCC64AF /* XCBreakpointList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCBreakpointList.swift; path = Sources/xcproj/XCBreakpointList.swift; sourceTree = "<group>"; };
-		1055BC4F1F58345A01804B36DF4D7FC4 /* library_wrapper_CXString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_CXString.swift; path = Source/SourceKittenFramework/library_wrapper_CXString.swift; sourceTree = "<group>"; };
-		10CEA2F11A704911B4DF5C348861887F /* AEXML.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AEXML.xcconfig; sourceTree = "<group>"; };
-		11932858CEB464498EF075B40D36564B /* Tokenizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Tokenizer.swift; path = Sources/Tokenizer.swift; sourceTree = "<group>"; };
+		0F2B872B0B8A7E30B0030F220EA8F46F /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
+		106390DFAAF8781C28401D3809A1EF64 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
+		10787C2541B7AFBA94FDA14B1D13740C /* scanner.c */ = {isa = PBXFileReference; includeInIndex = 1; name = scanner.c; path = Sources/CYaml/src/scanner.c; sourceTree = "<group>"; };
+		107F0C0381FF2D0AB3A27CCA54726050 /* PBXCopyFilesBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXCopyFilesBuildPhase.swift; path = Sources/xcproj/PBXCopyFilesBuildPhase.swift; sourceTree = "<group>"; };
+		10D5DF88B8C1A49FA7B107427B7CED9C /* Xcode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Xcode.swift; path = Source/SourceKittenFramework/Xcode.swift; sourceTree = "<group>"; };
+		11ABD7F41EBC38F328BDAFA65B420D47 /* Tokenizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Tokenizer.swift; path = Sources/Tokenizer.swift; sourceTree = "<group>"; };
 		11E4BB30FA37135B2E392C398E4F4575 /* Pods-CodableContextTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CodableContextTests-frameworks.sh"; sourceTree = "<group>"; };
-		121825A360455D76E9D30380D46078C4 /* Filters+Numbers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Filters+Numbers.swift"; path = "Sources/StencilSwiftKit/Filters+Numbers.swift"; sourceTree = "<group>"; };
-		13079FF13CE7BD8D8102F9B516FF7CD7 /* XCScheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCScheme.swift; path = Sources/xcproj/XCScheme.swift; sourceTree = "<group>"; };
-		13D49F4649317E86B0BF5806DFA59773 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		12005A3CC3291799984C711CE28C3169 /* SwiftDocKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftDocKey.swift; path = Source/SourceKittenFramework/SwiftDocKey.swift; sourceTree = "<group>"; };
+		1239DF8D5CAAD4C8DED858BB41DDECA3 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
+		12F46044D788C3589179FCD80081946E /* yaml_private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yaml_private.h; path = Sources/CYaml/src/yaml_private.h; sourceTree = "<group>"; };
+		136F67492999DFCAB1C063183E2574C8 /* AEXML-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AEXML-umbrella.h"; sourceTree = "<group>"; };
+		137C2B26F2D821B29C8BEF8F6F0AA9B4 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Source/SourceKittenFramework/SourceLocation.swift; sourceTree = "<group>"; };
+		13E87ED98D88F15CD9B87A7E4854AA2F /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
 		145176E1E87474A247B803F419110293 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		146A7254A290B5DD0EF8E1CBADB69FA4 /* xcproj.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = xcproj.framework; path = xcproj.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		15127D3B993D223E4402D112A406DAB9 /* Parameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parameters.swift; path = Sources/StencilSwiftKit/Parameters.swift; sourceTree = "<group>"; };
+		14C97C49B08170813210BDA75D9CFBFD /* Version.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Version.swift; path = Source/SourceKittenFramework/Version.swift; sourceTree = "<group>"; };
 		1573E277C875F0BE7907B5EBE406D32C /* Pods-SourceryFramework-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourceryFramework-umbrella.h"; sourceTree = "<group>"; };
-		166A93D1F2356F47D1B4541A8D2F2E4C /* JSONOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONOutput.swift; path = Source/SourceKittenFramework/JSONOutput.swift; sourceTree = "<group>"; };
-		16B1542BF2F7A7DA7EF5AFE5493BAFDF /* ArgumentDescription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArgumentDescription.swift; path = Sources/Commander/ArgumentDescription.swift; sourceTree = "<group>"; };
-		16CF383036BF7BD1336D99F3DC75E11A /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
-		16F4838709CEDAF1E0EAB7694FE6B885 /* StencilSwiftKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = StencilSwiftKit.modulemap; sourceTree = "<group>"; };
-		1877A03BCF290C780ECD69377D38E651 /* PlistValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlistValue.swift; path = Sources/xcproj/PlistValue.swift; sourceTree = "<group>"; };
+		15D760C84B7E14997427B57A70E60FEB /* Environment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Environment.swift; path = Sources/Environment.swift; sourceTree = "<group>"; };
+		177D9E3CA9F3EA76C7FE0DB16389C6FB /* Tag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Tag.swift; path = Sources/Yams/Tag.swift; sourceTree = "<group>"; };
+		1806E45C83E5F467B61754884CA3B6C9 /* PBXProjObjects+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PBXProjObjects+Helpers.swift"; path = "Sources/xcproj/PBXProjObjects+Helpers.swift"; sourceTree = "<group>"; };
+		18C572DA952DEE0E505E17354B16ED43 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
 		18E57C92D8755434DBF78AC2FC1D8BB5 /* Pods-Sourcery-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Sourcery-dummy.m"; sourceTree = "<group>"; };
-		1966DF340DFC3C39CBACF2830E2F0150 /* PBXFileElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXFileElement.swift; path = Sources/xcproj/PBXFileElement.swift; sourceTree = "<group>"; };
+		1983ECE41D1BBE9C285E96C67BFC35A5 /* SWXMLHash.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SWXMLHash.swift; path = Source/SWXMLHash.swift; sourceTree = "<group>"; };
 		19E4195784A6309491416D61BA6E25B5 /* Pods-SourceryTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryTests.debug.xcconfig"; sourceTree = "<group>"; };
-		1A361C9DFD03C42D3C2B14CFF0E37E44 /* xcproj-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "xcproj-dummy.m"; sourceTree = "<group>"; };
-		1B0C16B33DB1779E2885DD4CA756190B /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
-		1B5EE1FB9C62B41AA2C101167340B4B6 /* Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.swift; path = Sources/Node.swift; sourceTree = "<group>"; };
-		1C3FA0A338C0953A617B33994C148CE6 /* Yams.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Yams.h; path = Sources/Yams/Yams.h; sourceTree = "<group>"; };
-		1D64E4A688C9E2298D43DC0FD051F411 /* Commander-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Commander-Info.plist"; sourceTree = "<group>"; };
-		1D8549DCEEA3EB5F3E62810186AC48ED /* SWXMLHash+TypeConversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SWXMLHash+TypeConversion.swift"; path = "Source/SWXMLHash+TypeConversion.swift"; sourceTree = "<group>"; };
-		1E5EC2D95A0468568F3D7EAA4EDE5D78 /* Loader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Loader.swift; path = Sources/Loader.swift; sourceTree = "<group>"; };
-		1E939CF1BC6C22024EDF6DE626596C44 /* Template.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Template.swift; path = Sources/Template.swift; sourceTree = "<group>"; };
-		1E9E2DB7A5042619D513D7DC103CF2FF /* PathKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PathKit-umbrella.h"; sourceTree = "<group>"; };
-		1EA81100C5C01A43937190C2615F121F /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
+		19F0FEE218FB7A3E78C8E514B4D75900 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
+		1A3C8037776850A97A97A642B8C0DB80 /* PBXLegacyTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXLegacyTarget.swift; path = Sources/xcproj/PBXLegacyTarget.swift; sourceTree = "<group>"; };
+		1B192618E0DAFA0F11087A97ECD1F5B6 /* StencilSwiftKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = StencilSwiftKit.modulemap; sourceTree = "<group>"; };
+		1BB19424349984E1DD28537762814BAE /* PBXProj+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PBXProj+Helpers.swift"; path = "Sources/xcproj/PBXProj+Helpers.swift"; sourceTree = "<group>"; };
+		1C4338CD47D14F6D47BDE7FE08DB5C53 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
+		1C5EEFAD2574DC009FF7DC65A90F3F1A /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
+		1C7E0172FBA325347D373E18B52EB1CE /* Constructor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constructor.swift; path = Sources/Yams/Constructor.swift; sourceTree = "<group>"; };
+		1C853BDABAA1D07FA565A179F97970FD /* MapNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapNode.swift; path = Sources/StencilSwiftKit/MapNode.swift; sourceTree = "<group>"; };
+		1D0004644435F94BB20CA0B57DB34D76 /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
+		1D12D4009D505025D09CB822ECF53B04 /* XCConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCConfig.swift; path = Sources/xcproj/XCConfig.swift; sourceTree = "<group>"; };
+		1D6374ABF00E854BE449B574663DBA42 /* PathKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PathKit.xcconfig; sourceTree = "<group>"; };
+		1DCDDD5CD23B1383A2607C12F5933F62 /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
+		1E38A67B9F3C203F7CB3447549D949C8 /* Mark.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Mark.swift; path = Sources/Yams/Mark.swift; sourceTree = "<group>"; };
+		1E9FEFA07FC5D171461675B2F26F250A /* PathKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PathKit-umbrella.h"; sourceTree = "<group>"; };
 		1F32EE3342CFB9DED0682D0CAB542813 /* Pods-SourceryJS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryJS-Info.plist"; sourceTree = "<group>"; };
-		1F5C198567D5DB0873403F58ED415A33 /* PBXProject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProject.swift; path = Sources/xcproj/PBXProject.swift; sourceTree = "<group>"; };
-		1FE1188F1B061BB0BD4350E0F7AD88B5 /* AEXML-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AEXML-umbrella.h"; sourceTree = "<group>"; };
-		215F87888AB476DEA27760112E4476BA /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
-		217DFEAE385C8455D78C79581176947D /* SWXMLHash.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SWXMLHash.swift; path = Source/SWXMLHash.swift; sourceTree = "<group>"; };
-		21F2791B89C94B8A2D27E9EB37864733 /* FilterTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FilterTag.swift; path = Sources/FilterTag.swift; sourceTree = "<group>"; };
-		224D3B9C5F1D50A3565FFCDA32C3006A /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
-		231EA63ACC19C9C449BB6963C75F5AE4 /* Inheritence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Inheritence.swift; path = Sources/Inheritence.swift; sourceTree = "<group>"; };
-		2427229E4492A722B7247F958D5EF4B2 /* CommandRunner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandRunner.swift; path = Sources/Commander/CommandRunner.swift; sourceTree = "<group>"; };
-		2595AEAC3BCC5B1F193B53860D9DE182 /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
+		1F3E398D6F221DC29D748F3E0E117164 /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
+		2074B4C4A9D0036B09E35779F49AF48F /* xcproj-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "xcproj-prefix.pch"; sourceTree = "<group>"; };
+		2083552968181B40CB1DB43EC510B54E /* Stencil.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Stencil.modulemap; sourceTree = "<group>"; };
+		208F2AC1B3EEC8E298972FC244A869D4 /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "KeyedDecodingContainer+Additions.swift"; path = "Sources/xcproj/KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
+		20DAB2299B625C88F883A97FB72237DF /* Context.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Context.swift; path = Sources/StencilSwiftKit/Context.swift; sourceTree = "<group>"; };
+		21B674F3A351455A18E9706BFA80A4FB /* Document.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Document.swift; path = Sources/AEXML/Document.swift; sourceTree = "<group>"; };
+		225E0FAAF998C5CE3841B4566C428E02 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
+		2312777891D060B3CE48B394196A6156 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
+		239D0A65FC9B182DCEE20B0737E8466E /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
+		24335BB778E4E8FABAE840F11DCA3E36 /* PBXProductType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProductType.swift; path = Sources/xcproj/PBXProductType.swift; sourceTree = "<group>"; };
 		25C998DE3D118A49170680221ADBF128 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		2685D455EE0F19312102BC2798AD1909 /* SWXMLHash-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SWXMLHash-prefix.pch"; sourceTree = "<group>"; };
-		2691BD03039318ABF565B350BCF7FDAB /* Xcode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Xcode.swift; path = Source/SourceKittenFramework/Xcode.swift; sourceTree = "<group>"; };
-		26D92EEE91BAC1523C1482EA09C63021 /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
-		2812327BBDB24640DF1C3A4AF3AFBE3B /* Decoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Decoder.swift; path = Sources/Yams/Decoder.swift; sourceTree = "<group>"; };
-		28D2A11AA14EC190F3B24856BCB57D2A /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
-		29F4B0D34F8E7EFD91FEA05E46E24EE5 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
-		2A01C37F8242E71819A97E11B6F0294E /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
+		269CD577304C27A75B14AF9D3478FF99 /* reader.c */ = {isa = PBXFileReference; includeInIndex = 1; name = reader.c; path = Sources/CYaml/src/reader.c; sourceTree = "<group>"; };
+		26E1B3CD7904BE5C5911926F0E5181ED /* CYaml.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CYaml.h; path = Sources/CYaml/include/CYaml.h; sourceTree = "<group>"; };
+		2865EDFA8AF22FF4356704BB42B65AB9 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
+		2867E36381ECD8DC94C8E693004E23CF /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
+		2963C7EAD4BEEE074A8826E739F5FFA9 /* AEXML.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AEXML.modulemap; sourceTree = "<group>"; };
+		2980E467EF143EFF9BD13B0C9162417E /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		2983D1149015A22169081FF1DCCD005E /* ObjectReference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjectReference.swift; path = Sources/xcproj/ObjectReference.swift; sourceTree = "<group>"; };
+		2A21BB8DF46FA32B549339B5353AD265 /* Lexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Lexer.swift; path = Sources/Lexer.swift; sourceTree = "<group>"; };
 		2A82F33BD74B26F82C16EF3D42A7C32E /* Yams.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Yams.framework; path = Yams.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2B4B5233E9B7923DFD3424CE70510B65 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
 		2BABB0B365E5BDF6E7DD4DBC5AFF23CF /* Pods-TemplatesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TemplatesTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2BE139E45B399B01C03FFD70E66A97BE /* Pods-TemplatesTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TemplatesTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		2CA285345A5B858D1BA50A4C747EF933 /* Group.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Group.swift; path = Sources/Commander/Group.swift; sourceTree = "<group>"; };
-		2D46AC0283D38F2BDEA972AD1E845119 /* Representer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Representer.swift; path = Sources/Yams/Representer.swift; sourceTree = "<group>"; };
+		2BFC915222FDE94F799EE89F9EDACF74 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		2C112658D3B3F622CE76A34F5A224F8C /* Clang+SourceKitten.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Clang+SourceKitten.swift"; path = "Source/SourceKittenFramework/Clang+SourceKitten.swift"; sourceTree = "<group>"; };
+		2C2EFC5FEBB2CB2A0251DC0AF71473F1 /* emitter.c */ = {isa = PBXFileReference; includeInIndex = 1; name = emitter.c; path = Sources/CYaml/src/emitter.c; sourceTree = "<group>"; };
+		2C56F5C0F6431C173581048848D671BC /* StatementKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatementKind.swift; path = Source/SourceKittenFramework/StatementKind.swift; sourceTree = "<group>"; };
+		2C9CAC44A9FA5EE5D17A5FC973EE32C4 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
+		2CA9372044B55C8D12C2B322C7F9E2F0 /* SyntaxToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyntaxToken.swift; path = Source/SourceKittenFramework/SyntaxToken.swift; sourceTree = "<group>"; };
 		2E9FF9267FAE9B8C8F6B7A7B26598111 /* Pods-CodableContextTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-CodableContextTests-dummy.m"; sourceTree = "<group>"; };
-		2F2EE40DC06775538A74A9613C2DB9AA /* PBXVariantGroup+Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PBXVariantGroup+Deprecations.swift"; path = "Sources/xcproj/PBXVariantGroup+Deprecations.swift"; sourceTree = "<group>"; };
-		2F86057931001BAA8C7B11842AB87620 /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
-		2F9C560172035696B66B86D4D0D8C27B /* XCSharedData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCSharedData.swift; path = Sources/xcproj/XCSharedData.swift; sourceTree = "<group>"; };
+		2F625142D03D5F687E400FF784CAA614 /* File.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = File.swift; path = Source/SourceKittenFramework/File.swift; sourceTree = "<group>"; };
 		2FCDB2AFFA3FA7CE667785C7012F1545 /* Pods-CodableContextTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-CodableContextTests-umbrella.h"; sourceTree = "<group>"; };
 		2FDFF918F9B53615587C0F684FC14576 /* Pods-SourceryTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryTests-Info.plist"; sourceTree = "<group>"; };
 		30472E904B107E313CAE52358D0C9520 /* Pods-CodableContextTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CodableContextTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		313D84E0A5BC3FB5EAD5BCCA503F8AF8 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
-		319EDECE568D42A1979073BAED5E28D0 /* XCWorkspaceData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceData.swift; path = Sources/xcproj/XCWorkspaceData.swift; sourceTree = "<group>"; };
-		32234EFEF3A56F70B97A7AB03DEDA9B9 /* PBXHeadersBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXHeadersBuildPhase.swift; path = Sources/xcproj/PBXHeadersBuildPhase.swift; sourceTree = "<group>"; };
-		33072464A22946EF064FCF85100D1935 /* SourceKittenFramework-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SourceKittenFramework-dummy.m"; sourceTree = "<group>"; };
-		330EBD708AE6DF6853E09121B6C3CB60 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
+		3138AEB665E9549ED3FE04A9409C59D1 /* Yams.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Yams.h; path = Sources/Yams/Yams.h; sourceTree = "<group>"; };
+		31BC4029B5BF718BCC013880C3B7D0B8 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
+		331C005BADA747082B9CCD06BFEF2F83 /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
+		3324DCFC9DAAE9217CF425C3FD56CEE3 /* library_wrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper.swift; path = Source/SourceKittenFramework/library_wrapper.swift; sourceTree = "<group>"; };
+		33EF76818FDE6DE138055468EE2D10A1 /* Language.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Language.swift; path = Source/SourceKittenFramework/Language.swift; sourceTree = "<group>"; };
 		33F53E54B95B73557E1FAFF34D5ECB4E /* Pods-SourceryUtils.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryUtils.release.xcconfig"; sourceTree = "<group>"; };
-		349E0C80560F37F1B2A0F5C237E0BC41 /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
-		34B22DDBD2F986098454F0B048603572 /* Bool+Extras.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bool+Extras.swift"; path = "Sources/xcproj/Bool+Extras.swift"; sourceTree = "<group>"; };
-		34E3D33954C5BC9890F78A2B4B79D942 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
+		3490F6FEED4B46F4C2AB6EEABA592E37 /* Commander-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Commander-Info.plist"; sourceTree = "<group>"; };
+		34A74ACAB20DD9A3B8AB87F3EB6C970B /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Expression.swift; sourceTree = "<group>"; };
+		34ADBAE1E7BBCAC890E09CA156D70357 /* Quick-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Quick-Info.plist"; sourceTree = "<group>"; };
+		34C0BFAC05B9A7242C4FAC4FC03EDFBB /* PBXHeadersBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXHeadersBuildPhase.swift; path = Sources/xcproj/PBXHeadersBuildPhase.swift; sourceTree = "<group>"; };
 		359E46F10C0853E5B4BD8BC7E4E202F3 /* Pods-SourceryFramework.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryFramework.debug.xcconfig"; sourceTree = "<group>"; };
-		35ECBC25D0413090C8137AD74907DCBC /* Yams-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Yams-dummy.m"; sourceTree = "<group>"; };
-		372D038E60EEF4F3260D111C1FA93221 /* ArgumentConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArgumentConvertible.swift; path = Sources/Commander/ArgumentConvertible.swift; sourceTree = "<group>"; };
-		3762261094607EBF716EE3E89399F2E2 /* CXErrorCode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CXErrorCode.h; path = Source/Clang_C/include/CXErrorCode.h; sourceTree = "<group>"; };
-		37F7BBC72F0154D4CE641A89094DE603 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
-		3832F6CA61EE011754BEABC4B20198CB /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
-		3845CCC21459E679A858FBF5D7EC1501 /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
-		38E4C1BF4701C64A6658F1B7262F932A /* SourceKittenFramework-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "SourceKittenFramework-Info.plist"; sourceTree = "<group>"; };
-		3B606BC63FB1111DFEE6181CA112C8BE /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
-		3C720671DFE8CD58130BBD84CD649334 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
+		35A35880D1DD3BDB561569AF13E64B9A /* Filters+Numbers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Filters+Numbers.swift"; path = "Sources/StencilSwiftKit/Filters+Numbers.swift"; sourceTree = "<group>"; };
+		36B2A1C4BD8288C33F2110140B638F39 /* Representer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Representer.swift; path = Sources/Yams/Representer.swift; sourceTree = "<group>"; };
+		371BE6C7228D3E554420678816CDA4E7 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Request.swift; path = Source/SourceKittenFramework/Request.swift; sourceTree = "<group>"; };
+		38BD862A4D423A3A857F29E53891EFF6 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
+		393A8301D8B2EB031C1A57A2B9863488 /* XCConfigurationList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCConfigurationList.swift; path = Sources/xcproj/XCConfigurationList.swift; sourceTree = "<group>"; };
+		39439BF6BD56E03232A70EC58067AE6E /* PBXFrameworksBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXFrameworksBuildPhase.swift; path = Sources/xcproj/PBXFrameworksBuildPhase.swift; sourceTree = "<group>"; };
+		3959265D13A13963BBA7A3AF015B6DB7 /* XCWorkspaceDataElementLocationType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataElementLocationType.swift; path = Sources/xcproj/XCWorkspaceDataElementLocationType.swift; sourceTree = "<group>"; };
+		39641AC72362CE48B2C7100C3548E365 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
+		399DBC4458FA35BA737E37460B40A91E /* StencilSwiftKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = StencilSwiftKit.xcconfig; sourceTree = "<group>"; };
+		3A792739B3AF780C10529B0333413DFF /* PBXProject+Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PBXProject+Deprecations.swift"; path = "Sources/xcproj/PBXProject+Deprecations.swift"; sourceTree = "<group>"; };
+		3AB7ECE4B31F3818DCF9F372B651EF7D /* SourceKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SourceKit.h; path = Source/SourceKit/include/SourceKit.h; sourceTree = "<group>"; };
+		3C8339F41335DEEBCCCAD28A8FDA440E /* Commands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Commands.swift; path = Sources/Commander/Commands.swift; sourceTree = "<group>"; };
+		3D20F25FD6B17C7D7EBC7E99DBD45D88 /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
+		3D5E2B63AE98B21AFAD74258C2620F36 /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
+		3D8B424315307D4BF57359C5BD8409E1 /* CXCompilationDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CXCompilationDatabase.h; path = Source/Clang_C/include/CXCompilationDatabase.h; sourceTree = "<group>"; };
 		3DA537602DB30DAFF92104C21702B8B3 /* Pods-SourcerySwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SourcerySwift-dummy.m"; sourceTree = "<group>"; };
-		3DE6D72119440C7F729857E02A35F2EF /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
-		3ED55F1819BE802F721A4215C3B5A755 /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
-		3EFC7BC26C574A7C25CDFC86A281AD39 /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
-		402F261F96EF3BFAD7E7718CAE1B5AB0 /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
+		3DD63A54B176B6B2034FB4AAC38FF5E1 /* PBXVariantGroup+Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PBXVariantGroup+Deprecations.swift"; path = "Sources/xcproj/PBXVariantGroup+Deprecations.swift"; sourceTree = "<group>"; };
+		3E16C746C798A5EB431E7FCE153C73E1 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/AEXML/Parser.swift; sourceTree = "<group>"; };
+		3E2BE1B627A2E002EBE37BC5C0FA9C20 /* Parameter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parameter.swift; path = Source/SourceKittenFramework/Parameter.swift; sourceTree = "<group>"; };
+		3F2A6F1273D752515857E3C2AFDA0C0F /* StencilSwiftKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "StencilSwiftKit-Info.plist"; sourceTree = "<group>"; };
+		3FA6802EBAB5F9B43D0FCDBF0D85C122 /* ElementsEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementsEqual.swift; path = Sources/Nimble/Matchers/ElementsEqual.swift; sourceTree = "<group>"; };
+		3FB50CC17F9FD94FB51E0197CAF5CEFD /* Yams-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Yams-umbrella.h"; sourceTree = "<group>"; };
 		4047D221191414162B1F9F39B84F988D /* Pods-SourceryFramework.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryFramework.release.xcconfig"; sourceTree = "<group>"; };
-		40DE6AF01D4B78ED69E7DB1865D32A4C /* Stencil.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Stencil.xcconfig; sourceTree = "<group>"; };
+		405EF9A0D4830C181F450993D574880A /* XCBreakpointList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCBreakpointList.swift; path = Sources/xcproj/XCBreakpointList.swift; sourceTree = "<group>"; };
+		40E63A7EFE884499B9EB364D83DF59D9 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
 		40F6AEA6F2463D0584AC6D61489A0A69 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		42490B13736FF3B5BF55BCB60C9411FC /* library_wrapper_sourcekitd.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_sourcekitd.swift; path = Source/SourceKittenFramework/library_wrapper_sourcekitd.swift; sourceTree = "<group>"; };
-		434F9B69163B9B12F31B1869E76E8015 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
-		44697B5A6E94CE42393A5A5267BB5128 /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
-		458589868B4454B760A68D39CBC6922A /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
-		469A589CA2F94AE60393A5DB21FFA5F0 /* PBXGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXGroup.swift; path = Sources/xcproj/PBXGroup.swift; sourceTree = "<group>"; };
+		410CAE8B34014F1E379F7C87CEB95E92 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
+		419F20D5F7FA9CC8D26C251258CF3B1B /* Dictionary+Merge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Merge.swift"; path = "Source/SourceKittenFramework/Dictionary+Merge.swift"; sourceTree = "<group>"; };
+		428CEBBC652516B043D1FED31EF1B276 /* Stencil-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Stencil-dummy.m"; sourceTree = "<group>"; };
+		4521BE920C2B762DF0422FAD2A2D254C /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
 		46B3985C5E48FD997EFD090A7DD0AD62 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		46CECDBEA5625AFB00639CA391579D75 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/Yams/Parser.swift; sourceTree = "<group>"; };
-		471016ABCCA3820B513E285BCB3C1BF9 /* Variable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Variable.swift; path = Sources/Variable.swift; sourceTree = "<group>"; };
-		47C1E0158700AFAA9E7BEF3DE84D6EE0 /* api.c */ = {isa = PBXFileReference; includeInIndex = 1; name = api.c; path = Sources/CYaml/src/api.c; sourceTree = "<group>"; };
-		48C4309650684E7D3FAFC1EC8FF34AA6 /* CXCompilationDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CXCompilationDatabase.h; path = Source/Clang_C/include/CXCompilationDatabase.h; sourceTree = "<group>"; };
-		49820084B215591A9C4812447F86C33E /* BuildSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = BuildSystem.h; path = Source/Clang_C/include/BuildSystem.h; sourceTree = "<group>"; };
-		49E11AAAA532F08C143C144FBC897663 /* yaml_private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yaml_private.h; path = Sources/CYaml/src/yaml_private.h; sourceTree = "<group>"; };
-		4A1DBA8FEA298575651AA7C04EC4E382 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
-		4A5A10FE91A9D3DB3AEF2CF52976BE04 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
+		475A4F094A841646447016089D2DA5BE /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
+		48917552ED6ABA0DEAFB263114A60C8A /* SwiftDeclarationAttributeKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftDeclarationAttributeKind.swift; path = Source/SourceKittenFramework/SwiftDeclarationAttributeKind.swift; sourceTree = "<group>"; };
+		492A9A9BBE8346B8633EF900EA90B6E0 /* PathKit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PathKit.swift; path = Sources/PathKit.swift; sourceTree = "<group>"; };
+		497E72084DCDC4548A9372874A9C4C0E /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
+		4A2E9D0B5B33B0ADC1D7DFC1169C0EE1 /* ArgumentParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArgumentParser.swift; path = Sources/Commander/ArgumentParser.swift; sourceTree = "<group>"; };
+		4A42E3E0B61C0DE2C5799AD4BC054AC1 /* Stencil-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Stencil-umbrella.h"; sourceTree = "<group>"; };
+		4A545F434570A63FD5E1141F57691970 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
 		4A6ED07CC4BCA7552E8860349A48D278 /* PathKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PathKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4BA29A342B906E8C87932912C4135718 /* StencilSwiftKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "StencilSwiftKit-Info.plist"; sourceTree = "<group>"; };
+		4BCC55BB7938F3643E28832C88F19CB7 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/Parser.swift; sourceTree = "<group>"; };
 		4C0736973AC6586CD0FAA2FF9801740B /* Pods-SourceryUtils.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SourceryUtils.modulemap"; sourceTree = "<group>"; };
 		4C40074F4C39A920F924ECFD322D393A /* Pods-TemplatesTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TemplatesTests-frameworks.sh"; sourceTree = "<group>"; };
-		4CC5E0B5C0AEE1F4AD6DCC77A8C6B186 /* ForTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ForTag.swift; path = Sources/ForTag.swift; sourceTree = "<group>"; };
-		4D2AFD8C82D28185EFC76414D217BD9C /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
+		4D39AF047186A4E80625CF64060E2E42 /* PBXRezBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXRezBuildPhase.swift; path = Sources/xcproj/PBXRezBuildPhase.swift; sourceTree = "<group>"; };
+		4D60E3FD3376239C064B344949C7D17F /* xcproj.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = xcproj.modulemap; sourceTree = "<group>"; };
 		4D9FEA1C52A7900B43B13BF3EFD4B449 /* Pods-Sourcery.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Sourcery.debug.xcconfig"; sourceTree = "<group>"; };
-		4E0C2F46DA8110EBCD0CA344F9692F09 /* SWXMLHash.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SWXMLHash.xcconfig; sourceTree = "<group>"; };
-		4FA9896D8C8B9DDC35A782E13DC30D57 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/Commander/Error.swift; sourceTree = "<group>"; };
-		502188CB5D01AFC592E9546FBF708413 /* Commands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Commands.swift; path = Sources/Commander/Commands.swift; sourceTree = "<group>"; };
+		4EE83E22B4E14DE7B80206A906343756 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
+		4FC9F608593256F496D2B634D1A4CDBE /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
+		4FD84D7615FBFA926D4817684600C668 /* Bool+Extras.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bool+Extras.swift"; path = "Sources/xcproj/Bool+Extras.swift"; sourceTree = "<group>"; };
+		50989DDB7F65C9CB250FCAB54809DA7D /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
+		50B460BD9352B7E2010C46966FEE51F0 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
 		50B708B4E683A6DCE230CF572F7007CA /* Pods-SourceryUtils-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryUtils-Info.plist"; sourceTree = "<group>"; };
+		50CACB53DABCAC94D559E6A3A52DAE29 /* Documentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Documentation.swift; path = Source/SourceKittenFramework/Documentation.swift; sourceTree = "<group>"; };
 		50CE10363E780F5BCAE5BB5AF3550DBE /* Pods-SourceryJS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SourceryJS.modulemap"; sourceTree = "<group>"; };
+		50CFF005F442276AFE6D3CC0EC4C9186 /* YamlError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = YamlError.swift; path = Sources/Yams/YamlError.swift; sourceTree = "<group>"; };
 		50FC754CDB586247DDC83C447D3F05B0 /* Pods-SourcerySwift-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SourcerySwift-acknowledgements.markdown"; sourceTree = "<group>"; };
-		5301904B0430880CF863DC1D754BE28B /* Node.Scalar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.Scalar.swift; path = Sources/Yams/Node.Scalar.swift; sourceTree = "<group>"; };
-		545111DA9BF2D339E984FD2D86563BA6 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/AEXML/Error.swift; sourceTree = "<group>"; };
-		56373777FB1C28FA39AAA792711F0931 /* PBXProject+Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PBXProject+Deprecations.swift"; path = "Sources/xcproj/PBXProject+Deprecations.swift"; sourceTree = "<group>"; };
-		56787D29D44834F3B2F2B0767D9093F9 /* BuildSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildSettings.swift; path = Sources/xcproj/BuildSettings.swift; sourceTree = "<group>"; };
+		51AF4CF6B6AF701FB8654322CB441314 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
+		5210F2752F3AFC73EA007A814751C0E0 /* SourceKittenFramework-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "SourceKittenFramework-Info.plist"; sourceTree = "<group>"; };
+		52E48F04BCAFFC34E806B49A56673C86 /* SourceKittenFramework-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SourceKittenFramework-prefix.pch"; sourceTree = "<group>"; };
+		538B7D357DDE54A1EA611132E162F50A /* PBXReferenceProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXReferenceProxy.swift; path = Sources/xcproj/PBXReferenceProxy.swift; sourceTree = "<group>"; };
+		53CE6DBDC1B219FF9BD3C599980C3189 /* Options.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Options.swift; path = Sources/AEXML/Options.swift; sourceTree = "<group>"; };
+		55BDF279F8BB2B1A13B06D529A9FAFB3 /* StencilSwiftKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "StencilSwiftKit-umbrella.h"; sourceTree = "<group>"; };
 		56850663058480438E9EBFC2FD14867F /* Pods-SourcerySwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourcerySwift-umbrella.h"; sourceTree = "<group>"; };
-		56F70CC5B4785850C7DADFB797FAD33E /* Index.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Index.h; path = Source/Clang_C/include/Index.h; sourceTree = "<group>"; };
-		5853CB726136CCDA26B65398F6A402BB /* Yams.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Yams.xcconfig; sourceTree = "<group>"; };
+		5728998ADA4872819707DD8319F0C5B4 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
+		588735FCF590A1586ACE1D1F75BA4BD5 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
 		58DE866F82C26C389C8D7C1336BADCBF /* Pods_CodableContextTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CodableContextTests.framework; path = "Pods-CodableContextTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		590E2D58A86A0596AFB572EC4E16ED3B /* Module.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Module.swift; path = Source/SourceKittenFramework/Module.swift; sourceTree = "<group>"; };
-		5942E5427D88E187E66C1321C28773B8 /* KeyPath.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeyPath.swift; path = Sources/KeyPath.swift; sourceTree = "<group>"; };
-		5AA41B5B8D4900AF2DEE39860A5F7A67 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
-		5B544727DAB6079C1B87855A79F2390E /* PBXRezBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXRezBuildPhase.swift; path = Sources/xcproj/PBXRezBuildPhase.swift; sourceTree = "<group>"; };
-		5BAE2596144518B71925CF66DE01102B /* BuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildPhase.swift; path = Sources/xcproj/BuildPhase.swift; sourceTree = "<group>"; };
-		5C15CCBFB5DF55D7C24C4E8C11C7C312 /* SwiftDocs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftDocs.swift; path = Source/SourceKittenFramework/SwiftDocs.swift; sourceTree = "<group>"; };
+		59A6888E3FD8334345910158E5C23EEC /* String+Extras.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extras.swift"; path = "Sources/xcproj/String+Extras.swift"; sourceTree = "<group>"; };
+		59B71BCD94A4F7837FAF3FC5ED502484 /* AEXML-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AEXML-Info.plist"; sourceTree = "<group>"; };
+		59D05F4B45D5A8CB4F78E699EBC29657 /* Filters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filters.swift; path = Sources/Filters.swift; sourceTree = "<group>"; };
+		5B60F153D0565B5C9C1F8EEC11AD0B11 /* CommandType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandType.swift; path = Sources/Commander/CommandType.swift; sourceTree = "<group>"; };
+		5CA4B24251E95BB75042F53183CA51BD /* sourcekitd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sourcekitd.h; path = Source/SourceKit/include/sourcekitd.h; sourceTree = "<group>"; };
 		5CA7357EAEE8ACD683B18AFCB507CBF9 /* Pods_SourceryUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourceryUtils.framework; path = "Pods-SourceryUtils.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		5D4D73A5111113A2B575FE2295C62237 /* Commander-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Commander-prefix.pch"; sourceTree = "<group>"; };
-		5DFEAE3EEBE4AAB0F46CA502F6D7A6EF /* Documentation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Documentation.h; path = Source/Clang_C/include/Documentation.h; sourceTree = "<group>"; };
-		5E06747E57A600C09E53C52398349DAE /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
-		5E255670EBB9991D10652D6E8E3001F7 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
+		5CD858DF0844E498E56EDB0CA6AE8D97 /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
+		5D9B1CE464521550EFE378654965963A /* Nimble-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-Info.plist"; sourceTree = "<group>"; };
 		5E4E4B7F3A5C09246A57155846635A1F /* Pods-SourceryFramework-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryFramework-Info.plist"; sourceTree = "<group>"; };
-		5EEE670C2712D66E4C9EA652AC8239AD /* CommandType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandType.swift; path = Sources/Commander/CommandType.swift; sourceTree = "<group>"; };
+		5E691F87F3E6C35990223C9C2A8E054B /* xcproj.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = xcproj.xcconfig; sourceTree = "<group>"; };
+		5EB2C6BA52D2F9008F424BF707BD705D /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
 		5F72EB5983ADDB31A4E3A9D313CD8C93 /* Pods-Sourcery-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Sourcery-frameworks.sh"; sourceTree = "<group>"; };
-		60C0A5280E31C8437E25B1687FD612E3 /* Filters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filters.swift; path = Sources/Filters.swift; sourceTree = "<group>"; };
-		614CB9CC906E39FED732700FAA033F5E /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Sources/Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
+		5FAE2E7630397E1B0D00C761D0B58B6C /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
+		5FC5DCE812314A9FCCCF5B1BDEE2564A /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Quick/Configuration/Configuration.swift; sourceTree = "<group>"; };
+		60FA9671E8D8BCA97E5521E50EEA91BA /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
+		6101E623EF5C7724F5DB42E1D637A342 /* PathKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PathKit-dummy.m"; sourceTree = "<group>"; };
 		616232DB10AF687A8F697D05DF9AA95B /* Pods-SourceryJS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SourceryJS-dummy.m"; sourceTree = "<group>"; };
-		6268A034E876AE813B4D04882A6BAC78 /* CXString.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CXString.h; path = Source/Clang_C/include/CXString.h; sourceTree = "<group>"; };
+		624AC30FE642D0BFA4427760733ADF42 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
 		649EC6410169BB83E2544A117ABE41D5 /* Pods-SourceryFramework-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryFramework-acknowledgements.plist"; sourceTree = "<group>"; };
-		65654766C057FB4F10C60814B68DB824 /* StencilSwiftKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "StencilSwiftKit-prefix.pch"; sourceTree = "<group>"; };
-		6669B5EC13B9CB5848658465DC782680 /* PBXBuildFile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXBuildFile.swift; path = Sources/xcproj/PBXBuildFile.swift; sourceTree = "<group>"; };
+		65C3F00E6F232CFAC24CCF450769DBBE /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
 		674ECE5BD6529F599786246514CF77DF /* Pods-CodableContextTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CodableContextTests.release.xcconfig"; sourceTree = "<group>"; };
-		677B4B130BA10A6366A88349BBAAA3F5 /* sourcekitd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sourcekitd.h; path = Source/SourceKit/include/sourcekitd.h; sourceTree = "<group>"; };
-		687CC506A3442B0111E960B4B2D6C597 /* OffsetMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OffsetMap.swift; path = Source/SourceKittenFramework/OffsetMap.swift; sourceTree = "<group>"; };
-		68C428DA4D589EF21D6CFCFB9D6F2E43 /* PBXContainerItemProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXContainerItemProxy.swift; path = Sources/xcproj/PBXContainerItemProxy.swift; sourceTree = "<group>"; };
-		68DBB5AB0439D4E5124A15479732A19F /* Environment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Environment.swift; path = Sources/StencilSwiftKit/Environment.swift; sourceTree = "<group>"; };
-		69AA80704FE1E390E7E6EAD1C23DA8BA /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
-		6A61E20043C98596109322663E3EBCA4 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
-		6AF460E890AA0D2EEB88FFA4F49A684E /* String+SourceKitten.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+SourceKitten.swift"; path = "Source/SourceKittenFramework/String+SourceKitten.swift"; sourceTree = "<group>"; };
-		6B6F189BA4D1A62680E4B1B69193F002 /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
+		678B8FE171235792C83D131DB8383D44 /* PBXProjError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProjError.swift; path = Sources/xcproj/PBXProjError.swift; sourceTree = "<group>"; };
+		68ED56E961C40490163B0C2B5F2C6448 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
+		69632434F3112F733F8A87FA795F8753 /* writer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = writer.c; path = Sources/CYaml/src/writer.c; sourceTree = "<group>"; };
+		69B71A8D3ECA5543E9021731E04C9EBC /* PBXFileReference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXFileReference.swift; path = Sources/xcproj/PBXFileReference.swift; sourceTree = "<group>"; };
+		69CE06279246EC77C9980B88D70814B9 /* parser.c */ = {isa = PBXFileReference; includeInIndex = 1; name = parser.c; path = Sources/CYaml/src/parser.c; sourceTree = "<group>"; };
 		6B745302A893C3C9EAF87439AC84F002 /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6BC9501038F61F601936078AF117C4A6 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h; sourceTree = "<group>"; };
-		6C651386D5A6F392BE0C580DAC94A51B /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
-		6D9F20F354004D3DCD2B94F7BB88CED8 /* XcodeProj.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XcodeProj.swift; path = Sources/xcproj/XcodeProj.swift; sourceTree = "<group>"; };
-		6DE40819D1CE69A0C7B59ED67948FF45 /* CommentedString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommentedString.swift; path = Sources/xcproj/CommentedString.swift; sourceTree = "<group>"; };
-		6E17333EC12616FEE1DCC33CC1325743 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
-		6ECFF68AD5008800603D332189159D63 /* ObjectReference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjectReference.swift; path = Sources/xcproj/ObjectReference.swift; sourceTree = "<group>"; };
-		6FE9D6ED53B6D6760800E1132AA84D64 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
-		701453889D728B9BB5100F9B15B09730 /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
-		706806B89DB516AD322A94BFA196E8AE /* SourceKittenFramework.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SourceKittenFramework.xcconfig; sourceTree = "<group>"; };
-		7084B7BFF3FCF57B87E018FE057A1CF8 /* reader.c */ = {isa = PBXFileReference; includeInIndex = 1; name = reader.c; path = Sources/CYaml/src/reader.c; sourceTree = "<group>"; };
+		6CBCB28D2F10375D61703A9733DE444A /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
+		6CFE302FEA83EF711FEB3842743F7D24 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
+		6D9C71B219C77CB709319D25FFEC89A5 /* CodeCompletionItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CodeCompletionItem.swift; path = Source/SourceKittenFramework/CodeCompletionItem.swift; sourceTree = "<group>"; };
+		6EA404C525F5E3D6A8016BD7475C4DD0 /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
+		6FB46165117F30DE74BF10C9A354E9F8 /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
+		6FC55DDC3190A083979C051D1FDD2166 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Sources/Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
+		703E12109416B70D40F4802DA2D70108 /* PBXSourcesBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXSourcesBuildPhase.swift; path = Sources/xcproj/PBXSourcesBuildPhase.swift; sourceTree = "<group>"; };
+		71313AE80A30431A02EB459A3A642DF7 /* AEXML-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AEXML-dummy.m"; sourceTree = "<group>"; };
 		71C57F7EE59EE7846C41FF4DC26FB779 /* Pods_SourceryFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourceryFramework.framework; path = "Pods-SourceryFramework.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		71EF8ECD799B5D2FCC44CD976F73E9CF /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
-		71F1E7057742CED3E437901DF8D17E23 /* XCWorkspaceDataElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataElement.swift; path = Sources/xcproj/XCWorkspaceDataElement.swift; sourceTree = "<group>"; };
-		72F8B81DEBDBDB660D7D778BEDA07D09 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
-		7336EEF50F41578E607ABB7379D35029 /* SourceKitObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceKitObject.swift; path = Source/SourceKittenFramework/SourceKitObject.swift; sourceTree = "<group>"; };
-		737D0EE3EC612F9D3DB132F72D59D8FC /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
-		7402719B2267A34BFBD088FF9B66D837 /* xcproj.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = xcproj.modulemap; sourceTree = "<group>"; };
-		743DE2C453FC27A0D319CCCB7613743F /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
+		724CD53C96E3A5066A5CBBA124A23F74 /* library_wrapper_sourcekitd.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_sourcekitd.swift; path = Source/SourceKittenFramework/library_wrapper_sourcekitd.swift; sourceTree = "<group>"; };
+		724CDE81D5A9A0D37CDC47265C72502B /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
+		73AC51682E5204ECAF44C61C6D227AE4 /* CXErrorCode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CXErrorCode.h; path = Source/Clang_C/include/CXErrorCode.h; sourceTree = "<group>"; };
+		744FF4C8CACC10E026C4B8C5941FE38A /* Stencil-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Stencil-Info.plist"; sourceTree = "<group>"; };
 		74FD3EA1B1EC727B7667F2CA91DAD912 /* Pods-TemplatesTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-TemplatesTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		75BC3789FD43653C8FBA28B958FCC5AB /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
-		763CEC8B6B1D48223EA3A489E9CCF731 /* Version.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Version.swift; path = Source/SourceKittenFramework/Version.swift; sourceTree = "<group>"; };
-		763D247D13A9B4E42A5882942697F569 /* SWXMLHash-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "SWXMLHash-Info.plist"; sourceTree = "<group>"; };
+		75CC526A9B66BD89B6A1EC926EC6A5EF /* shim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = shim.swift; path = Sources/Yams/shim.swift; sourceTree = "<group>"; };
+		76294F8D74C2D7376B9EC996D9131596 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
+		76337E3F50337CB8E301F09E989DE4A1 /* PBXProjEncoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProjEncoder.swift; path = Sources/xcproj/PBXProjEncoder.swift; sourceTree = "<group>"; };
 		7704ADF037A1D12F4BEBF1A04B5B47E4 /* Commander.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Commander.framework; path = Commander.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7748EDF5B0EFD7D513FB06EC2A6E9403 /* SwiftIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftIdentifier.swift; path = Sources/StencilSwiftKit/SwiftIdentifier.swift; sourceTree = "<group>"; };
-		782AB024816388DFD9776DBBAB907741 /* File.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = File.swift; path = Source/SourceKittenFramework/File.swift; sourceTree = "<group>"; };
-		78348A371E1D2833CE251DF5EF58052E /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
-		7C11694083C15CAC1DBF387D858BD3B7 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
-		7C13932E3FD00DC6C06FA2809950BE3A /* Node.Sequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.Sequence.swift; path = Sources/Yams/Node.Sequence.swift; sourceTree = "<group>"; };
-		7C89315E1EF04A0808A3DB4742DEB3D6 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/AEXML/Parser.swift; sourceTree = "<group>"; };
-		7D5E76231D541B6BDBD0694A75971BC6 /* yaml.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yaml.h; path = Sources/CYaml/include/yaml.h; sourceTree = "<group>"; };
-		7E3891F76F0BF44385AC30B6C1129DB9 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
-		7F2BB0DF0447B28C112C7F7DDE0416DC /* Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.swift; path = Sources/Yams/Node.swift; sourceTree = "<group>"; };
-		7FCFE50C0FFC83F542D8CB5B32321DD9 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
+		776214A053BBF81117AEF49F94714BD8 /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
+		784C42C8B774EBB778FB0F8041D5892C /* xcproj-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "xcproj-umbrella.h"; sourceTree = "<group>"; };
+		78CF2129AB9AC3574CC2E29CECC392DD /* ClangTranslationUnit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClangTranslationUnit.swift; path = Source/SourceKittenFramework/ClangTranslationUnit.swift; sourceTree = "<group>"; };
+		796BD1961FD3BBC2E779361F39420484 /* BuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildPhase.swift; path = Sources/xcproj/BuildPhase.swift; sourceTree = "<group>"; };
+		7A0CD2970F06D4831A45FE0CB37B49E1 /* Text.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Text.swift; path = Source/SourceKittenFramework/Text.swift; sourceTree = "<group>"; };
+		7B42AD7D47626559CDB07DB7D4E566D4 /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
+		7B66B070F558C8D96591917995D5090C /* Stencil.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Stencil.xcconfig; sourceTree = "<group>"; };
+		7D093D987A5069F8351B900597275D09 /* KeyPath.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeyPath.swift; path = Sources/KeyPath.swift; sourceTree = "<group>"; };
+		7F44C93EE89CBD00E32817E141E99058 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
 		7FFBE3D95C1012EC1619FD97268BD17C /* Pods-Sourcery.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Sourcery.modulemap"; sourceTree = "<group>"; };
-		80A797EA0A1A0CDE6F427B699A18241A /* PBXAggregateTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXAggregateTarget.swift; path = Sources/xcproj/PBXAggregateTarget.swift; sourceTree = "<group>"; };
+		806E866705CE5BA9A15CFF2D6DB9A048 /* Module.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Module.swift; path = Source/SourceKittenFramework/Module.swift; sourceTree = "<group>"; };
 		80B105969A02697FCF2AD637049A030C /* Pods_SourceryJS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourceryJS.framework; path = "Pods-SourceryJS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		80D2206E90D4152F008B842C9E69C691 /* Stencil-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Stencil-Info.plist"; sourceTree = "<group>"; };
+		80C21296EF982928752977E0C3AF373E /* UID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UID.swift; path = Source/SourceKittenFramework/UID.swift; sourceTree = "<group>"; };
 		80E425D80CDF87F037D294E37642B048 /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81E585B7ED9B07124CA32E112FF8AB92 /* Pods-CodableContextTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CodableContextTests-Info.plist"; sourceTree = "<group>"; };
-		8269C7AEC9E678BD76F3A3B0988DABA8 /* xcproj-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "xcproj-umbrella.h"; sourceTree = "<group>"; };
-		82B664B140061DAB41620131AAA50675 /* SWXMLHash.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SWXMLHash.modulemap; sourceTree = "<group>"; };
-		82CD334BA0A54B2AAB1293E0BDBB0692 /* Documentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Documentation.swift; path = Source/SourceKittenFramework/Documentation.swift; sourceTree = "<group>"; };
-		8313C7659E1AB4F9E2CCCFCF26E7D2C8 /* Nimble-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-Info.plist"; sourceTree = "<group>"; };
+		82F20050C1512B68623E7193D35460A2 /* library_wrapper_Documentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_Documentation.swift; path = Source/SourceKittenFramework/library_wrapper_Documentation.swift; sourceTree = "<group>"; };
+		83C2B3703304D4EF5B7455ADEE207E72 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
+		8471ECCC0116913C56515B4D0EF505C6 /* AEXML-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AEXML-prefix.pch"; sourceTree = "<group>"; };
 		84B8B1842A5234759AC4CF12DDB9B4A0 /* Pods-SourceryTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SourceryTests-dummy.m"; sourceTree = "<group>"; };
+		84D2AAC4A83087615D20A1842737DFF5 /* PBXFileElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXFileElement.swift; path = Sources/xcproj/PBXFileElement.swift; sourceTree = "<group>"; };
 		84DF5AC545C2C0A6FAD0CA8155284808 /* Stencil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		85F073EE38FCAC3AFE15FE8F5BAD6585 /* PBXSourceTree.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXSourceTree.swift; path = Sources/xcproj/PBXSourceTree.swift; sourceTree = "<group>"; };
-		862824B94DD6B06B03D179006051F916 /* Stencil.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Stencil.modulemap; sourceTree = "<group>"; };
-		864682329DAF9796573B4E5CD92E8887 /* PathKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PathKit-Info.plist"; sourceTree = "<group>"; };
-		86657F955ED624F632751451403157CD /* MatcherFunc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherFunc.swift; path = Sources/Nimble/Matchers/MatcherFunc.swift; sourceTree = "<group>"; };
-		86766CFDB30423496E2278A6471B9AE1 /* Dictionary+Merge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Merge.swift"; path = "Source/SourceKittenFramework/Dictionary+Merge.swift"; sourceTree = "<group>"; };
-		86E7458F33BE6B49E441EB99D1E66E41 /* Filters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filters.swift; path = Sources/StencilSwiftKit/Filters.swift; sourceTree = "<group>"; };
-		87C0B31794B1ABE28DD9180F32B201AF /* Referenceable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Referenceable.swift; path = Sources/xcproj/Referenceable.swift; sourceTree = "<group>"; };
-		88EDAE799F0B29969B1A72FE28C090FE /* StatementKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatementKind.swift; path = Source/SourceKittenFramework/StatementKind.swift; sourceTree = "<group>"; };
-		8904C6ACC3569C21F951874EF301C037 /* PBXLegacyTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXLegacyTarget.swift; path = Sources/xcproj/PBXLegacyTarget.swift; sourceTree = "<group>"; };
-		89261071D4DF90CD5B0610CA2F515A42 /* Text.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Text.swift; path = Source/SourceKittenFramework/Text.swift; sourceTree = "<group>"; };
-		8A610346F082C6EFC756FC490E66CB6B /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
-		8A89AA45740EE5A54ACA07BF3E2F173D /* SwiftDocKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftDocKey.swift; path = Source/SourceKittenFramework/SwiftDocKey.swift; sourceTree = "<group>"; };
-		8AAEF487A8F518B2554778FF0112ADBF /* Context.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Context.swift; path = Sources/StencilSwiftKit/Context.swift; sourceTree = "<group>"; };
-		8C8F794C5E8EA988E6C3B1A81EA215F7 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
-		8D0C214947B910E1811148FEB33BF85C /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
-		8F7609175A5C8067D4BF812B6E986F9C /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
-		8FB52B2EA57047A2E09B1828AA240F29 /* SourceKittenFramework-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SourceKittenFramework-umbrella.h"; sourceTree = "<group>"; };
-		8FDE06C40D085B3213AC1F10A5243C33 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
+		851965D057C3408B376D869449761D45 /* SyntaxKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyntaxKind.swift; path = Source/SourceKittenFramework/SyntaxKind.swift; sourceTree = "<group>"; };
+		85B2A0588079756EDA937C1209E642B6 /* PBXResourcesBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXResourcesBuildPhase.swift; path = Sources/xcproj/PBXResourcesBuildPhase.swift; sourceTree = "<group>"; };
+		8622D4B035F740661308D2ABC1D4C93D /* Node.Mapping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.Mapping.swift; path = Sources/Yams/Node.Mapping.swift; sourceTree = "<group>"; };
+		86B565337F2260DDDE77ECC14171ADBB /* PathKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PathKit-prefix.pch"; sourceTree = "<group>"; };
+		876E69BB30C15D467257B58B41BD71EA /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
+		87F6D32F8C58ADC0F5CD438C94827E31 /* PBXAggregateTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXAggregateTarget.swift; path = Sources/xcproj/PBXAggregateTarget.swift; sourceTree = "<group>"; };
+		88127F8E25EF8B7FD7BDAAC30E5D93E7 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
+		88A23FD40CECDD9C445EA86F236AC8CF /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
+		8A0857F9532A5F5578C3A9B43ADC720A /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
+		8BC119E25152D883EA65D7F20991B383 /* OffsetMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OffsetMap.swift; path = Source/SourceKittenFramework/OffsetMap.swift; sourceTree = "<group>"; };
+		8EE60519AF5071B1F75B32146E6C45F9 /* Template.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Template.swift; path = Sources/Template.swift; sourceTree = "<group>"; };
 		8FDF5C763D15BC18E295F4A81DAB1BDF /* Pods-SourceryTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SourceryTests.modulemap"; sourceTree = "<group>"; };
-		8FE64A598784642BDF5075123E1B9B60 /* PathKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PathKit-prefix.pch"; sourceTree = "<group>"; };
 		8FFA9CE72A4B0BE2DEEF7E40A5D93CB0 /* Pods-Sourcery-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Sourcery-Info.plist"; sourceTree = "<group>"; };
+		90143D33F5F43B2AC844E8027C2B9A58 /* Environment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Environment.swift; path = Sources/StencilSwiftKit/Environment.swift; sourceTree = "<group>"; };
 		902C5359511463CAA81BC11F4873FAA8 /* Pods-TemplatesTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-TemplatesTests.modulemap"; sourceTree = "<group>"; };
-		908E4BA247C8BED71D9A14CEAEEEB327 /* PBXProj+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PBXProj+Helpers.swift"; path = "Sources/xcproj/PBXProj+Helpers.swift"; sourceTree = "<group>"; };
-		90F7E82F109A2232E1166802EAD00C06 /* StencilSwiftKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "StencilSwiftKit-umbrella.h"; sourceTree = "<group>"; };
-		918C549C317298F3E4C16B5603662316 /* scanner.c */ = {isa = PBXFileReference; includeInIndex = 1; name = scanner.c; path = Sources/CYaml/src/scanner.c; sourceTree = "<group>"; };
+		906ED5AAC255184C2E301FEB22CC64B7 /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
+		91A001B32BFF90791FE414183A62E633 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
+		9256BF91D068CBBFEAC4245578DDBC99 /* Commander-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Commander-dummy.m"; sourceTree = "<group>"; };
+		92602C4E1DF04F0B4FB5ABEB64354C92 /* Commander.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Commander.xcconfig; sourceTree = "<group>"; };
 		928332349FEE256A24658E6B5B5EF979 /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SWXMLHash.framework; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		92A58584447AD7CF6234686646644836 /* JSONDecoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONDecoding.swift; path = Sources/xcproj/JSONDecoding.swift; sourceTree = "<group>"; };
-		930614056B1E73896FC3334A2A5893B4 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
+		92B2629C742F046972BA51DBEA11EABA /* IfTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IfTag.swift; path = Sources/IfTag.swift; sourceTree = "<group>"; };
 		9308CBEC7BD5EE4EC03EE042089062FC /* Pods_Sourcery.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Sourcery.framework; path = "Pods-Sourcery.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9589331403E4DEBD9A7703CC8EBB399E /* Constructor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constructor.swift; path = Sources/Yams/Constructor.swift; sourceTree = "<group>"; };
-		96519D90DBC67540EBD84E74F92E0C9B /* shim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = shim.swift; path = Source/shim.swift; sourceTree = "<group>"; };
-		96E70641FF5262B79101656AE2878B6B /* SWXMLHash-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SWXMLHash-dummy.m"; sourceTree = "<group>"; };
-		9734EA8E9FAC9D97FD0CFC957B268FE6 /* ObjCDeclarationKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjCDeclarationKind.swift; path = Source/SourceKittenFramework/ObjCDeclarationKind.swift; sourceTree = "<group>"; };
-		99C53E013FAC2D9ADE1E9A094E02A908 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Quick/Configuration/Configuration.swift; sourceTree = "<group>"; };
-		9A204386D6FF280726EB1FABE9D15541 /* shim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = shim.swift; path = Sources/Yams/shim.swift; sourceTree = "<group>"; };
-		9BBC2DABCB8CBBA98357EB57930FBA78 /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
+		9337F8EC7F37E67B0EB7C5AC854172AB /* CommentedString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommentedString.swift; path = Sources/xcproj/CommentedString.swift; sourceTree = "<group>"; };
+		94E0948E7E9E0DDAC3AFCBA13E647A0E /* SourceKittenFramework-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SourceKittenFramework-dummy.m"; sourceTree = "<group>"; };
+		9646D60E4888A57E32E05DF58D9AAF5F /* XcodeProj.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XcodeProj.swift; path = Sources/xcproj/XcodeProj.swift; sourceTree = "<group>"; };
+		9688ED2F2B90D7B3D257CD99821A9EA0 /* Platform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Platform.h; path = Source/Clang_C/include/Platform.h; sourceTree = "<group>"; };
+		969139ED9A9F94B35C1C8EDE8B2ED1D0 /* Node.Sequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.Sequence.swift; path = Sources/Yams/Node.Sequence.swift; sourceTree = "<group>"; };
+		96F070C2246720CCAE9AE3B37172D6EF /* Yams.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Yams.modulemap; sourceTree = "<group>"; };
+		9703595520BF6F070F6A9850BCA3547B /* Encoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Encoder.swift; path = Sources/Yams/Encoder.swift; sourceTree = "<group>"; };
+		9891F4608FA0A7B2C94F702189F80B31 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/Commander/Error.swift; sourceTree = "<group>"; };
+		99D9536FAFDE10451A504808ECBFA7D8 /* xcproj-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "xcproj-Info.plist"; sourceTree = "<group>"; };
+		99EACE4455929BB6FA78B93E672D6317 /* Clang_C.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Clang_C.h; path = Source/Clang_C/include/Clang_C.h; sourceTree = "<group>"; };
+		9B50811A8539F4000B8902F066F142C0 /* AEXML+XcodeFormat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AEXML+XcodeFormat.swift"; path = "Sources/xcproj/AEXML+XcodeFormat.swift"; sourceTree = "<group>"; };
+		9C8338743B57A2D4C2844A2679D32DBF /* PBXGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXGroup.swift; path = Sources/xcproj/PBXGroup.swift; sourceTree = "<group>"; };
+		9CEA086E8BD8006B28AA9FA1A7BE0ECF /* shim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = shim.swift; path = Source/SourceKittenFramework/shim.swift; sourceTree = "<group>"; };
+		9D7914CA125394D8F1EA05CCDFC2D30B /* PBXTargetDependency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXTargetDependency.swift; path = Sources/xcproj/PBXTargetDependency.swift; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9DA94081B5833FD432108861C88B65E2 /* StencilSwiftKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "StencilSwiftKit-dummy.m"; sourceTree = "<group>"; };
-		9DC357A14C7A15C85E4BDF56E9FD41BA /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
-		9E47534C344A9005D799E92586C7109B /* xcproj.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = xcproj.xcconfig; sourceTree = "<group>"; };
-		9ECC71F7DED24BF46E1F384A08BE6A20 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
+		9D9AB9DBA14ED1725777745F484592E8 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/Yams/Parser.swift; sourceTree = "<group>"; };
+		9ECB41E90854ABC0D5EFF0192768A7FD /* PBXBuildFile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXBuildFile.swift; path = Sources/xcproj/PBXBuildFile.swift; sourceTree = "<group>"; };
 		9F4F329A9345D1A9604411CBCBC64878 /* Pods-CodableContextTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CodableContextTests.debug.xcconfig"; sourceTree = "<group>"; };
-		A07721AE5E7A35411D3A1714BDCCBFF4 /* Yams-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Yams-prefix.pch"; sourceTree = "<group>"; };
-		A0A9E730385794274DE40C9F1BAD543F /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
-		A0E1962A587D8F2DF0332E485886E945 /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
-		A0FD9BE14D163B58F2FF9FCEB937E6EF /* SourceKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SourceKit.h; path = Source/SourceKit/include/SourceKit.h; sourceTree = "<group>"; };
-		A204C09542A5FC0C1A2F7CFA5D487030 /* SourceDeclaration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceDeclaration.swift; path = Source/SourceKittenFramework/SourceDeclaration.swift; sourceTree = "<group>"; };
+		A0359557D6F9E4B6E5C82E48488CC8E6 /* SWXMLHash-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SWXMLHash-dummy.m"; sourceTree = "<group>"; };
+		A05B1D669D1907D83F96CAFE21A9C4AC /* Commander-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Commander-prefix.pch"; sourceTree = "<group>"; };
+		A18F155424176FDF82BF07B5BF89E328 /* Yams-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Yams-Info.plist"; sourceTree = "<group>"; };
+		A1F2B921FD32145CB67DFE1E9A25D8E0 /* JSONDecoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONDecoding.swift; path = Sources/xcproj/JSONDecoding.swift; sourceTree = "<group>"; };
 		A2143E4AEEFC39243F548F86B3FC8611 /* SourceKittenFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SourceKittenFramework.framework; path = SourceKittenFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A21CF738800F69EA8BAFC20D2B1347B0 /* xcproj-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "xcproj-prefix.pch"; sourceTree = "<group>"; };
 		A244D68C6A77215A9C29A658F5FA7259 /* Pods-SourceryTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SourceryTests-frameworks.sh"; sourceTree = "<group>"; };
-		A29D92F82B778344AF35BBE23B6DE521 /* PBXCopyFilesBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXCopyFilesBuildPhase.swift; path = Sources/xcproj/PBXCopyFilesBuildPhase.swift; sourceTree = "<group>"; };
-		A2B51A6BC636B1115C5A162A9588B9B7 /* parser.c */ = {isa = PBXFileReference; includeInIndex = 1; name = parser.c; path = Sources/CYaml/src/parser.c; sourceTree = "<group>"; };
-		A2E96AF77221F5589CE93229D97E5EB4 /* XCConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCConfig.swift; path = Sources/xcproj/XCConfig.swift; sourceTree = "<group>"; };
-		A3335214CF90C999095CE68C39C946CA /* Quick-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Quick-Info.plist"; sourceTree = "<group>"; };
-		A3BF4D477B9D113C3E2EF24CDE561742 /* StencilSwiftKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = StencilSwiftKit.xcconfig; sourceTree = "<group>"; };
-		A3BFCB717681FABCD52E7E521A8885BF /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
-		A3D95FFC25C234AC52F455CEBF0AF4EA /* xcproj-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "xcproj-Info.plist"; sourceTree = "<group>"; };
-		A409EEED1D16F55CCC3ECFC826D6DF55 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
+		A2A0C466F7866E0322F7546EEE3FFCA5 /* FilterTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FilterTag.swift; path = Sources/FilterTag.swift; sourceTree = "<group>"; };
+		A3415853B20AD79A6FC57A3A85CA67CA /* AEXML.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AEXML.xcconfig; sourceTree = "<group>"; };
+		A37D12B5030FC2B6C84603464DB9FCA9 /* Inheritence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Inheritence.swift; path = Sources/Inheritence.swift; sourceTree = "<group>"; };
+		A3B06BC11AA25C779382CEEC38844ABD /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
 		A42956B878AC080F7C85E67F3443A69E /* Pods-SourceryUtils-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourceryUtils-umbrella.h"; sourceTree = "<group>"; };
-		A6459435DBB72829839607EB712F1337 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Request.swift; path = Source/SourceKittenFramework/Request.swift; sourceTree = "<group>"; };
-		A6EB0E53947D176E894C5B2D1CA7EE9D /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		A630E9B19712F4E441412E4781FD66A6 /* XCVersionGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCVersionGroup.swift; path = Sources/xcproj/XCVersionGroup.swift; sourceTree = "<group>"; };
+		A6E92D3E9A926DD127B0315FB36E2E01 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
 		A72AE5CE3131006A639F47212EFEF25E /* Pods-Sourcery-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Sourcery-acknowledgements.plist"; sourceTree = "<group>"; };
-		A7F14BF5E4B3082D8035D802DD81DA41 /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Decodable+Dictionary.swift"; path = "Sources/xcproj/Decodable+Dictionary.swift"; sourceTree = "<group>"; };
-		A7FBDEF172CE4AEC4591A23B451771C6 /* AEXML+XcodeFormat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AEXML+XcodeFormat.swift"; path = "Sources/xcproj/AEXML+XcodeFormat.swift"; sourceTree = "<group>"; };
-		A8231D4EF1852B83481A2C35F3C85115 /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
-		A8989F7935A230D696905CC8AC353FC3 /* Stencil-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Stencil-prefix.pch"; sourceTree = "<group>"; };
-		AAA52AA7D10C2DB34B157CB99590BCCC /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
-		AC98B0092E4E82396DD4B76FD39712B6 /* PBXResourcesBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXResourcesBuildPhase.swift; path = Sources/xcproj/PBXResourcesBuildPhase.swift; sourceTree = "<group>"; };
-		AD06D865DFBCD695CF7BD134BFADD0B5 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
-		AD20DD4C565C9D58FA179D4F033F238C /* PBXBuildRule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXBuildRule.swift; path = Sources/xcproj/PBXBuildRule.swift; sourceTree = "<group>"; };
-		AD233B046D1101ED9AC6F11964527700 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
-		ADDEF5FA01F5DADFC0478F13D89E1AA4 /* AEXML-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AEXML-Info.plist"; sourceTree = "<group>"; };
-		AE275577630A5584534B7E7C643D9835 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
-		AE2B1D4CD4103BAFAE3EA9B94C73ADC0 /* PBXTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXTarget.swift; path = Sources/xcproj/PBXTarget.swift; sourceTree = "<group>"; };
-		AE633EA1200B10C2AE81161F5B2372EE /* SwiftDeclarationKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftDeclarationKind.swift; path = Source/SourceKittenFramework/SwiftDeclarationKind.swift; sourceTree = "<group>"; };
-		AF5AB8A585BCB8D9DA75014B18941F05 /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
-		AF7EF8E3FD503FAE5D5068418202B38B /* Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Extension.swift; path = Sources/Extension.swift; sourceTree = "<group>"; };
-		AF857CED27C511D9172CBBA428FD330C /* Structure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Structure.swift; path = Source/SourceKittenFramework/Structure.swift; sourceTree = "<group>"; };
-		AFD41892E8810AA35A18488D700A85A8 /* PBXContainerItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXContainerItem.swift; path = Sources/xcproj/PBXContainerItem.swift; sourceTree = "<group>"; };
+		A77896CE8A81F314E78F3A8B620A4385 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
+		A8270EE942DB4D0FEE7B27BC88C5E218 /* Yams-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Yams-dummy.m"; sourceTree = "<group>"; };
+		A9367BDCE37CFBC7778DA94E5F0A4F4F /* Parameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parameters.swift; path = Sources/StencilSwiftKit/Parameters.swift; sourceTree = "<group>"; };
+		AAACEA64D9724241826D6BA5594566E8 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
+		AC327897196E329B6427C375FBF2C039 /* JSONOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONOutput.swift; path = Source/SourceKittenFramework/JSONOutput.swift; sourceTree = "<group>"; };
+		AC3E72BB8C9B109AE543B59B72B61EC7 /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
+		ADFCC348C33BD5CFDEF0CFD4AEE6BAAB /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
+		AE5225920B0BCC69D1F01F8307C648EB /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Errors.swift; sourceTree = "<group>"; };
+		AE96403D31B9963E837CB9808DB8A20F /* PathKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PathKit-Info.plist"; sourceTree = "<group>"; };
 		B0100A7298EFB4FC02D8F8DCA0CD74CA /* Pods-CodableContextTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-CodableContextTests.modulemap"; sourceTree = "<group>"; };
-		B030415E7290E7829C1A40D6CF40CA21 /* Commander.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Commander.xcconfig; sourceTree = "<group>"; };
-		B0C186AB6A651C1AA36E1D4D4B72621C /* Commander-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Commander-dummy.m"; sourceTree = "<group>"; };
+		B01FE6CA5E93266827963FE245EC5C89 /* StencilSwiftKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "StencilSwiftKit-prefix.pch"; sourceTree = "<group>"; };
+		B0A96B81F5168E3DC7FF81A91600035A /* Referenceable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Referenceable.swift; path = Sources/xcproj/Referenceable.swift; sourceTree = "<group>"; };
+		B0AF22A2C0194990E2C3726CABB664A9 /* api.c */ = {isa = PBXFileReference; includeInIndex = 1; name = api.c; path = Sources/CYaml/src/api.c; sourceTree = "<group>"; };
 		B0EDFDBE7AF483B2B00EA1C29149159C /* Pods-SourceryTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		B14525739EB13CBB5CDA70AB08AA1B68 /* Lexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Lexer.swift; path = Sources/Lexer.swift; sourceTree = "<group>"; };
-		B190854AFDC66912D57A546D3F5C0B14 /* PBXProj.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProj.swift; path = Sources/xcproj/PBXProj.swift; sourceTree = "<group>"; };
-		B1CC8AC7FE775ECA1A7DF19BE02AEA89 /* PathKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PathKit.modulemap; sourceTree = "<group>"; };
-		B24241FFE39B64EE82D70ABFDF38D91A /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Source/SourceKittenFramework/SourceLocation.swift; sourceTree = "<group>"; };
-		B283A8568909F9D09FAB2E0C0A30DDBF /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/Parser.swift; sourceTree = "<group>"; };
-		B2B46E0B6F9986A48ED38C876BFBEB63 /* String+Yams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Yams.swift"; path = "Sources/Yams/String+Yams.swift"; sourceTree = "<group>"; };
-		B30522199DBCF74F2160AF50C37CBBB8 /* PBXFrameworksBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXFrameworksBuildPhase.swift; path = Sources/xcproj/PBXFrameworksBuildPhase.swift; sourceTree = "<group>"; };
+		B1185262182BF8C2904E1C94E00CBEE0 /* PathKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PathKit.modulemap; sourceTree = "<group>"; };
+		B156B9A00C759C4FFBAC0D7886C7C9BB /* CXString.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CXString.h; path = Source/Clang_C/include/CXString.h; sourceTree = "<group>"; };
+		B1A37DC2B51B6C077488D9F0AAFE54F4 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
+		B2075DC4B09A0F15576EA6C347DAEAC3 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
+		B2E9C034674D21790244D9460A160663 /* Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.swift; path = Sources/Node.swift; sourceTree = "<group>"; };
+		B2F9FE6422C2C76783DDEC35FD918D6F /* PBXSourceTree.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXSourceTree.swift; path = Sources/xcproj/PBXSourceTree.swift; sourceTree = "<group>"; };
 		B310D86E1C8534186728D14284B6C10E /* Pods-SourcerySwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SourcerySwift.modulemap"; sourceTree = "<group>"; };
-		B313ECCDB14FD79AC6BFB415BB0F959F /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
-		B3510FD7EE673AFF1DD4938BAAE99E5B /* PBXShellScriptBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXShellScriptBuildPhase.swift; path = Sources/xcproj/PBXShellScriptBuildPhase.swift; sourceTree = "<group>"; };
-		B3A80CDE43BED2CE02D0C9E9DAD69AAA /* library_wrapper_Index.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_Index.swift; path = Source/SourceKittenFramework/library_wrapper_Index.swift; sourceTree = "<group>"; };
-		B41B4237BC69B6EF17DB486776767990 /* StencilSwiftTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StencilSwiftTemplate.swift; path = Sources/StencilSwiftKit/StencilSwiftTemplate.swift; sourceTree = "<group>"; };
+		B3DC89DFE06119563E55378C1581D5A2 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
 		B42F3ED60B26C5E4A92E21E2D5B963D1 /* Pods-Sourcery.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Sourcery.release.xcconfig"; sourceTree = "<group>"; };
-		B4CE2479EF39C7D1551F41F553DEA07A /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Expression.swift; sourceTree = "<group>"; };
+		B46E34D9803715249741363C105AEBBF /* CommandRunner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandRunner.swift; path = Sources/Commander/CommandRunner.swift; sourceTree = "<group>"; };
+		B54C552319DB529ACEA317D82ED3A4CC /* LinuxCompatibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LinuxCompatibility.swift; path = Source/SourceKittenFramework/LinuxCompatibility.swift; sourceTree = "<group>"; };
+		B5749A684FD4A16EF0D0EA5D8E321985 /* PlistValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlistValue.swift; path = Sources/xcproj/PlistValue.swift; sourceTree = "<group>"; };
+		B6194EF134E0C05224BD731E84371A1A /* Dictionary+Extras.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extras.swift"; path = "Sources/xcproj/Dictionary+Extras.swift"; sourceTree = "<group>"; };
+		B641481219EB1331EA9C9B440306F66B /* PBXShellScriptBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXShellScriptBuildPhase.swift; path = Sources/xcproj/PBXShellScriptBuildPhase.swift; sourceTree = "<group>"; };
+		B69786045B50248334DDBB789A2B6F0C /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
+		B6EB84D7064384AA64D3BF638BB44B58 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
+		B70EA8900B945F212B11AEBC26B42506 /* PBXProject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProject.swift; path = Sources/xcproj/PBXProject.swift; sourceTree = "<group>"; };
 		B71469ECCCB0AE37079562EBF73B1E0D /* Pods-SourceryUtils-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SourceryUtils-dummy.m"; sourceTree = "<group>"; };
-		B741C0360D65D26B6443AC3E52D2D8B9 /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
+		B72C0F08AC5739D484DDE83DDFB6879E /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
+		B788BB33BFDAE79378AF1CC131FFFF72 /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
+		B7BED265C9690AF35FB3BE79DBFB6A3A /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
 		B88F9C5B5BCB9C94564A44D1EF814189 /* Pods-SourceryTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryTests.release.xcconfig"; sourceTree = "<group>"; };
-		B8C9839DEE4610A4DB3CA2F137C28774 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		B994AA2115476FFB2EC30EAED7BD1B63 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
-		B9B01949076F1547B435472A14561555 /* Mark.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Mark.swift; path = Sources/Yams/Mark.swift; sourceTree = "<group>"; };
-		B9D3D92F70A685B232ABC6781DC52726 /* PBXBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXBuildPhase.swift; path = Sources/xcproj/PBXBuildPhase.swift; sourceTree = "<group>"; };
-		BD2DB45369BE988EB5E3290A29AB381A /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
-		BDD552233B9B5503D1F989CE3AB06BDE /* PBXNativeTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXNativeTarget.swift; path = Sources/xcproj/PBXNativeTarget.swift; sourceTree = "<group>"; };
+		BA7167F0F96B5E16E0446666685305B0 /* Command.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Command.swift; path = Sources/Commander/Command.swift; sourceTree = "<group>"; };
+		BA8750424B343AF43C9D5C19144B400F /* SWXMLHash-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SWXMLHash-prefix.pch"; sourceTree = "<group>"; };
+		BA88B10C73D26CCCF76D5E1DAF34570F /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
+		BA8D8CD2E7354236099415D4C75247FD /* library_wrapper_CXString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_CXString.swift; path = Source/SourceKittenFramework/library_wrapper_CXString.swift; sourceTree = "<group>"; };
+		BABFDF969A7F032C33E684E67454FE92 /* shim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = shim.swift; path = Source/shim.swift; sourceTree = "<group>"; };
+		BB8F43A5788E6DF310C17CC1CA0B12FA /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
+		BC9482A58E11515F5A26F5163AB05522 /* SWXMLHash.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SWXMLHash.xcconfig; sourceTree = "<group>"; };
+		BCC7EEB4CBDA235AF20A2F4E3292FCD7 /* library_wrapper_Index.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_Index.swift; path = Source/SourceKittenFramework/library_wrapper_Index.swift; sourceTree = "<group>"; };
+		BD20E9F784FAB05697C736E9B6AA86D6 /* StencilSwiftTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StencilSwiftTemplate.swift; path = Sources/StencilSwiftKit/StencilSwiftTemplate.swift; sourceTree = "<group>"; };
+		BE149041B5CC5E87E47F7749849813E2 /* SWXMLHash-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SWXMLHash-umbrella.h"; sourceTree = "<group>"; };
 		BE758E818711B442EC7672ED9FFB2763 /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AEXML.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BE767B0372B41ADBAF7D353693F9FE96 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
-		BEA40B1D07DB53A8726B6086A76B3318 /* Clang_C.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Clang_C.h; path = Source/Clang_C/include/Clang_C.h; sourceTree = "<group>"; };
-		BF31B6091EC0F6CF1052688292E3572C /* ArgumentParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArgumentParser.swift; path = Sources/Commander/ArgumentParser.swift; sourceTree = "<group>"; };
+		BF00D49AE0D754ACDD15BF373709A4E2 /* Emitter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Emitter.swift; path = Sources/Yams/Emitter.swift; sourceTree = "<group>"; };
 		BF478A83FC7AE0123B5D03B9BB10782F /* Pods-TemplatesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TemplatesTests.release.xcconfig"; sourceTree = "<group>"; };
+		BF7E9F1177F9C9DE785CCBA2AAD834B7 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
+		BF904A7F46503A348ADDD6FE2677A895 /* Filters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filters.swift; path = Sources/StencilSwiftKit/Filters.swift; sourceTree = "<group>"; };
 		C002B9239503CBC411AA7C16286DFF69 /* Pods-SourceryFramework.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SourceryFramework.modulemap"; sourceTree = "<group>"; };
-		C06D0ECE52B3FBD54BE68F9966526A3B /* String+Extras.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extras.swift"; path = "Sources/xcproj/String+Extras.swift"; sourceTree = "<group>"; };
-		C2A681F9653588B23F16F9E26C3F907B /* Yams-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Yams-umbrella.h"; sourceTree = "<group>"; };
+		C151C096DF67A7ABF7D345102DD85489 /* Loader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Loader.swift; path = Sources/Loader.swift; sourceTree = "<group>"; };
+		C1C43D41C41B4487C24BFA10EFADD820 /* Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.swift; path = Sources/Yams/Node.swift; sourceTree = "<group>"; };
 		C35DB1B1D9D40464466C8F0DD55B12B6 /* Pods_TemplatesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_TemplatesTests.framework; path = "Pods-TemplatesTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C3A999F8A82D861064F2044A0698B64C /* CallMacroNodes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CallMacroNodes.swift; path = Sources/StencilSwiftKit/CallMacroNodes.swift; sourceTree = "<group>"; };
 		C3EA4FE39B408EC4C2B7C4BB0722E04C /* StencilSwiftKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = StencilSwiftKit.framework; path = StencilSwiftKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C46BBC6D42701827772C10C342891F00 /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
-		C53AFDB65DB8537F74FF1D4B5D0E7CAF /* Commander-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Commander-umbrella.h"; sourceTree = "<group>"; };
-		C6ABD7DF77635B8EB76DBCD540ACD8A7 /* Command.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Command.swift; path = Sources/Commander/Command.swift; sourceTree = "<group>"; };
-		C7392EE5BE7C9E6F293892057AD48657 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
+		C43F84DD01888A6303A8C3C2056209A9 /* String+SourceKitten.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+SourceKitten.swift"; path = "Source/SourceKittenFramework/String+SourceKitten.swift"; sourceTree = "<group>"; };
+		C4675108A8CCBD654FBC27C4AB7054C2 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
+		C4D2CCE82E1834F02896039E01A68C6B /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
+		C56F3EDBF4E0080BD8DE0B6888C89B0F /* SourceKittenFramework.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SourceKittenFramework.xcconfig; sourceTree = "<group>"; };
+		C603340285CA7C6CDEF084D3E2F8CA85 /* SourceDeclaration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceDeclaration.swift; path = Source/SourceKittenFramework/SourceDeclaration.swift; sourceTree = "<group>"; };
+		C6854B654588CAE315C2957FFDA593BD /* XCWorkspaceData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceData.swift; path = Sources/xcproj/XCWorkspaceData.swift; sourceTree = "<group>"; };
+		C71AE4A4EEE20E5A2FC29E20B24C0BC3 /* Variable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Variable.swift; path = Sources/Variable.swift; sourceTree = "<group>"; };
+		C73A303C46F3F862C25F7F261EA36A4D /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
 		C75E6707D21847CB10B82A5B60CCDDA1 /* Pods-SourceryJS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryJS.release.xcconfig"; sourceTree = "<group>"; };
-		C83F42744F3811C0B8A341602F52F4AE /* XCWorkspaceDataElementLocationType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataElementLocationType.swift; path = Sources/xcproj/XCWorkspaceDataElementLocationType.swift; sourceTree = "<group>"; };
-		C86E786690D5CA5323D9D057B88B8BCA /* library_wrapper_Documentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper_Documentation.swift; path = Source/SourceKittenFramework/library_wrapper_Documentation.swift; sourceTree = "<group>"; };
+		C8681C5C69A18640B47D67D8E0F0857F /* ArgumentConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArgumentConvertible.swift; path = Sources/Commander/ArgumentConvertible.swift; sourceTree = "<group>"; };
+		C87A9B0633680E89DAAB3758DEA40C9D /* BuildSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = BuildSystem.h; path = Source/Clang_C/include/BuildSystem.h; sourceTree = "<group>"; };
 		C8E2C9A56C3322A05D2B144A56E038B9 /* Pods-SourceryUtils-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SourceryUtils-acknowledgements.markdown"; sourceTree = "<group>"; };
-		C90556615C47011E9D9BD379B34EB2D8 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
-		C922F01C57C683504FABB2D63E6E0A0E /* Dictionary+Extras.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extras.swift"; path = "Sources/xcproj/Dictionary+Extras.swift"; sourceTree = "<group>"; };
-		C92D003728236DBB5E15F5D4C99D3DFD /* XCConfigurationList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCConfigurationList.swift; path = Sources/xcproj/XCConfigurationList.swift; sourceTree = "<group>"; };
-		C9B665D10CA3739672253EE7BAAC75E7 /* shim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = shim.swift; path = Source/SourceKittenFramework/shim.swift; sourceTree = "<group>"; };
-		CA7645CB90A27AC2B00EB1E997010F57 /* PBXProjObjects+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PBXProjObjects+Helpers.swift"; path = "Sources/xcproj/PBXProjObjects+Helpers.swift"; sourceTree = "<group>"; };
-		CA9D897FA60D583E597EB8FDA7A01148 /* Element.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Element.swift; path = Sources/AEXML/Element.swift; sourceTree = "<group>"; };
+		C948D65F9BF004850F65FDD9C1D55238 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
+		C9E8353831309132DB8AD563989192C8 /* XCWorkspaceDataFileRef.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataFileRef.swift; path = Sources/xcproj/XCWorkspaceDataFileRef.swift; sourceTree = "<group>"; };
+		CA53A1FF8052C6F70BCA344624C6015F /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
+		CA791A6EEC25E40FCE158A68580EC2F2 /* SourceKittenFramework.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SourceKittenFramework.modulemap; sourceTree = "<group>"; };
+		CAA86889C80EF4E033C9C848E7B1B65B /* PBXObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXObject.swift; path = Sources/xcproj/PBXObject.swift; sourceTree = "<group>"; };
 		CAD70781ECBFDA2794B309661F2CEE57 /* Pods-SourceryFramework-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SourceryFramework-dummy.m"; sourceTree = "<group>"; };
-		CB84142A76513C17533CB6F6C04AEB0A /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
-		CB9CDA6191946FBA1E9882F4A96E91FE /* PBXProjError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProjError.swift; path = Sources/xcproj/PBXProjError.swift; sourceTree = "<group>"; };
-		CBD06437C20B04A8D508E39EF1FB79BC /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "KeyedDecodingContainer+Additions.swift"; path = "Sources/xcproj/KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
-		CC3B91A3A38F895FC38532700B223815 /* UID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UID.swift; path = Source/SourceKittenFramework/UID.swift; sourceTree = "<group>"; };
-		CCA6DA2739C00AE8AAB56B2B4B6BE41D /* Environment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Environment.swift; path = Sources/Environment.swift; sourceTree = "<group>"; };
-		CCEEA040ADC36DED371505E82B97E0B9 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
-		CD8EF75B2223937F2DDE31B173227623 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
-		CE43F487478A99E4B5F6F69E26B11B17 /* library_wrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = library_wrapper.swift; path = Source/SourceKittenFramework/library_wrapper.swift; sourceTree = "<group>"; };
-		CE483A1BE7235E4C11CCD9D132AF093F /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
+		CB141316ECEC7EF5C2DEBA446C671A35 /* XCWorkspaceDataGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataGroup.swift; path = Sources/xcproj/XCWorkspaceDataGroup.swift; sourceTree = "<group>"; };
+		CC0EA486EBFC79426031555D128D5FD3 /* SwiftIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftIdentifier.swift; path = Sources/StencilSwiftKit/SwiftIdentifier.swift; sourceTree = "<group>"; };
+		CC841FA257A928A8870849338198F5DA /* NowTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NowTag.swift; path = Sources/NowTag.swift; sourceTree = "<group>"; };
+		CCE82CB6DD2CCB8C890A2B58613340C3 /* Commander-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Commander-umbrella.h"; sourceTree = "<group>"; };
+		CE094C28A56B2166361BC09BF4040E6D /* ForTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ForTag.swift; path = Sources/ForTag.swift; sourceTree = "<group>"; };
+		CE346E383BCE6F0117BDDEA5F008DFE6 /* SourceKittenFramework-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SourceKittenFramework-umbrella.h"; sourceTree = "<group>"; };
 		CE6B3E2E49C1A127925D37946C688290 /* Pods-Sourcery-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Sourcery-acknowledgements.markdown"; sourceTree = "<group>"; };
-		CE7249B16A82DD696BFA3C7C70B59E3A /* NowTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NowTag.swift; path = Sources/NowTag.swift; sourceTree = "<group>"; };
 		CEFBB7466778E06C1BFC53FC5B67A0A4 /* Pods-SourcerySwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourcerySwift.debug.xcconfig"; sourceTree = "<group>"; };
+		CF157A94145675FCAB9B84EC03A01DBE /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
 		D0211CB52469DB3DE38DDF2935B957CF /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		D05CC6E6A995325E9D386E3B2FDE0FC7 /* PBXSourcesBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXSourcesBuildPhase.swift; path = Sources/xcproj/PBXSourcesBuildPhase.swift; sourceTree = "<group>"; };
-		D06BB4BAB3185269CC71624E254968EB /* PBXFileReference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXFileReference.swift; path = Sources/xcproj/PBXFileReference.swift; sourceTree = "<group>"; };
-		D0B864172123704FCFAF3AAE755225CB /* Document.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Document.swift; path = Sources/AEXML/Document.swift; sourceTree = "<group>"; };
-		D0F619B455A59CD9A00A0E71CF454DFB /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
-		D15AF46B1EE374DBDC6FD146C694052C /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
 		D18E937B4749B63452E1AE18C50D2AD8 /* Pods-SourceryUtils-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryUtils-acknowledgements.plist"; sourceTree = "<group>"; };
-		D1E4793FDD9B7EF8E09E839FA82DF04C /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
-		D1EEA18E28CE549A4A778F719637A351 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
-		D26E3C20FE91C1E2648367DA27E82849 /* SyntaxKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyntaxKind.swift; path = Source/SourceKittenFramework/SyntaxKind.swift; sourceTree = "<group>"; };
-		D3681FC401FC223BE8B1A75D8558D903 /* Commander.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Commander.modulemap; sourceTree = "<group>"; };
+		D1F1960B83B53A9E3DC7EB808A65ACBD /* BuildSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildSettings.swift; path = Sources/xcproj/BuildSettings.swift; sourceTree = "<group>"; };
+		D20C035F391F5A4BBEF2E37DB2215FD4 /* XCWorkspace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspace.swift; path = Sources/xcproj/XCWorkspace.swift; sourceTree = "<group>"; };
+		D2E669B1637A0F53943635C746AB5706 /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
 		D399F73A316B61034A5C05FBC0AD9AF6 /* Stencil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Stencil.framework; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D4E8409F1B4B1B8BC1C2E34C5E349134 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
-		D58A1287295B6B911238BFAF4CFB529B /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
-		D6545BF4A41DEFC6135774D20FB96260 /* PBXVariantGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXVariantGroup.swift; path = Sources/xcproj/PBXVariantGroup.swift; sourceTree = "<group>"; };
-		D77DAA13055ECF12D9BE59C7F962EEC9 /* CodeCompletionItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CodeCompletionItem.swift; path = Source/SourceKittenFramework/CodeCompletionItem.swift; sourceTree = "<group>"; };
-		D82BAEAB0C6CBF439D69467E09A01AA6 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Errors.swift; sourceTree = "<group>"; };
-		D864A9F7795746FBA7C4EC7E67295C25 /* Node.Mapping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.Mapping.swift; path = Sources/Yams/Node.Mapping.swift; sourceTree = "<group>"; };
-		D8915235F4B5593FE8CB345F8894173B /* PathKit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PathKit.swift; path = Sources/PathKit.swift; sourceTree = "<group>"; };
-		D89F9DB55352C44062C786AA4734D2C5 /* PBXProjEncoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProjEncoder.swift; path = Sources/xcproj/PBXProjEncoder.swift; sourceTree = "<group>"; };
-		D9BD0A0E134B61D2458372804651C782 /* ClangTranslationUnit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClangTranslationUnit.swift; path = Source/SourceKittenFramework/ClangTranslationUnit.swift; sourceTree = "<group>"; };
+		D548406E39D0C950B3148E9689318412 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		D57DD1A559732BAF33B0751F859838C2 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
+		D5BD296CA0134DA85EADBB14155AB85D /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		D6CADF5D9D71EA3DC8035961AC1222EB /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
+		D7986044B4C2171879E1A3278AAA1C58 /* PBXContainerItemProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXContainerItemProxy.swift; path = Sources/xcproj/PBXContainerItemProxy.swift; sourceTree = "<group>"; };
+		D7C4D2EBCFD4619585436A7FAAC11F49 /* Decoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Decoder.swift; path = Sources/Yams/Decoder.swift; sourceTree = "<group>"; };
+		D86A917AFC624894FB49DCD2F9E5BD1C /* SetNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SetNode.swift; path = Sources/StencilSwiftKit/SetNode.swift; sourceTree = "<group>"; };
+		D8BD6F629FF8501670E09ACA487A7E2B /* PBXTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXTarget.swift; path = Sources/xcproj/PBXTarget.swift; sourceTree = "<group>"; };
+		D9BBFD4D71EDE1BC59DF0A878A3CDFAB /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
+		DACF398DB7DF863AAC927F36E4CE0329 /* Structure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Structure.swift; path = Source/SourceKittenFramework/Structure.swift; sourceTree = "<group>"; };
 		DAF8B317DFDF016F29860E4549E7AE90 /* Pods-SourceryJS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryJS.debug.xcconfig"; sourceTree = "<group>"; };
-		DC919B132CFD067415D999CBB690867A /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
-		DCB2AB2E90E9E28D76F238AAF0938CCF /* writer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = writer.c; path = Sources/CYaml/src/writer.c; sourceTree = "<group>"; };
-		DD3D0599D67F5814B5C61A4D67EC22AC /* PathKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PathKit.xcconfig; sourceTree = "<group>"; };
-		DE2874AF9DF818105E8416A160FD5113 /* Options.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Options.swift; path = Sources/AEXML/Options.swift; sourceTree = "<group>"; };
-		DECEBDEBD1453734849D83A03665D85B /* AEXML-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AEXML-prefix.pch"; sourceTree = "<group>"; };
-		DF9AE190591194C88B74C31BFE071AE3 /* AEXML-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AEXML-dummy.m"; sourceTree = "<group>"; };
-		E044078E15CF9AC524696234B51E0637 /* LinuxCompatibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LinuxCompatibility.swift; path = Source/SourceKittenFramework/LinuxCompatibility.swift; sourceTree = "<group>"; };
-		E121DDBE119662141438479A7AB91AFA /* XCWorkspaceDataFileRef.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspaceDataFileRef.swift; path = Sources/xcproj/XCWorkspaceDataFileRef.swift; sourceTree = "<group>"; };
-		E1FDB2F5242C6AD138ABFC3B4571EB3C /* PBXTargetDependency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXTargetDependency.swift; path = Sources/xcproj/PBXTargetDependency.swift; sourceTree = "<group>"; };
-		E265DDAEF41849BFBFEA3429F4D255AA /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
+		DC536B7ED5C3A1B78F5F23AD0A2975D2 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
+		DC5B1F188D237D7925092A772AF58A64 /* Commander.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Commander.modulemap; sourceTree = "<group>"; };
+		DD3B83AE7AF5A5CD29A843FBEEC43A03 /* SWXMLHash-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "SWXMLHash-Info.plist"; sourceTree = "<group>"; };
+		DDB430B1ABD157C3B664036F5BD6A2E0 /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
+		DF4357BB240F1789713BB70B06818909 /* PBXContainerItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXContainerItem.swift; path = Sources/xcproj/PBXContainerItem.swift; sourceTree = "<group>"; };
+		DF7883F44838153A966BB457DFBE865A /* Writable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Writable.swift; path = Sources/xcproj/Writable.swift; sourceTree = "<group>"; };
+		E154FC4DD574CA54F8E375466873E9D4 /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Resolver.swift; path = Sources/Yams/Resolver.swift; sourceTree = "<group>"; };
+		E199270F45434E40032A42DB68D234B4 /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
+		E234C5490AF52AC1EBB9598C8CF1A3AD /* Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Extension.swift; path = Sources/Extension.swift; sourceTree = "<group>"; };
+		E2685F20E55B0CBB29554B433A6B067A /* yaml.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yaml.h; path = Sources/CYaml/include/yaml.h; sourceTree = "<group>"; };
 		E285FF83213CB9F241956FDD95032375 /* Pods-SourcerySwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourcerySwift.release.xcconfig"; sourceTree = "<group>"; };
 		E2CC4B2024D96FD77C8EE85163FDB388 /* Pods_SourceryTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SourceryTests.framework; path = "Pods-SourceryTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2D643202F781CF3B4801F9E9770CC3E /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/AEXML/Error.swift; sourceTree = "<group>"; };
+		E30C396EAA660FA5BB5720BAE611D83C /* MatcherFunc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherFunc.swift; path = Sources/Nimble/Matchers/MatcherFunc.swift; sourceTree = "<group>"; };
+		E396312C669D85CFB73C073295DD1B2A /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Decodable+Dictionary.swift"; path = "Sources/xcproj/Decodable+Dictionary.swift"; sourceTree = "<group>"; };
+		E3F74AF8F8400AE4D6A2816F90520629 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h; sourceTree = "<group>"; };
 		E45EE152BC185B6844092552B2D19283 /* Pods-SourcerySwift-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourcerySwift-Info.plist"; sourceTree = "<group>"; };
-		E474360C0B9B8FCD59FD41E27AA917CA /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
 		E4B61DDEAFC2DB69E9C19BD87472D00A /* Pods-SourcerySwift-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourcerySwift-acknowledgements.plist"; sourceTree = "<group>"; };
-		E61D38AF942509E9201C2AA77D850075 /* XCWorkspace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCWorkspace.swift; path = Sources/xcproj/XCWorkspace.swift; sourceTree = "<group>"; };
+		E591F7FB4DFCB4B84C9E0D1661120A87 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
+		E5E7F55A7F9EA55D4CDFC942B8C552B1 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
+		E691BC0943758341AEC4E0B9E8206091 /* Index.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Index.h; path = Source/Clang_C/include/Index.h; sourceTree = "<group>"; };
+		E6D58E8E3711D7F3BD2E8F1FCAED1C86 /* String+Yams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Yams.swift"; path = "Sources/Yams/String+Yams.swift"; sourceTree = "<group>"; };
+		E73FD141C233CFDDA2496E400261789B /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
 		E765E3E604B1FF4478CD9DCCA1BCDB51 /* Pods-SourceryFramework-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SourceryFramework-acknowledgements.markdown"; sourceTree = "<group>"; };
-		E79BB67C8F1276973939340AACB6591A /* YamlError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = YamlError.swift; path = Sources/Yams/YamlError.swift; sourceTree = "<group>"; };
-		E7A0D4145C9E1429398168DCEDCBAEB2 /* Clang+SourceKitten.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Clang+SourceKitten.swift"; path = "Source/SourceKittenFramework/Clang+SourceKitten.swift"; sourceTree = "<group>"; };
-		E84D33BAF0F491D5AEFE97B53AB18454 /* CYaml.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CYaml.h; path = Sources/CYaml/include/CYaml.h; sourceTree = "<group>"; };
+		E7929A05EFBF1B6D0976A01B86C926D3 /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
 		E89B0ED7DD1CA3684078BF136BD497E2 /* Pods-SourceryJS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourceryJS-acknowledgements.plist"; sourceTree = "<group>"; };
-		E8B437058791C226D47D3FC34F915545 /* XCBuildConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCBuildConfiguration.swift; path = Sources/xcproj/XCBuildConfiguration.swift; sourceTree = "<group>"; };
-		E8F5E4DA24732B6AD19F6DE8D6882A52 /* Stencil-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Stencil-umbrella.h"; sourceTree = "<group>"; };
-		E987A7407635A743DF10A31071A932BD /* Yams.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Yams.modulemap; sourceTree = "<group>"; };
-		E99239F198074863873476B7D14412AC /* SWXMLHash-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SWXMLHash-umbrella.h"; sourceTree = "<group>"; };
-		E9A1A1F89C6828F37C81C123404DAA12 /* Yams-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Yams-Info.plist"; sourceTree = "<group>"; };
-		EB43CC6B8961A67EB7228452C71BCA92 /* XCVersionGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCVersionGroup.swift; path = Sources/xcproj/XCVersionGroup.swift; sourceTree = "<group>"; };
-		EBB22B278F84EA92C2A8988C226D2BAE /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
-		EECE42F8B397AB7CDE5F0E6A3BF4F0E3 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
-		EEDC60111B661A45F613AE63CDBD6C78 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
+		E93D7B4B53B6DB72A04217820C2DC1EA /* xcproj-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "xcproj-dummy.m"; sourceTree = "<group>"; };
+		ED25C511E54A20108EA2153859BA9094 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
+		EE3F8D2F517630E4E38ACAAF7557256C /* SourceKitObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceKitObject.swift; path = Source/SourceKittenFramework/SourceKitObject.swift; sourceTree = "<group>"; };
 		F0274C88F3C23370C32398E304619505 /* PathKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PathKit.framework; path = PathKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F0F358757C92386AFCE20D3329EFD8FC /* SwiftDeclarationAttributeKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftDeclarationAttributeKind.swift; path = Source/SourceKittenFramework/SwiftDeclarationAttributeKind.swift; sourceTree = "<group>"; };
+		F0DA4D7D26C640FE21EA0CA8C84DD9CC /* Node.Scalar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.Scalar.swift; path = Sources/Yams/Node.Scalar.swift; sourceTree = "<group>"; };
+		F0E6E8C6D9E278CC973E855B38529B8D /* StencilSwiftKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "StencilSwiftKit-dummy.m"; sourceTree = "<group>"; };
 		F1044C484AE4C092BF0DC41D762F2C0C /* Pods-SourceryUtils.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourceryUtils.debug.xcconfig"; sourceTree = "<group>"; };
-		F1282F8D5254839B2545FBD3406476CE /* Writable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Writable.swift; path = Sources/xcproj/Writable.swift; sourceTree = "<group>"; };
 		F156B8C4EA48BD576F334B6313D5519E /* Pods-TemplatesTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TemplatesTests-umbrella.h"; sourceTree = "<group>"; };
-		F1B0592F4B9CB2196EA8F47689CC0469 /* AEXML.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AEXML.modulemap; sourceTree = "<group>"; };
-		F2DC6228F47860320F6F4C4DF312E6BD /* Language.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Language.swift; path = Source/SourceKittenFramework/Language.swift; sourceTree = "<group>"; };
-		F2E65D62CD2C21A669D961D5B68FAD71 /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Resolver.swift; path = Sources/Yams/Resolver.swift; sourceTree = "<group>"; };
-		F33479BE1FE58E94688F5EE54E6EFAB6 /* Encoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Encoder.swift; path = Sources/Yams/Encoder.swift; sourceTree = "<group>"; };
-		F3B0A7421D12D76EF050348023C7D813 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
-		F573901AF13F0E0EF143310AC7F5D9F9 /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
-		F5B25C0463A934A6315CE00A44B9009E /* Tag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Tag.swift; path = Sources/Yams/Tag.swift; sourceTree = "<group>"; };
-		F5C1CCB1B732E1F1EADAD88B59225CE9 /* PathKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PathKit-dummy.m"; sourceTree = "<group>"; };
-		F5C3AE8D17836380139E081732390885 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
-		F699C6B7A3515AEEB8B048C8C44F5AAA /* emitter.c */ = {isa = PBXFileReference; includeInIndex = 1; name = emitter.c; path = Sources/CYaml/src/emitter.c; sourceTree = "<group>"; };
-		F75B4B308B344BA187EAA9DBDD94EC9C /* SourceKittenFramework.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SourceKittenFramework.modulemap; sourceTree = "<group>"; };
-		F799158A78693CE3DDB056F1C9DFD5B9 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
-		F82337671DE84A5CDB73CE67D6808A2B /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
-		F8264855112B3E35985270903400F81F /* MapNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapNode.swift; path = Sources/StencilSwiftKit/MapNode.swift; sourceTree = "<group>"; };
+		F28FDC0C5809EDF7D5867823B3D4689B /* Include.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Include.swift; path = Sources/Include.swift; sourceTree = "<group>"; };
+		F32EA9241C6B88939BA00B98DBA1453F /* PBXProj.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXProj.swift; path = Sources/xcproj/PBXProj.swift; sourceTree = "<group>"; };
+		F342B0918ABA45D405009CF98D78FB7B /* XCScheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCScheme.swift; path = Sources/xcproj/XCScheme.swift; sourceTree = "<group>"; };
+		F34A607D23E520311D5FB2AA94A4A4AD /* Context.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Context.swift; path = Sources/Context.swift; sourceTree = "<group>"; };
+		F44719B431957647278C9C274C0CEE58 /* SWXMLHash+TypeConversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SWXMLHash+TypeConversion.swift"; path = "Source/SWXMLHash+TypeConversion.swift"; sourceTree = "<group>"; };
+		F4489EA2029BA75698245FEF0391A3F1 /* ObjCDeclarationKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjCDeclarationKind.swift; path = Source/SourceKittenFramework/ObjCDeclarationKind.swift; sourceTree = "<group>"; };
+		F507997DE78AA048FB013D8C035C6382 /* PBXBuildPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXBuildPhase.swift; path = Sources/xcproj/PBXBuildPhase.swift; sourceTree = "<group>"; };
+		F5109351B112682BDE28A756394713AB /* SwiftDocs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftDocs.swift; path = Source/SourceKittenFramework/SwiftDocs.swift; sourceTree = "<group>"; };
+		F573E2FE76FA8E3558ECDD3C19F2E453 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
+		F69C4424FAE88671945425007BAAA258 /* Stencil-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Stencil-prefix.pch"; sourceTree = "<group>"; };
+		F82B20DCED350CF321B30A93A67A9245 /* XCBuildConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCBuildConfiguration.swift; path = Sources/xcproj/XCBuildConfiguration.swift; sourceTree = "<group>"; };
 		F8F72ED6A8311FA14760E026F1CD586A /* Pods-Sourcery-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Sourcery-umbrella.h"; sourceTree = "<group>"; };
+		F9DDF557D7ADB4E46279A7721464D64F /* CallMacroNodes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CallMacroNodes.swift; path = Sources/StencilSwiftKit/CallMacroNodes.swift; sourceTree = "<group>"; };
+		F9FC39B394CCA10A79B741170B3FACCD /* SWXMLHash.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SWXMLHash.modulemap; sourceTree = "<group>"; };
+		F9FEDC5CF1150B66BE9C52C34B9356C2 /* PBXBuildRule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBXBuildRule.swift; path = Sources/xcproj/PBXBuildRule.swift; sourceTree = "<group>"; };
+		FA0E96B1AEAAE2903E43628062F67A6E /* Filters+Strings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Filters+Strings.swift"; path = "Sources/StencilSwiftKit/Filters+Strings.swift"; sourceTree = "<group>"; };
+		FA2B526E6D1095B48CFD04B52224C6DD /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
 		FA4F25F6E863DAA79B9A7DE3A62B385B /* Pods-SourceryTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SourceryTests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		FA4FA4043FB75E62C84F49D5950697AE /* Group.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Group.swift; path = Sources/Commander/Group.swift; sourceTree = "<group>"; };
+		FBBBA263EE53B2C94366E441A22CB4D4 /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
 		FBBEEEC02002438012A01646CE86409C /* Yams.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Yams.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FC180E84CAD74CEDF65751E028D42C1B /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
-		FC87F667C36C105F9A93C51DAAEB1CA4 /* IfTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IfTag.swift; path = Sources/IfTag.swift; sourceTree = "<group>"; };
-		FDD578CB1A0530161F0746FF3F65BC0E /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
+		FC5CB58922C0843CF71F3DB93AD04081 /* Yams.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Yams.xcconfig; sourceTree = "<group>"; };
+		FCBB0808CDFB1454167D96C962FE70DB /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
 		FDD9E9CDCFE937FF2C8EAB27F50C6AC0 /* Pods-SourceryJS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourceryJS-umbrella.h"; sourceTree = "<group>"; };
-		FDE2760C6D9487BA6DF67EF3F27551CB /* SetNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SetNode.swift; path = Sources/StencilSwiftKit/SetNode.swift; sourceTree = "<group>"; };
-		FEA8D981E028EA1D8875942F66D1CC13 /* SourceKittenFramework-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SourceKittenFramework-prefix.pch"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1075,14 +1077,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7ECF1F6EDEC4C7354B0C6D5B2DCE5B7E /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8EFEC7DE8D9D8F72113B8C5107E46125 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FF0AF8CB78A281A62CBFA7B696995C8D /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1189,6 +1183,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E6B54F3471A343C63C3C9AAB30121A32 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				12555CF44BDE2DCB3011CC2005A562E8 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E8DD4B2A7741DB1D809E597B0456AE97 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1200,34 +1202,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		06C0043D26277CE0F42619910AD9E07A /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				D3681FC401FC223BE8B1A75D8558D903 /* Commander.modulemap */,
-				B030415E7290E7829C1A40D6CF40CA21 /* Commander.xcconfig */,
-				B0C186AB6A651C1AA36E1D4D4B72621C /* Commander-dummy.m */,
-				1D64E4A688C9E2298D43DC0FD051F411 /* Commander-Info.plist */,
-				5D4D73A5111113A2B575FE2295C62237 /* Commander-prefix.pch */,
-				C53AFDB65DB8537F74FF1D4B5D0E7CAF /* Commander-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Commander";
-			sourceTree = "<group>";
-		};
-		07935ED61DACB8426444D9AC3DF5679E /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				224D3B9C5F1D50A3565FFCDA32C3006A /* Quick.modulemap */,
-				6FE9D6ED53B6D6760800E1132AA84D64 /* Quick.xcconfig */,
-				458589868B4454B760A68D39CBC6922A /* Quick-dummy.m */,
-				A3335214CF90C999095CE68C39C946CA /* Quick-Info.plist */,
-				2F86057931001BAA8C7B11842AB87620 /* Quick-prefix.pch */,
-				9DC357A14C7A15C85E4BDF56E9FD41BA /* Quick-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Quick";
-			sourceTree = "<group>";
-		};
 		07D49BC500E269D5BE176045AC4629CA /* Pods-TemplatesTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1245,165 +1219,18 @@
 			path = "Target Support Files/Pods-TemplatesTests";
 			sourceTree = "<group>";
 		};
-		0F3878E3243FC373DC3B61D1CBE0C479 /* StencilSwiftKit */ = {
+		189861EDC6128DFFA899256FFF38BABB /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				C3A999F8A82D861064F2044A0698B64C /* CallMacroNodes.swift */,
-				8AAEF487A8F518B2554778FF0112ADBF /* Context.swift */,
-				68DBB5AB0439D4E5124A15479732A19F /* Environment.swift */,
-				86E7458F33BE6B49E441EB99D1E66E41 /* Filters.swift */,
-				121825A360455D76E9D30380D46078C4 /* Filters+Numbers.swift */,
-				0EEF742C448CFA02719FF525409C7764 /* Filters+Strings.swift */,
-				F8264855112B3E35985270903400F81F /* MapNode.swift */,
-				15127D3B993D223E4402D112A406DAB9 /* Parameters.swift */,
-				FDE2760C6D9487BA6DF67EF3F27551CB /* SetNode.swift */,
-				B41B4237BC69B6EF17DB486776767990 /* StencilSwiftTemplate.swift */,
-				7748EDF5B0EFD7D513FB06EC2A6E9403 /* SwiftIdentifier.swift */,
-				60664974D5169D1B4FF834F466363236 /* Support Files */,
-			);
-			name = StencilSwiftKit;
-			path = StencilSwiftKit;
-			sourceTree = "<group>";
-		};
-		10830DC4CDC099AD67648E28A9AF9DE7 /* Nimble */ = {
-			isa = PBXGroup;
-			children = (
-				72F8B81DEBDBDB660D7D778BEDA07D09 /* AdapterProtocols.swift */,
-				B994AA2115476FFB2EC30EAED7BD1B63 /* AllPass.swift */,
-				69AA80704FE1E390E7E6EAD1C23DA8BA /* AssertionDispatcher.swift */,
-				2595AEAC3BCC5B1F193B53860D9DE182 /* AssertionRecorder.swift */,
-				A0E1962A587D8F2DF0332E485886E945 /* Async.swift */,
-				1B0C16B33DB1779E2885DD4CA756190B /* Await.swift */,
-				7C11694083C15CAC1DBF387D858BD3B7 /* BeAKindOf.swift */,
-				EBB22B278F84EA92C2A8988C226D2BAE /* BeAnInstanceOf.swift */,
-				37F7BBC72F0154D4CE641A89094DE603 /* BeCloseTo.swift */,
-				D0F619B455A59CD9A00A0E71CF454DFB /* BeEmpty.swift */,
-				F5C3AE8D17836380139E081732390885 /* BeginWith.swift */,
-				0BCA4105AC7D57E92315742675842F15 /* BeGreaterThan.swift */,
-				9BBC2DABCB8CBBA98357EB57930FBA78 /* BeGreaterThanOrEqualTo.swift */,
-				6A61E20043C98596109322663E3EBCA4 /* BeIdenticalTo.swift */,
-				C7392EE5BE7C9E6F293892057AD48657 /* BeLessThan.swift */,
-				3DE6D72119440C7F729857E02A35F2EF /* BeLessThanOrEqual.swift */,
-				9ECC71F7DED24BF46E1F384A08BE6A20 /* BeLogical.swift */,
-				2A01C37F8242E71819A97E11B6F0294E /* BeNil.swift */,
-				4D2AFD8C82D28185EFC76414D217BD9C /* BeVoid.swift */,
-				16CF383036BF7BD1336D99F3DC75E11A /* Contain.swift */,
-				8F7609175A5C8067D4BF812B6E986F9C /* ContainElementSatisfying.swift */,
-				AD06D865DFBCD695CF7BD134BFADD0B5 /* CwlBadInstructionException.swift */,
-				215F87888AB476DEA27760112E4476BA /* CwlCatchBadInstruction.swift */,
-				B8C9839DEE4610A4DB3CA2F137C28774 /* CwlCatchException.h */,
-				4A1DBA8FEA298575651AA7C04EC4E382 /* CwlCatchException.m */,
-				00A24E557109A736FAE3D8E3386937BB /* CwlCatchException.swift */,
-				13D49F4649317E86B0BF5806DFA59773 /* CwlDarwinDefinitions.swift */,
-				CD8EF75B2223937F2DDE31B173227623 /* CwlMachBadInstructionHandler.h */,
-				930614056B1E73896FC3334A2A5893B4 /* CwlMachBadInstructionHandler.m */,
-				6BC9501038F61F601936078AF117C4A6 /* CwlPreconditionTesting.h */,
-				AAA52AA7D10C2DB34B157CB99590BCCC /* DSL.h */,
-				737D0EE3EC612F9D3DB132F72D59D8FC /* DSL.m */,
-				F3B0A7421D12D76EF050348023C7D813 /* DSL.swift */,
-				402F261F96EF3BFAD7E7718CAE1B5AB0 /* DSL+Wait.swift */,
-				AD233B046D1101ED9AC6F11964527700 /* EndWith.swift */,
-				349E0C80560F37F1B2A0F5C237E0BC41 /* Equal.swift */,
-				A0A9E730385794274DE40C9F1BAD543F /* Errors.swift */,
-				78348A371E1D2833CE251DF5EF58052E /* Expectation.swift */,
-				7E3891F76F0BF44385AC30B6C1129DB9 /* ExpectationMessage.swift */,
-				29F4B0D34F8E7EFD91FEA05E46E24EE5 /* Expression.swift */,
-				051EB1331381FD568472DB8DC67F3BEF /* FailureMessage.swift */,
-				614CB9CC906E39FED732700FAA033F5E /* Functional.swift */,
-				CCEEA040ADC36DED371505E82B97E0B9 /* HaveCount.swift */,
-				6C651386D5A6F392BE0C580DAC94A51B /* mach_excServer.c */,
-				A6EB0E53947D176E894C5B2D1CA7EE9D /* mach_excServer.h */,
-				E474360C0B9B8FCD59FD41E27AA917CA /* Match.swift */,
-				86657F955ED624F632751451403157CD /* MatcherFunc.swift */,
-				E265DDAEF41849BFBFEA3429F4D255AA /* MatcherProtocols.swift */,
-				C46BBC6D42701827772C10C342891F00 /* MatchError.swift */,
-				A8231D4EF1852B83481A2C35F3C85115 /* Nimble.h */,
-				330EBD708AE6DF6853E09121B6C3CB60 /* NimbleEnvironment.swift */,
-				D4E8409F1B4B1B8BC1C2E34C5E349134 /* NimbleXCTestHandler.swift */,
-				4A5A10FE91A9D3DB3AEF2CF52976BE04 /* NMBExceptionCapture.h */,
-				743DE2C453FC27A0D319CCCB7613743F /* NMBExceptionCapture.m */,
-				D1EEA18E28CE549A4A778F719637A351 /* NMBExpectation.swift */,
-				D58A1287295B6B911238BFAF4CFB529B /* NMBObjCMatcher.swift */,
-				3845CCC21459E679A858FBF5D7EC1501 /* NMBStringify.h */,
-				5E06747E57A600C09E53C52398349DAE /* NMBStringify.m */,
-				A3BFCB717681FABCD52E7E521A8885BF /* PostNotification.swift */,
-				8A610346F082C6EFC756FC490E66CB6B /* Predicate.swift */,
-				34E3D33954C5BC9890F78A2B4B79D942 /* RaisesException.swift */,
-				6B6F189BA4D1A62680E4B1B69193F002 /* SatisfyAllOf.swift */,
-				0631987778343A27B02CBEA909528F3F /* SatisfyAnyOf.swift */,
-				6E17333EC12616FEE1DCC33CC1325743 /* SourceLocation.swift */,
-				B313ECCDB14FD79AC6BFB415BB0F959F /* Stringers.swift */,
-				3832F6CA61EE011754BEABC4B20198CB /* ThrowAssertion.swift */,
-				DC919B132CFD067415D999CBB690867A /* ThrowError.swift */,
-				AE275577630A5584534B7E7C643D9835 /* ToSucceed.swift */,
-				EEDC60111B661A45F613AE63CDBD6C78 /* XCTestObservationCenter+Register.m */,
-				12A3F53458F82EDE2D63D348114B49F3 /* Support Files */,
-			);
-			name = Nimble;
-			path = Nimble;
-			sourceTree = "<group>";
-		};
-		12A3F53458F82EDE2D63D348114B49F3 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				71EF8ECD799B5D2FCC44CD976F73E9CF /* Nimble.modulemap */,
-				44697B5A6E94CE42393A5A5267BB5128 /* Nimble.xcconfig */,
-				FDD578CB1A0530161F0746FF3F65BC0E /* Nimble-dummy.m */,
-				8313C7659E1AB4F9E2CCCFCF26E7D2C8 /* Nimble-Info.plist */,
-				8C8F794C5E8EA988E6C3B1A81EA215F7 /* Nimble-prefix.pch */,
-				BD2DB45369BE988EB5E3290A29AB381A /* Nimble-umbrella.h */,
+				2083552968181B40CB1DB43EC510B54E /* Stencil.modulemap */,
+				7B66B070F558C8D96591917995D5090C /* Stencil.xcconfig */,
+				428CEBBC652516B043D1FED31EF1B276 /* Stencil-dummy.m */,
+				744FF4C8CACC10E026C4B8C5941FE38A /* Stencil-Info.plist */,
+				F69C4424FAE88671945425007BAAA258 /* Stencil-prefix.pch */,
+				4A42E3E0B61C0DE2C5799AD4BC054AC1 /* Stencil-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/Nimble";
-			sourceTree = "<group>";
-		};
-		1FE6736C4DAEFF41B903440A847753CB /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				F1B0592F4B9CB2196EA8F47689CC0469 /* AEXML.modulemap */,
-				10CEA2F11A704911B4DF5C348861887F /* AEXML.xcconfig */,
-				DF9AE190591194C88B74C31BFE071AE3 /* AEXML-dummy.m */,
-				ADDEF5FA01F5DADFC0478F13D89E1AA4 /* AEXML-Info.plist */,
-				DECEBDEBD1453734849D83A03665D85B /* AEXML-prefix.pch */,
-				1FE1188F1B061BB0BD4350E0F7AD88B5 /* AEXML-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/AEXML";
-			sourceTree = "<group>";
-		};
-		257CE6D2021C527E5A9978BDAE4DA3AD /* Yams */ = {
-			isa = PBXGroup;
-			children = (
-				47C1E0158700AFAA9E7BEF3DE84D6EE0 /* api.c */,
-				9589331403E4DEBD9A7703CC8EBB399E /* Constructor.swift */,
-				E84D33BAF0F491D5AEFE97B53AB18454 /* CYaml.h */,
-				2812327BBDB24640DF1C3A4AF3AFBE3B /* Decoder.swift */,
-				F699C6B7A3515AEEB8B048C8C44F5AAA /* emitter.c */,
-				0E035CAE40FE5642B42CD21C080BD86B /* Emitter.swift */,
-				F33479BE1FE58E94688F5EE54E6EFAB6 /* Encoder.swift */,
-				B9B01949076F1547B435472A14561555 /* Mark.swift */,
-				7F2BB0DF0447B28C112C7F7DDE0416DC /* Node.swift */,
-				D864A9F7795746FBA7C4EC7E67295C25 /* Node.Mapping.swift */,
-				5301904B0430880CF863DC1D754BE28B /* Node.Scalar.swift */,
-				7C13932E3FD00DC6C06FA2809950BE3A /* Node.Sequence.swift */,
-				A2B51A6BC636B1115C5A162A9588B9B7 /* parser.c */,
-				46CECDBEA5625AFB00639CA391579D75 /* Parser.swift */,
-				7084B7BFF3FCF57B87E018FE057A1CF8 /* reader.c */,
-				2D46AC0283D38F2BDEA972AD1E845119 /* Representer.swift */,
-				F2E65D62CD2C21A669D961D5B68FAD71 /* Resolver.swift */,
-				918C549C317298F3E4C16B5603662316 /* scanner.c */,
-				9A204386D6FF280726EB1FABE9D15541 /* shim.swift */,
-				B2B46E0B6F9986A48ED38C876BFBEB63 /* String+Yams.swift */,
-				F5B25C0463A934A6315CE00A44B9009E /* Tag.swift */,
-				DCB2AB2E90E9E28D76F238AAF0938CCF /* writer.c */,
-				7D5E76231D541B6BDBD0694A75971BC6 /* yaml.h */,
-				49E11AAAA532F08C143C144FBC897663 /* yaml_private.h */,
-				E79BB67C8F1276973939340AACB6591A /* YamlError.swift */,
-				1C3FA0A338C0953A617B33994C148CE6 /* Yams.h */,
-				BDF2EA1A4106BC96773615FC11F23115 /* Support Files */,
-			);
-			name = Yams;
-			path = Yams;
+			path = "../Target Support Files/Stencil";
 			sourceTree = "<group>";
 		};
 		2F159B603FA3BF6C336A79F665E2AFAF /* Pods-SourceryJS */ = {
@@ -1448,76 +1275,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		370EAD5A7DC64ED75ADE6B549A4AE02D /* xcproj */ = {
-			isa = PBXGroup;
-			children = (
-				A7FBDEF172CE4AEC4591A23B451771C6 /* AEXML+XcodeFormat.swift */,
-				34B22DDBD2F986098454F0B048603572 /* Bool+Extras.swift */,
-				5BAE2596144518B71925CF66DE01102B /* BuildPhase.swift */,
-				56787D29D44834F3B2F2B0767D9093F9 /* BuildSettings.swift */,
-				6DE40819D1CE69A0C7B59ED67948FF45 /* CommentedString.swift */,
-				A7F14BF5E4B3082D8035D802DD81DA41 /* Decodable+Dictionary.swift */,
-				C922F01C57C683504FABB2D63E6E0A0E /* Dictionary+Extras.swift */,
-				92A58584447AD7CF6234686646644836 /* JSONDecoding.swift */,
-				CBD06437C20B04A8D508E39EF1FB79BC /* KeyedDecodingContainer+Additions.swift */,
-				6ECFF68AD5008800603D332189159D63 /* ObjectReference.swift */,
-				80A797EA0A1A0CDE6F427B699A18241A /* PBXAggregateTarget.swift */,
-				6669B5EC13B9CB5848658465DC782680 /* PBXBuildFile.swift */,
-				B9D3D92F70A685B232ABC6781DC52726 /* PBXBuildPhase.swift */,
-				AD20DD4C565C9D58FA179D4F033F238C /* PBXBuildRule.swift */,
-				AFD41892E8810AA35A18488D700A85A8 /* PBXContainerItem.swift */,
-				68C428DA4D589EF21D6CFCFB9D6F2E43 /* PBXContainerItemProxy.swift */,
-				A29D92F82B778344AF35BBE23B6DE521 /* PBXCopyFilesBuildPhase.swift */,
-				1966DF340DFC3C39CBACF2830E2F0150 /* PBXFileElement.swift */,
-				D06BB4BAB3185269CC71624E254968EB /* PBXFileReference.swift */,
-				B30522199DBCF74F2160AF50C37CBBB8 /* PBXFrameworksBuildPhase.swift */,
-				469A589CA2F94AE60393A5DB21FFA5F0 /* PBXGroup.swift */,
-				32234EFEF3A56F70B97A7AB03DEDA9B9 /* PBXHeadersBuildPhase.swift */,
-				8904C6ACC3569C21F951874EF301C037 /* PBXLegacyTarget.swift */,
-				BDD552233B9B5503D1F989CE3AB06BDE /* PBXNativeTarget.swift */,
-				002E04E0B6468B698ABF80D96DB0EB60 /* PBXObject.swift */,
-				086ADD308FBE51A4B27AE84423934070 /* PBXProductType.swift */,
-				B190854AFDC66912D57A546D3F5C0B14 /* PBXProj.swift */,
-				908E4BA247C8BED71D9A14CEAEEEB327 /* PBXProj+Helpers.swift */,
-				1F5C198567D5DB0873403F58ED415A33 /* PBXProject.swift */,
-				56373777FB1C28FA39AAA792711F0931 /* PBXProject+Deprecations.swift */,
-				D89F9DB55352C44062C786AA4734D2C5 /* PBXProjEncoder.swift */,
-				CB9CDA6191946FBA1E9882F4A96E91FE /* PBXProjError.swift */,
-				CA7645CB90A27AC2B00EB1E997010F57 /* PBXProjObjects+Helpers.swift */,
-				0F0C4697704B1853B1E47DB94A1BBB89 /* PBXReferenceProxy.swift */,
-				AC98B0092E4E82396DD4B76FD39712B6 /* PBXResourcesBuildPhase.swift */,
-				5B544727DAB6079C1B87855A79F2390E /* PBXRezBuildPhase.swift */,
-				B3510FD7EE673AFF1DD4938BAAE99E5B /* PBXShellScriptBuildPhase.swift */,
-				D05CC6E6A995325E9D386E3B2FDE0FC7 /* PBXSourcesBuildPhase.swift */,
-				85F073EE38FCAC3AFE15FE8F5BAD6585 /* PBXSourceTree.swift */,
-				AE2B1D4CD4103BAFAE3EA9B94C73ADC0 /* PBXTarget.swift */,
-				E1FDB2F5242C6AD138ABFC3B4571EB3C /* PBXTargetDependency.swift */,
-				D6545BF4A41DEFC6135774D20FB96260 /* PBXVariantGroup.swift */,
-				2F2EE40DC06775538A74A9613C2DB9AA /* PBXVariantGroup+Deprecations.swift */,
-				1877A03BCF290C780ECD69377D38E651 /* PlistValue.swift */,
-				87C0B31794B1ABE28DD9180F32B201AF /* Referenceable.swift */,
-				C06D0ECE52B3FBD54BE68F9966526A3B /* String+Extras.swift */,
-				F1282F8D5254839B2545FBD3406476CE /* Writable.swift */,
-				103533744DE5007DA2D31E812DCC64AF /* XCBreakpointList.swift */,
-				E8B437058791C226D47D3FC34F915545 /* XCBuildConfiguration.swift */,
-				A2E96AF77221F5589CE93229D97E5EB4 /* XCConfig.swift */,
-				C92D003728236DBB5E15F5D4C99D3DFD /* XCConfigurationList.swift */,
-				6D9F20F354004D3DCD2B94F7BB88CED8 /* XcodeProj.swift */,
-				13079FF13CE7BD8D8102F9B516FF7CD7 /* XCScheme.swift */,
-				2F9C560172035696B66B86D4D0D8C27B /* XCSharedData.swift */,
-				EB43CC6B8961A67EB7228452C71BCA92 /* XCVersionGroup.swift */,
-				E61D38AF942509E9201C2AA77D850075 /* XCWorkspace.swift */,
-				319EDECE568D42A1979073BAED5E28D0 /* XCWorkspaceData.swift */,
-				71F1E7057742CED3E437901DF8D17E23 /* XCWorkspaceDataElement.swift */,
-				C83F42744F3811C0B8A341602F52F4AE /* XCWorkspaceDataElementLocationType.swift */,
-				E121DDBE119662141438479A7AB91AFA /* XCWorkspaceDataFileRef.swift */,
-				039B28B0AD3B8FEEDAA82F74C6E6E434 /* XCWorkspaceDataGroup.swift */,
-				C5693BA59844188196A431F0C84E31A8 /* Support Files */,
-			);
-			name = xcproj;
-			path = xcproj;
-			sourceTree = "<group>";
-		};
 		3D835C82524DE093FB7CAFBBE2F6DDAC /* OS X */ = {
 			isa = PBXGroup;
 			children = (
@@ -1528,84 +1285,80 @@
 			name = "OS X";
 			sourceTree = "<group>";
 		};
-		429332F4822F16D694A883440F6B09C5 /* Pods */ = {
+		40D7CE6CEC1FFEE1E319AF4C6438ECCC /* SwiftLint */ = {
 			isa = PBXGroup;
 			children = (
-				4FEAA3C001482CFC9B1EE1C850B9379F /* AEXML */,
-				443D4BF47176E3D9D3B8903FE94E0A92 /* Commander */,
-				10830DC4CDC099AD67648E28A9AF9DE7 /* Nimble */,
-				D5F7F49F6EEA0598083FE63E6F3A3EAC /* PathKit */,
-				DC6AD165CA3FC5FE1A4F1FD83212E8D5 /* Quick */,
-				9CF1697D972230F097E9B4F06FD5ACC0 /* SourceKittenFramework */,
-				44F76A566E40F15A61D2819AE7710E32 /* Stencil */,
-				0F3878E3243FC373DC3B61D1CBE0C479 /* StencilSwiftKit */,
-				86A344F1C8D0DEDA4D6AD70BF510609A /* SwiftLint */,
-				F8F1EDBDCA18930E4EB4C9DA22338237 /* SWXMLHash */,
-				370EAD5A7DC64ED75ADE6B549A4AE02D /* xcproj */,
-				257CE6D2021C527E5A9978BDAE4DA3AD /* Yams */,
+				A4FABE42BC7E6108F92CD4A0773E6BF4 /* Support Files */,
 			);
-			name = Pods;
+			name = SwiftLint;
+			path = SwiftLint;
 			sourceTree = "<group>";
 		};
-		443D4BF47176E3D9D3B8903FE94E0A92 /* Commander */ = {
+		424665A961E4459DB062A8BD6D7C0E03 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				372D038E60EEF4F3260D111C1FA93221 /* ArgumentConvertible.swift */,
-				16B1542BF2F7A7DA7EF5AFE5493BAFDF /* ArgumentDescription.swift */,
-				BF31B6091EC0F6CF1052688292E3572C /* ArgumentParser.swift */,
-				C6ABD7DF77635B8EB76DBCD540ACD8A7 /* Command.swift */,
-				2427229E4492A722B7247F958D5EF4B2 /* CommandRunner.swift */,
-				502188CB5D01AFC592E9546FBF708413 /* Commands.swift */,
-				5EEE670C2712D66E4C9EA652AC8239AD /* CommandType.swift */,
-				4FA9896D8C8B9DDC35A782E13DC30D57 /* Error.swift */,
-				2CA285345A5B858D1BA50A4C747EF933 /* Group.swift */,
-				06C0043D26277CE0F42619910AD9E07A /* Support Files */,
+				4D60E3FD3376239C064B344949C7D17F /* xcproj.modulemap */,
+				5E691F87F3E6C35990223C9C2A8E054B /* xcproj.xcconfig */,
+				E93D7B4B53B6DB72A04217820C2DC1EA /* xcproj-dummy.m */,
+				99D9536FAFDE10451A504808ECBFA7D8 /* xcproj-Info.plist */,
+				2074B4C4A9D0036B09E35779F49AF48F /* xcproj-prefix.pch */,
+				784C42C8B774EBB778FB0F8041D5892C /* xcproj-umbrella.h */,
 			);
-			name = Commander;
-			path = Commander;
+			name = "Support Files";
+			path = "../Target Support Files/xcproj";
 			sourceTree = "<group>";
 		};
-		44F76A566E40F15A61D2819AE7710E32 /* Stencil */ = {
+		43147FE3CC74FE4AA87E3F49FAF4A089 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				0E19AF940019148F45F7D8F7B53C373D /* Context.swift */,
-				CCA6DA2739C00AE8AAB56B2B4B6BE41D /* Environment.swift */,
-				D82BAEAB0C6CBF439D69467E09A01AA6 /* Errors.swift */,
-				B4CE2479EF39C7D1551F41F553DEA07A /* Expression.swift */,
-				AF7EF8E3FD503FAE5D5068418202B38B /* Extension.swift */,
-				60C0A5280E31C8437E25B1687FD612E3 /* Filters.swift */,
-				21F2791B89C94B8A2D27E9EB37864733 /* FilterTag.swift */,
-				4CC5E0B5C0AEE1F4AD6DCC77A8C6B186 /* ForTag.swift */,
-				FC87F667C36C105F9A93C51DAAEB1CA4 /* IfTag.swift */,
-				049EDB5FB01A5CD8A0BE7A93A46B91AD /* Include.swift */,
-				231EA63ACC19C9C449BB6963C75F5AE4 /* Inheritence.swift */,
-				5942E5427D88E187E66C1321C28773B8 /* KeyPath.swift */,
-				B14525739EB13CBB5CDA70AB08AA1B68 /* Lexer.swift */,
-				1E5EC2D95A0468568F3D7EAA4EDE5D78 /* Loader.swift */,
-				1B5EE1FB9C62B41AA2C101167340B4B6 /* Node.swift */,
-				CE7249B16A82DD696BFA3C7C70B59E3A /* NowTag.swift */,
-				B283A8568909F9D09FAB2E0C0A30DDBF /* Parser.swift */,
-				1E939CF1BC6C22024EDF6DE626596C44 /* Template.swift */,
-				11932858CEB464498EF075B40D36564B /* Tokenizer.swift */,
-				471016ABCCA3820B513E285BCB3C1BF9 /* Variable.swift */,
-				97D1C53943D3FE29569B5E0306C661C6 /* Support Files */,
+				F9FC39B394CCA10A79B741170B3FACCD /* SWXMLHash.modulemap */,
+				BC9482A58E11515F5A26F5163AB05522 /* SWXMLHash.xcconfig */,
+				A0359557D6F9E4B6E5C82E48488CC8E6 /* SWXMLHash-dummy.m */,
+				DD3B83AE7AF5A5CD29A843FBEEC43A03 /* SWXMLHash-Info.plist */,
+				BA8750424B343AF43C9D5C19144B400F /* SWXMLHash-prefix.pch */,
+				BE149041B5CC5E87E47F7749849813E2 /* SWXMLHash-umbrella.h */,
 			);
-			name = Stencil;
-			path = Stencil;
+			name = "Support Files";
+			path = "../Target Support Files/SWXMLHash";
 			sourceTree = "<group>";
 		};
-		4FEAA3C001482CFC9B1EE1C850B9379F /* AEXML */ = {
+		51B1235DD8CA552AC98C21713E2DE56D /* Quick */ = {
 			isa = PBXGroup;
 			children = (
-				D0B864172123704FCFAF3AAE755225CB /* Document.swift */,
-				CA9D897FA60D583E597EB8FDA7A01148 /* Element.swift */,
-				545111DA9BF2D339E984FD2D86563BA6 /* Error.swift */,
-				DE2874AF9DF818105E8416A160FD5113 /* Options.swift */,
-				7C89315E1EF04A0808A3DB4742DEB3D6 /* Parser.swift */,
-				1FE6736C4DAEFF41B903440A847753CB /* Support Files */,
+				E73FD141C233CFDDA2496E400261789B /* Behavior.swift */,
+				2312777891D060B3CE48B394196A6156 /* Callsite.swift */,
+				5FAE2E7630397E1B0D00C761D0B58B6C /* Closures.swift */,
+				5FC5DCE812314A9FCCCF5B1BDEE2564A /* Configuration.swift */,
+				B6EB84D7064384AA64D3BF638BB44B58 /* DSL.swift */,
+				6FB46165117F30DE74BF10C9A354E9F8 /* ErrorUtility.swift */,
+				6EA404C525F5E3D6A8016BD7475C4DD0 /* Example.swift */,
+				1C5EEFAD2574DC009FF7DC65A90F3F1A /* ExampleGroup.swift */,
+				410CAE8B34014F1E379F7C87CEB95E92 /* ExampleHooks.swift */,
+				40E63A7EFE884499B9EB364D83DF59D9 /* ExampleMetadata.swift */,
+				BA88B10C73D26CCCF76D5E1DAF34570F /* Filter.swift */,
+				FBBBA263EE53B2C94366E441A22CB4D4 /* HooksPhase.swift */,
+				CA53A1FF8052C6F70BCA344624C6015F /* NSBundle+CurrentTestBundle.swift */,
+				5CD858DF0844E498E56EDB0CA6AE8D97 /* NSString+C99ExtendedIdentifier.swift */,
+				1239DF8D5CAAD4C8DED858BB41DDECA3 /* QCKDSL.h */,
+				C948D65F9BF004850F65FDD9C1D55238 /* QCKDSL.m */,
+				5728998ADA4872819707DD8319F0C5B4 /* Quick.h */,
+				38BD862A4D423A3A857F29E53891EFF6 /* QuickConfiguration.h */,
+				B3DC89DFE06119563E55378C1581D5A2 /* QuickConfiguration.m */,
+				225E0FAAF998C5CE3841B4566C428E02 /* QuickSelectedTestSuiteBuilder.swift */,
+				106390DFAAF8781C28401D3809A1EF64 /* QuickSpec.h */,
+				0F2B872B0B8A7E30B0030F220EA8F46F /* QuickSpec.m */,
+				60FA9671E8D8BCA97E5521E50EEA91BA /* QuickSpecBase.h */,
+				0BE0DF62AC40ADD7624A0368F23C18B1 /* QuickSpecBase.m */,
+				7F44C93EE89CBD00E32817E141E99058 /* QuickTestSuite.swift */,
+				C4675108A8CCBD654FBC27C4AB7054C2 /* SuiteHooks.swift */,
+				13E87ED98D88F15CD9B87A7E4854AA2F /* URL+FileName.swift */,
+				C73A303C46F3F862C25F7F261EA36A4D /* World.swift */,
+				CF157A94145675FCAB9B84EC03A01DBE /* World+DSL.swift */,
+				6CFE302FEA83EF711FEB3842743F7D24 /* XCTestSuite+QuickTestSuiteBuilder.m */,
+				7A848A6E9FC1BD2FB39928B30A09BB8D /* Support Files */,
 			);
-			name = AEXML;
-			path = AEXML;
+			name = Quick;
+			path = Quick;
 			sourceTree = "<group>";
 		};
 		5636130F527698EF161CF75E6890F9A5 /* Pods-Sourcery */ = {
@@ -1625,32 +1378,144 @@
 			path = "Target Support Files/Pods-Sourcery";
 			sourceTree = "<group>";
 		};
-		60664974D5169D1B4FF834F466363236 /* Support Files */ = {
+		564EC4ADEC1176AC0FD6AC18F3D84D3C /* Commander */ = {
 			isa = PBXGroup;
 			children = (
-				16F4838709CEDAF1E0EAB7694FE6B885 /* StencilSwiftKit.modulemap */,
-				A3BF4D477B9D113C3E2EF24CDE561742 /* StencilSwiftKit.xcconfig */,
-				9DA94081B5833FD432108861C88B65E2 /* StencilSwiftKit-dummy.m */,
-				4BA29A342B906E8C87932912C4135718 /* StencilSwiftKit-Info.plist */,
-				65654766C057FB4F10C60814B68DB824 /* StencilSwiftKit-prefix.pch */,
-				90F7E82F109A2232E1166802EAD00C06 /* StencilSwiftKit-umbrella.h */,
+				C8681C5C69A18640B47D67D8E0F0857F /* ArgumentConvertible.swift */,
+				00134483696AC1CDE67EFA7F2F84EC5F /* ArgumentDescription.swift */,
+				4A2E9D0B5B33B0ADC1D7DFC1169C0EE1 /* ArgumentParser.swift */,
+				BA7167F0F96B5E16E0446666685305B0 /* Command.swift */,
+				B46E34D9803715249741363C105AEBBF /* CommandRunner.swift */,
+				3C8339F41335DEEBCCCAD28A8FDA440E /* Commands.swift */,
+				5B60F153D0565B5C9C1F8EEC11AD0B11 /* CommandType.swift */,
+				9891F4608FA0A7B2C94F702189F80B31 /* Error.swift */,
+				FA4FA4043FB75E62C84F49D5950697AE /* Group.swift */,
+				94FD991E5F0F7F8F6E92328FAE80697A /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/StencilSwiftKit";
+			name = Commander;
+			path = Commander;
 			sourceTree = "<group>";
 		};
-		6424C41F7432DC67A38C4656A380CDB5 /* Support Files */ = {
+		57F3AF41CCD6BCA33388E7D8F62D0ADE /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				82B664B140061DAB41620131AAA50675 /* SWXMLHash.modulemap */,
-				4E0C2F46DA8110EBCD0CA344F9692F09 /* SWXMLHash.xcconfig */,
-				96E70641FF5262B79101656AE2878B6B /* SWXMLHash-dummy.m */,
-				763D247D13A9B4E42A5882942697F569 /* SWXMLHash-Info.plist */,
-				2685D455EE0F19312102BC2798AD1909 /* SWXMLHash-prefix.pch */,
-				E99239F198074863873476B7D14412AC /* SWXMLHash-umbrella.h */,
+				2963C7EAD4BEEE074A8826E739F5FFA9 /* AEXML.modulemap */,
+				A3415853B20AD79A6FC57A3A85CA67CA /* AEXML.xcconfig */,
+				71313AE80A30431A02EB459A3A642DF7 /* AEXML-dummy.m */,
+				59B71BCD94A4F7837FAF3FC5ED502484 /* AEXML-Info.plist */,
+				8471ECCC0116913C56515B4D0EF505C6 /* AEXML-prefix.pch */,
+				136F67492999DFCAB1C063183E2574C8 /* AEXML-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/SWXMLHash";
+			path = "../Target Support Files/AEXML";
+			sourceTree = "<group>";
+		};
+		5F11E7256F1827AA4CCB61DC7962D70C /* Nimble */ = {
+			isa = PBXGroup;
+			children = (
+				83C2B3703304D4EF5B7455ADEE207E72 /* AdapterProtocols.swift */,
+				50989DDB7F65C9CB250FCAB54809DA7D /* AllPass.swift */,
+				D2E669B1637A0F53943635C746AB5706 /* AssertionDispatcher.swift */,
+				AC3E72BB8C9B109AE543B59B72B61EC7 /* AssertionRecorder.swift */,
+				0430F1956BC5D453B60A6DC6476C3445 /* Async.swift */,
+				3D5E2B63AE98B21AFAD74258C2620F36 /* Await.swift */,
+				ED25C511E54A20108EA2153859BA9094 /* BeAKindOf.swift */,
+				1DCDDD5CD23B1383A2607C12F5933F62 /* BeAnInstanceOf.swift */,
+				B2075DC4B09A0F15576EA6C347DAEAC3 /* BeCloseTo.swift */,
+				588735FCF590A1586ACE1D1F75BA4BD5 /* BeEmpty.swift */,
+				88127F8E25EF8B7FD7BDAAC30E5D93E7 /* BeginWith.swift */,
+				4A545F434570A63FD5E1141F57691970 /* BeGreaterThan.swift */,
+				1F3E398D6F221DC29D748F3E0E117164 /* BeGreaterThanOrEqualTo.swift */,
+				B1A37DC2B51B6C077488D9F0AAFE54F4 /* BeIdenticalTo.swift */,
+				C4D2CCE82E1834F02896039E01A68C6B /* BeLessThan.swift */,
+				4FC9F608593256F496D2B634D1A4CDBE /* BeLessThanOrEqual.swift */,
+				2C9CAC44A9FA5EE5D17A5FC973EE32C4 /* BeLogical.swift */,
+				51AF4CF6B6AF701FB8654322CB441314 /* BeNil.swift */,
+				E199270F45434E40032A42DB68D234B4 /* BeVoid.swift */,
+				18C572DA952DEE0E505E17354B16ED43 /* Contain.swift */,
+				331C005BADA747082B9CCD06BFEF2F83 /* ContainElementSatisfying.swift */,
+				D548406E39D0C950B3148E9689318412 /* CwlBadInstructionException.swift */,
+				B7BED265C9690AF35FB3BE79DBFB6A3A /* CwlCatchBadInstruction.swift */,
+				876E69BB30C15D467257B58B41BD71EA /* CwlCatchException.h */,
+				E5E7F55A7F9EA55D4CDFC942B8C552B1 /* CwlCatchException.m */,
+				1C4338CD47D14F6D47BDE7FE08DB5C53 /* CwlCatchException.swift */,
+				2980E467EF143EFF9BD13B0C9162417E /* CwlDarwinDefinitions.swift */,
+				BF7E9F1177F9C9DE785CCBA2AAD834B7 /* CwlMachBadInstructionHandler.h */,
+				4EE83E22B4E14DE7B80206A906343756 /* CwlMachBadInstructionHandler.m */,
+				E3F74AF8F8400AE4D6A2816F90520629 /* CwlPreconditionTesting.h */,
+				76294F8D74C2D7376B9EC996D9131596 /* DSL.h */,
+				4521BE920C2B762DF0422FAD2A2D254C /* DSL.m */,
+				B72C0F08AC5739D484DDE83DDFB6879E /* DSL.swift */,
+				7B42AD7D47626559CDB07DB7D4E566D4 /* DSL+Wait.swift */,
+				3FA6802EBAB5F9B43D0FCDBF0D85C122 /* ElementsEqual.swift */,
+				AAACEA64D9724241826D6BA5594566E8 /* EndWith.swift */,
+				FA2B526E6D1095B48CFD04B52224C6DD /* Equal.swift */,
+				2B4B5233E9B7923DFD3424CE70510B65 /* Errors.swift */,
+				DDB430B1ABD157C3B664036F5BD6A2E0 /* Expectation.swift */,
+				2867E36381ECD8DC94C8E693004E23CF /* ExpectationMessage.swift */,
+				DC536B7ED5C3A1B78F5F23AD0A2975D2 /* Expression.swift */,
+				497E72084DCDC4548A9372874A9C4C0E /* FailureMessage.swift */,
+				6FC55DDC3190A083979C051D1FDD2166 /* Functional.swift */,
+				FCBB0808CDFB1454167D96C962FE70DB /* HaveCount.swift */,
+				2BFC915222FDE94F799EE89F9EDACF74 /* mach_excServer.c */,
+				D5BD296CA0134DA85EADBB14155AB85D /* mach_excServer.h */,
+				ADFCC348C33BD5CFDEF0CFD4AEE6BAAB /* Match.swift */,
+				E30C396EAA660FA5BB5720BAE611D83C /* MatcherFunc.swift */,
+				D9BBFD4D71EDE1BC59DF0A878A3CDFAB /* MatcherProtocols.swift */,
+				072760713591AC981C004DC576FE1D09 /* MatchError.swift */,
+				D6CADF5D9D71EA3DC8035961AC1222EB /* Nimble.h */,
+				39641AC72362CE48B2C7100C3548E365 /* NimbleEnvironment.swift */,
+				50B460BD9352B7E2010C46966FEE51F0 /* NimbleXCTestHandler.swift */,
+				31BC4029B5BF718BCC013880C3B7D0B8 /* NMBExceptionCapture.h */,
+				91A001B32BFF90791FE414183A62E633 /* NMBExceptionCapture.m */,
+				A3B06BC11AA25C779382CEEC38844ABD /* NMBExpectation.swift */,
+				776214A053BBF81117AEF49F94714BD8 /* NMBObjCMatcher.swift */,
+				B69786045B50248334DDBB789A2B6F0C /* NMBStringify.h */,
+				724CDE81D5A9A0D37CDC47265C72502B /* NMBStringify.m */,
+				239D0A65FC9B182DCEE20B0737E8466E /* PostNotification.swift */,
+				1D0004644435F94BB20CA0B57DB34D76 /* Predicate.swift */,
+				A77896CE8A81F314E78F3A8B620A4385 /* RaisesException.swift */,
+				3D20F25FD6B17C7D7EBC7E99DBD45D88 /* SatisfyAllOf.swift */,
+				BB8F43A5788E6DF310C17CC1CA0B12FA /* SatisfyAnyOf.swift */,
+				D57DD1A559732BAF33B0751F859838C2 /* SourceLocation.swift */,
+				B788BB33BFDAE79378AF1CC131FFFF72 /* Stringers.swift */,
+				906ED5AAC255184C2E301FEB22CC64B7 /* ThrowAssertion.swift */,
+				88A23FD40CECDD9C445EA86F236AC8CF /* ThrowError.swift */,
+				F573E2FE76FA8E3558ECDD3C19F2E453 /* ToSucceed.swift */,
+				19F0FEE218FB7A3E78C8E514B4D75900 /* XCTestObservationCenter+Register.m */,
+				AB88B226F20FC67F7969B0B100A97D1D /* Support Files */,
+			);
+			name = Nimble;
+			path = Nimble;
+			sourceTree = "<group>";
+		};
+		606B4A7EC46B48D33281657D5E71F5C7 /* Stencil */ = {
+			isa = PBXGroup;
+			children = (
+				F34A607D23E520311D5FB2AA94A4A4AD /* Context.swift */,
+				15D760C84B7E14997427B57A70E60FEB /* Environment.swift */,
+				AE5225920B0BCC69D1F01F8307C648EB /* Errors.swift */,
+				34A74ACAB20DD9A3B8AB87F3EB6C970B /* Expression.swift */,
+				E234C5490AF52AC1EBB9598C8CF1A3AD /* Extension.swift */,
+				59D05F4B45D5A8CB4F78E699EBC29657 /* Filters.swift */,
+				A2A0C466F7866E0322F7546EEE3FFCA5 /* FilterTag.swift */,
+				CE094C28A56B2166361BC09BF4040E6D /* ForTag.swift */,
+				92B2629C742F046972BA51DBEA11EABA /* IfTag.swift */,
+				F28FDC0C5809EDF7D5867823B3D4689B /* Include.swift */,
+				A37D12B5030FC2B6C84603464DB9FCA9 /* Inheritence.swift */,
+				7D093D987A5069F8351B900597275D09 /* KeyPath.swift */,
+				2A21BB8DF46FA32B549339B5353AD265 /* Lexer.swift */,
+				C151C096DF67A7ABF7D345102DD85489 /* Loader.swift */,
+				B2E9C034674D21790244D9460A160663 /* Node.swift */,
+				CC841FA257A928A8870849338198F5DA /* NowTag.swift */,
+				4BCC55BB7938F3643E28832C88F19CB7 /* Parser.swift */,
+				8EE60519AF5071B1F75B32146E6C45F9 /* Template.swift */,
+				11ABD7F41EBC38F328BDAFA65B420D47 /* Tokenizer.swift */,
+				C71AE4A4EEE20E5A2FC29E20B24C0BC3 /* Variable.swift */,
+				189861EDC6128DFFA899256FFF38BABB /* Support Files */,
+			);
+			name = Stencil;
+			path = Stencil;
 			sourceTree = "<group>";
 		};
 		6C2FDD165A288EBE2D7D12B850BBC1EA /* Pods-SourceryFramework */ = {
@@ -1669,97 +1534,129 @@
 			path = "Target Support Files/Pods-SourceryFramework";
 			sourceTree = "<group>";
 		};
-		86A344F1C8D0DEDA4D6AD70BF510609A /* SwiftLint */ = {
+		75C180F4B0F861B5967C790C762F532A /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				A630400A5321F5C16AC78F51C50E21AF /* Support Files */,
+				B1185262182BF8C2904E1C94E00CBEE0 /* PathKit.modulemap */,
+				1D6374ABF00E854BE449B574663DBA42 /* PathKit.xcconfig */,
+				6101E623EF5C7724F5DB42E1D637A342 /* PathKit-dummy.m */,
+				AE96403D31B9963E837CB9808DB8A20F /* PathKit-Info.plist */,
+				86B565337F2260DDDE77ECC14171ADBB /* PathKit-prefix.pch */,
+				1E9FEFA07FC5D171461675B2F26F250A /* PathKit-umbrella.h */,
 			);
-			name = SwiftLint;
-			path = SwiftLint;
+			name = "Support Files";
+			path = "../Target Support Files/PathKit";
 			sourceTree = "<group>";
 		};
-		918C85BF41CCB523BBBEFE669ED1B466 /* Support Files */ = {
+		7A848A6E9FC1BD2FB39928B30A09BB8D /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				F75B4B308B344BA187EAA9DBDD94EC9C /* SourceKittenFramework.modulemap */,
-				706806B89DB516AD322A94BFA196E8AE /* SourceKittenFramework.xcconfig */,
-				33072464A22946EF064FCF85100D1935 /* SourceKittenFramework-dummy.m */,
-				38E4C1BF4701C64A6658F1B7262F932A /* SourceKittenFramework-Info.plist */,
-				FEA8D981E028EA1D8875942F66D1CC13 /* SourceKittenFramework-prefix.pch */,
-				8FB52B2EA57047A2E09B1828AA240F29 /* SourceKittenFramework-umbrella.h */,
+				475A4F094A841646447016089D2DA5BE /* Quick.modulemap */,
+				624AC30FE642D0BFA4427760733ADF42 /* Quick.xcconfig */,
+				68ED56E961C40490163B0C2B5F2C6448 /* Quick-dummy.m */,
+				34ADBAE1E7BBCAC890E09CA156D70357 /* Quick-Info.plist */,
+				6CBCB28D2F10375D61703A9733DE444A /* Quick-prefix.pch */,
+				E591F7FB4DFCB4B84C9E0D1661120A87 /* Quick-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Quick";
+			sourceTree = "<group>";
+		};
+		8EB53A2DD7053D4826BF664F033821F8 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				1B192618E0DAFA0F11087A97ECD1F5B6 /* StencilSwiftKit.modulemap */,
+				399DBC4458FA35BA737E37460B40A91E /* StencilSwiftKit.xcconfig */,
+				F0E6E8C6D9E278CC973E855B38529B8D /* StencilSwiftKit-dummy.m */,
+				3F2A6F1273D752515857E3C2AFDA0C0F /* StencilSwiftKit-Info.plist */,
+				B01FE6CA5E93266827963FE245EC5C89 /* StencilSwiftKit-prefix.pch */,
+				55BDF279F8BB2B1A13B06D529A9FAFB3 /* StencilSwiftKit-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/StencilSwiftKit";
+			sourceTree = "<group>";
+		};
+		94FD991E5F0F7F8F6E92328FAE80697A /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				DC5B1F188D237D7925092A772AF58A64 /* Commander.modulemap */,
+				92602C4E1DF04F0B4FB5ABEB64354C92 /* Commander.xcconfig */,
+				9256BF91D068CBBFEAC4245578DDBC99 /* Commander-dummy.m */,
+				3490F6FEED4B46F4C2AB6EEABA592E37 /* Commander-Info.plist */,
+				A05B1D669D1907D83F96CAFE21A9C4AC /* Commander-prefix.pch */,
+				CCE82CB6DD2CCB8C890A2B58613340C3 /* Commander-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Commander";
+			sourceTree = "<group>";
+		};
+		9647E4C42A9B459E9AC9D3A4C5C100B7 /* Yams */ = {
+			isa = PBXGroup;
+			children = (
+				B0AF22A2C0194990E2C3726CABB664A9 /* api.c */,
+				1C7E0172FBA325347D373E18B52EB1CE /* Constructor.swift */,
+				26E1B3CD7904BE5C5911926F0E5181ED /* CYaml.h */,
+				D7C4D2EBCFD4619585436A7FAAC11F49 /* Decoder.swift */,
+				2C2EFC5FEBB2CB2A0251DC0AF71473F1 /* emitter.c */,
+				BF00D49AE0D754ACDD15BF373709A4E2 /* Emitter.swift */,
+				9703595520BF6F070F6A9850BCA3547B /* Encoder.swift */,
+				1E38A67B9F3C203F7CB3447549D949C8 /* Mark.swift */,
+				C1C43D41C41B4487C24BFA10EFADD820 /* Node.swift */,
+				8622D4B035F740661308D2ABC1D4C93D /* Node.Mapping.swift */,
+				F0DA4D7D26C640FE21EA0CA8C84DD9CC /* Node.Scalar.swift */,
+				969139ED9A9F94B35C1C8EDE8B2ED1D0 /* Node.Sequence.swift */,
+				69CE06279246EC77C9980B88D70814B9 /* parser.c */,
+				9D9AB9DBA14ED1725777745F484592E8 /* Parser.swift */,
+				269CD577304C27A75B14AF9D3478FF99 /* reader.c */,
+				36B2A1C4BD8288C33F2110140B638F39 /* Representer.swift */,
+				E154FC4DD574CA54F8E375466873E9D4 /* Resolver.swift */,
+				10787C2541B7AFBA94FDA14B1D13740C /* scanner.c */,
+				75CC526A9B66BD89B6A1EC926EC6A5EF /* shim.swift */,
+				E6D58E8E3711D7F3BD2E8F1FCAED1C86 /* String+Yams.swift */,
+				177D9E3CA9F3EA76C7FE0DB16389C6FB /* Tag.swift */,
+				69632434F3112F733F8A87FA795F8753 /* writer.c */,
+				E2685F20E55B0CBB29554B433A6B067A /* yaml.h */,
+				12F46044D788C3589179FCD80081946E /* yaml_private.h */,
+				50CFF005F442276AFE6D3CC0EC4C9186 /* YamlError.swift */,
+				3138AEB665E9549ED3FE04A9409C59D1 /* Yams.h */,
+				E8DB3849090719B056B8CBBC081F17EF /* Support Files */,
+			);
+			name = Yams;
+			path = Yams;
+			sourceTree = "<group>";
+		};
+		9828E24C05E1EA900B14651B1726DB68 /* StencilSwiftKit */ = {
+			isa = PBXGroup;
+			children = (
+				F9DDF557D7ADB4E46279A7721464D64F /* CallMacroNodes.swift */,
+				20DAB2299B625C88F883A97FB72237DF /* Context.swift */,
+				90143D33F5F43B2AC844E8027C2B9A58 /* Environment.swift */,
+				BF904A7F46503A348ADDD6FE2677A895 /* Filters.swift */,
+				35A35880D1DD3BDB561569AF13E64B9A /* Filters+Numbers.swift */,
+				FA0E96B1AEAAE2903E43628062F67A6E /* Filters+Strings.swift */,
+				1C853BDABAA1D07FA565A179F97970FD /* MapNode.swift */,
+				A9367BDCE37CFBC7778DA94E5F0A4F4F /* Parameters.swift */,
+				D86A917AFC624894FB49DCD2F9E5BD1C /* SetNode.swift */,
+				BD20E9F784FAB05697C736E9B6AA86D6 /* StencilSwiftTemplate.swift */,
+				CC0EA486EBFC79426031555D128D5FD3 /* SwiftIdentifier.swift */,
+				8EB53A2DD7053D4826BF664F033821F8 /* Support Files */,
+			);
+			name = StencilSwiftKit;
+			path = StencilSwiftKit;
+			sourceTree = "<group>";
+		};
+		98E364A28FFE6FCA1E4E8103F3E3240A /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				CA791A6EEC25E40FCE158A68580EC2F2 /* SourceKittenFramework.modulemap */,
+				C56F3EDBF4E0080BD8DE0B6888C89B0F /* SourceKittenFramework.xcconfig */,
+				94E0948E7E9E0DDAC3AFCBA13E647A0E /* SourceKittenFramework-dummy.m */,
+				5210F2752F3AFC73EA007A814751C0E0 /* SourceKittenFramework-Info.plist */,
+				52E48F04BCAFFC34E806B49A56673C86 /* SourceKittenFramework-prefix.pch */,
+				CE346E383BCE6F0117BDDEA5F008DFE6 /* SourceKittenFramework-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/SourceKittenFramework";
-			sourceTree = "<group>";
-		};
-		97D1C53943D3FE29569B5E0306C661C6 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				862824B94DD6B06B03D179006051F916 /* Stencil.modulemap */,
-				40DE6AF01D4B78ED69E7DB1865D32A4C /* Stencil.xcconfig */,
-				048D5F5BEEB35FD533102D34FB65E476 /* Stencil-dummy.m */,
-				80D2206E90D4152F008B842C9E69C691 /* Stencil-Info.plist */,
-				A8989F7935A230D696905CC8AC353FC3 /* Stencil-prefix.pch */,
-				E8F5E4DA24732B6AD19F6DE8D6882A52 /* Stencil-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Stencil";
-			sourceTree = "<group>";
-		};
-		9CF1697D972230F097E9B4F06FD5ACC0 /* SourceKittenFramework */ = {
-			isa = PBXGroup;
-			children = (
-				49820084B215591A9C4812447F86C33E /* BuildSystem.h */,
-				E7A0D4145C9E1429398168DCEDCBAEB2 /* Clang+SourceKitten.swift */,
-				BEA40B1D07DB53A8726B6086A76B3318 /* Clang_C.h */,
-				D9BD0A0E134B61D2458372804651C782 /* ClangTranslationUnit.swift */,
-				D77DAA13055ECF12D9BE59C7F962EEC9 /* CodeCompletionItem.swift */,
-				48C4309650684E7D3FAFC1EC8FF34AA6 /* CXCompilationDatabase.h */,
-				3762261094607EBF716EE3E89399F2E2 /* CXErrorCode.h */,
-				6268A034E876AE813B4D04882A6BAC78 /* CXString.h */,
-				86766CFDB30423496E2278A6471B9AE1 /* Dictionary+Merge.swift */,
-				5DFEAE3EEBE4AAB0F46CA502F6D7A6EF /* Documentation.h */,
-				82CD334BA0A54B2AAB1293E0BDBB0692 /* Documentation.swift */,
-				782AB024816388DFD9776DBBAB907741 /* File.swift */,
-				56F70CC5B4785850C7DADFB797FAD33E /* Index.h */,
-				166A93D1F2356F47D1B4541A8D2F2E4C /* JSONOutput.swift */,
-				F2DC6228F47860320F6F4C4DF312E6BD /* Language.swift */,
-				CE43F487478A99E4B5F6F69E26B11B17 /* library_wrapper.swift */,
-				1055BC4F1F58345A01804B36DF4D7FC4 /* library_wrapper_CXString.swift */,
-				C86E786690D5CA5323D9D057B88B8BCA /* library_wrapper_Documentation.swift */,
-				B3A80CDE43BED2CE02D0C9E9DAD69AAA /* library_wrapper_Index.swift */,
-				42490B13736FF3B5BF55BCB60C9411FC /* library_wrapper_sourcekitd.swift */,
-				E044078E15CF9AC524696234B51E0637 /* LinuxCompatibility.swift */,
-				590E2D58A86A0596AFB572EC4E16ED3B /* Module.swift */,
-				9734EA8E9FAC9D97FD0CFC957B268FE6 /* ObjCDeclarationKind.swift */,
-				687CC506A3442B0111E960B4B2D6C597 /* OffsetMap.swift */,
-				0D6C6177DBAC24C74A589CAE871EC376 /* Parameter.swift */,
-				0103E4F62C4C612B4D03514043CDAC1E /* Platform.h */,
-				A6459435DBB72829839607EB712F1337 /* Request.swift */,
-				C9B665D10CA3739672253EE7BAAC75E7 /* shim.swift */,
-				A204C09542A5FC0C1A2F7CFA5D487030 /* SourceDeclaration.swift */,
-				A0FD9BE14D163B58F2FF9FCEB937E6EF /* SourceKit.h */,
-				677B4B130BA10A6366A88349BBAAA3F5 /* sourcekitd.h */,
-				7336EEF50F41578E607ABB7379D35029 /* SourceKitObject.swift */,
-				B24241FFE39B64EE82D70ABFDF38D91A /* SourceLocation.swift */,
-				88EDAE799F0B29969B1A72FE28C090FE /* StatementKind.swift */,
-				6AF460E890AA0D2EEB88FFA4F49A684E /* String+SourceKitten.swift */,
-				AF857CED27C511D9172CBBA428FD330C /* Structure.swift */,
-				F0F358757C92386AFCE20D3329EFD8FC /* SwiftDeclarationAttributeKind.swift */,
-				AE633EA1200B10C2AE81161F5B2372EE /* SwiftDeclarationKind.swift */,
-				8A89AA45740EE5A54ACA07BF3E2F173D /* SwiftDocKey.swift */,
-				5C15CCBFB5DF55D7C24C4E8C11C7C312 /* SwiftDocs.swift */,
-				D26E3C20FE91C1E2648367DA27E82849 /* SyntaxKind.swift */,
-				0A2CE84D54458AB23908FA1CAFEE70AF /* SyntaxMap.swift */,
-				0EC538D7DC72CE8B9C7A703B81464F2B /* SyntaxToken.swift */,
-				89261071D4DF90CD5B0610CA2F515A42 /* Text.swift */,
-				CC3B91A3A38F895FC38532700B223815 /* UID.swift */,
-				763CEC8B6B1D48223EA3A489E9CCF731 /* Version.swift */,
-				2691BD03039318ABF565B350BCF7FDAB /* Xcode.swift */,
-				918C85BF41CCB523BBBEFE669ED1B466 /* Support Files */,
-			);
-			name = SourceKittenFramework;
-			path = SourceKittenFramework;
 			sourceTree = "<group>";
 		};
 		A4937F48C8BF2B2E589E0FFC4EA703FC /* Pods-SourceryTests */ = {
@@ -1779,13 +1676,83 @@
 			path = "Target Support Files/Pods-SourceryTests";
 			sourceTree = "<group>";
 		};
-		A630400A5321F5C16AC78F51C50E21AF /* Support Files */ = {
+		A4FABE42BC7E6108F92CD4A0773E6BF4 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				3C720671DFE8CD58130BBD84CD649334 /* SwiftLint.xcconfig */,
+				65C3F00E6F232CFAC24CCF450769DBBE /* SwiftLint.xcconfig */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/SwiftLint";
+			sourceTree = "<group>";
+		};
+		AB88B226F20FC67F7969B0B100A97D1D /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E7929A05EFBF1B6D0976A01B86C926D3 /* Nimble.modulemap */,
+				5EB2C6BA52D2F9008F424BF707BD705D /* Nimble.xcconfig */,
+				A6E92D3E9A926DD127B0315FB36E2E01 /* Nimble-dummy.m */,
+				5D9B1CE464521550EFE378654965963A /* Nimble-Info.plist */,
+				2865EDFA8AF22FF4356704BB42B65AB9 /* Nimble-prefix.pch */,
+				8A0857F9532A5F5578C3A9B43ADC720A /* Nimble-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Nimble";
+			sourceTree = "<group>";
+		};
+		AC8D6CAE2C7ABC83E7B0B9B7721573DB /* SourceKittenFramework */ = {
+			isa = PBXGroup;
+			children = (
+				C87A9B0633680E89DAAB3758DEA40C9D /* BuildSystem.h */,
+				2C112658D3B3F622CE76A34F5A224F8C /* Clang+SourceKitten.swift */,
+				99EACE4455929BB6FA78B93E672D6317 /* Clang_C.h */,
+				78CF2129AB9AC3574CC2E29CECC392DD /* ClangTranslationUnit.swift */,
+				6D9C71B219C77CB709319D25FFEC89A5 /* CodeCompletionItem.swift */,
+				3D8B424315307D4BF57359C5BD8409E1 /* CXCompilationDatabase.h */,
+				73AC51682E5204ECAF44C61C6D227AE4 /* CXErrorCode.h */,
+				B156B9A00C759C4FFBAC0D7886C7C9BB /* CXString.h */,
+				419F20D5F7FA9CC8D26C251258CF3B1B /* Dictionary+Merge.swift */,
+				0696E69C82BB1CD491EBCF282E81B846 /* Documentation.h */,
+				50CACB53DABCAC94D559E6A3A52DAE29 /* Documentation.swift */,
+				2F625142D03D5F687E400FF784CAA614 /* File.swift */,
+				E691BC0943758341AEC4E0B9E8206091 /* Index.h */,
+				AC327897196E329B6427C375FBF2C039 /* JSONOutput.swift */,
+				33EF76818FDE6DE138055468EE2D10A1 /* Language.swift */,
+				3324DCFC9DAAE9217CF425C3FD56CEE3 /* library_wrapper.swift */,
+				BA8D8CD2E7354236099415D4C75247FD /* library_wrapper_CXString.swift */,
+				82F20050C1512B68623E7193D35460A2 /* library_wrapper_Documentation.swift */,
+				BCC7EEB4CBDA235AF20A2F4E3292FCD7 /* library_wrapper_Index.swift */,
+				724CD53C96E3A5066A5CBBA124A23F74 /* library_wrapper_sourcekitd.swift */,
+				B54C552319DB529ACEA317D82ED3A4CC /* LinuxCompatibility.swift */,
+				806E866705CE5BA9A15CFF2D6DB9A048 /* Module.swift */,
+				F4489EA2029BA75698245FEF0391A3F1 /* ObjCDeclarationKind.swift */,
+				8BC119E25152D883EA65D7F20991B383 /* OffsetMap.swift */,
+				3E2BE1B627A2E002EBE37BC5C0FA9C20 /* Parameter.swift */,
+				9688ED2F2B90D7B3D257CD99821A9EA0 /* Platform.h */,
+				371BE6C7228D3E554420678816CDA4E7 /* Request.swift */,
+				9CEA086E8BD8006B28AA9FA1A7BE0ECF /* shim.swift */,
+				C603340285CA7C6CDEF084D3E2F8CA85 /* SourceDeclaration.swift */,
+				3AB7ECE4B31F3818DCF9F372B651EF7D /* SourceKit.h */,
+				5CA4B24251E95BB75042F53183CA51BD /* sourcekitd.h */,
+				EE3F8D2F517630E4E38ACAAF7557256C /* SourceKitObject.swift */,
+				137C2B26F2D821B29C8BEF8F6F0AA9B4 /* SourceLocation.swift */,
+				2C56F5C0F6431C173581048848D671BC /* StatementKind.swift */,
+				C43F84DD01888A6303A8C3C2056209A9 /* String+SourceKitten.swift */,
+				DACF398DB7DF863AAC927F36E4CE0329 /* Structure.swift */,
+				48917552ED6ABA0DEAFB263114A60C8A /* SwiftDeclarationAttributeKind.swift */,
+				05D0636E24B7E22B7A8B37E7A848E0E8 /* SwiftDeclarationKind.swift */,
+				12005A3CC3291799984C711CE28C3169 /* SwiftDocKey.swift */,
+				F5109351B112682BDE28A756394713AB /* SwiftDocs.swift */,
+				851965D057C3408B376D869449761D45 /* SyntaxKind.swift */,
+				04DEBB1340ABF4AF30057BC605D9C931 /* SyntaxMap.swift */,
+				2CA9372044B55C8D12C2B322C7F9E2F0 /* SyntaxToken.swift */,
+				7A0CD2970F06D4831A45FE0CB37B49E1 /* Text.swift */,
+				80C21296EF982928752977E0C3AF373E /* UID.swift */,
+				14C97C49B08170813210BDA75D9CFBFD /* Version.swift */,
+				10D5DF88B8C1A49FA7B107427B7CED9C /* Xcode.swift */,
+				98E364A28FFE6FCA1E4E8103F3E3240A /* Support Files */,
+			);
+			name = SourceKittenFramework;
+			path = SourceKittenFramework;
 			sourceTree = "<group>";
 		};
 		AE493D585A9889482FC4283401427300 /* Pods-SourcerySwift */ = {
@@ -1819,20 +1786,6 @@
 			);
 			name = "Pods-CodableContextTests";
 			path = "Target Support Files/Pods-CodableContextTests";
-			sourceTree = "<group>";
-		};
-		BDF2EA1A4106BC96773615FC11F23115 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				E987A7407635A743DF10A31071A932BD /* Yams.modulemap */,
-				5853CB726136CCDA26B65398F6A402BB /* Yams.xcconfig */,
-				35ECBC25D0413090C8137AD74907DCBC /* Yams-dummy.m */,
-				E9A1A1F89C6828F37C81C123404DAA12 /* Yams-Info.plist */,
-				A07721AE5E7A35411D3A1714BDCCBFF4 /* Yams-prefix.pch */,
-				C2A681F9653588B23F16F9E26C3F907B /* Yams-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Yams";
 			sourceTree = "<group>";
 		};
 		BFF845D1821B5DEB607B68E8CCBB59A9 /* Pods-SourceryUtils */ = {
@@ -1879,18 +1832,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		C5693BA59844188196A431F0C84E31A8 /* Support Files */ = {
+		C6CAA125BC3B93F4E2CA158C84375DCB /* PathKit */ = {
 			isa = PBXGroup;
 			children = (
-				7402719B2267A34BFBD088FF9B66D837 /* xcproj.modulemap */,
-				9E47534C344A9005D799E92586C7109B /* xcproj.xcconfig */,
-				1A361C9DFD03C42D3C2B14CFF0E37E44 /* xcproj-dummy.m */,
-				A3D95FFC25C234AC52F455CEBF0AF4EA /* xcproj-Info.plist */,
-				A21CF738800F69EA8BAFC20D2B1347B0 /* xcproj-prefix.pch */,
-				8269C7AEC9E678BD76F3A3B0988DABA8 /* xcproj-umbrella.h */,
+				492A9A9BBE8346B8633EF900EA90B6E0 /* PathKit.swift */,
+				75C180F4B0F861B5967C790C762F532A /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/xcproj";
+			name = PathKit;
+			path = PathKit;
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -1898,82 +1847,136 @@
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
 				C5566F665D5AA0EF171B52056CEAB4D9 /* Frameworks */,
-				429332F4822F16D694A883440F6B09C5 /* Pods */,
+				EBEAB2926D29158D75F202D50FAEEAAC /* Pods */,
 				31DF96407C398E005CFCDDA72497D92A /* Products */,
 				C0CACA0B5F7F732D3ED41E5DFB281555 /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		D5F7F49F6EEA0598083FE63E6F3A3EAC /* PathKit */ = {
+		D602BB839E1A684EF2FF226DC72A684D /* AEXML */ = {
 			isa = PBXGroup;
 			children = (
-				D8915235F4B5593FE8CB345F8894173B /* PathKit.swift */,
-				DD07D75112F45D2D66C5D4B6364B1324 /* Support Files */,
+				21B674F3A351455A18E9706BFA80A4FB /* Document.swift */,
+				06F514801346F8E0DB83F7C06222C4EA /* Element.swift */,
+				E2D643202F781CF3B4801F9E9770CC3E /* Error.swift */,
+				53CE6DBDC1B219FF9BD3C599980C3189 /* Options.swift */,
+				3E16C746C798A5EB431E7FCE153C73E1 /* Parser.swift */,
+				57F3AF41CCD6BCA33388E7D8F62D0ADE /* Support Files */,
 			);
-			name = PathKit;
-			path = PathKit;
+			name = AEXML;
+			path = AEXML;
 			sourceTree = "<group>";
 		};
-		DC6AD165CA3FC5FE1A4F1FD83212E8D5 /* Quick */ = {
+		E8DB3849090719B056B8CBBC081F17EF /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				3ED55F1819BE802F721A4215C3B5A755 /* Behavior.swift */,
-				EECE42F8B397AB7CDE5F0E6A3BF4F0E3 /* Callsite.swift */,
-				3EFC7BC26C574A7C25CDFC86A281AD39 /* Closures.swift */,
-				99C53E013FAC2D9ADE1E9A094E02A908 /* Configuration.swift */,
-				F799158A78693CE3DDB056F1C9DFD5B9 /* DSL.swift */,
-				D15AF46B1EE374DBDC6FD146C694052C /* ErrorUtility.swift */,
-				F573901AF13F0E0EF143310AC7F5D9F9 /* Example.swift */,
-				C90556615C47011E9D9BD379B34EB2D8 /* ExampleGroup.swift */,
-				CE483A1BE7235E4C11CCD9D132AF093F /* ExampleHooks.swift */,
-				5AA41B5B8D4900AF2DEE39860A5F7A67 /* ExampleMetadata.swift */,
-				1EA81100C5C01A43937190C2615F121F /* Filter.swift */,
-				701453889D728B9BB5100F9B15B09730 /* HooksPhase.swift */,
-				CB84142A76513C17533CB6F6C04AEB0A /* NSBundle+CurrentTestBundle.swift */,
-				B741C0360D65D26B6443AC3E52D2D8B9 /* NSString+C99ExtendedIdentifier.swift */,
-				8FDE06C40D085B3213AC1F10A5243C33 /* QCKDSL.h */,
-				434F9B69163B9B12F31B1869E76E8015 /* QCKDSL.m */,
-				FC180E84CAD74CEDF65751E028D42C1B /* Quick.h */,
-				A409EEED1D16F55CCC3ECFC826D6DF55 /* QuickConfiguration.h */,
-				3B606BC63FB1111DFEE6181CA112C8BE /* QuickConfiguration.m */,
-				313D84E0A5BC3FB5EAD5BCCA503F8AF8 /* QuickSelectedTestSuiteBuilder.swift */,
-				7FCFE50C0FFC83F542D8CB5B32321DD9 /* QuickSpec.h */,
-				75BC3789FD43653C8FBA28B958FCC5AB /* QuickSpec.m */,
-				5E255670EBB9991D10652D6E8E3001F7 /* QuickSpecBase.h */,
-				28D2A11AA14EC190F3B24856BCB57D2A /* QuickSpecBase.m */,
-				D1E4793FDD9B7EF8E09E839FA82DF04C /* QuickTestSuite.swift */,
-				8D0C214947B910E1811148FEB33BF85C /* SuiteHooks.swift */,
-				AF5AB8A585BCB8D9DA75014B18941F05 /* URL+FileName.swift */,
-				26D92EEE91BAC1523C1482EA09C63021 /* World.swift */,
-				F82337671DE84A5CDB73CE67D6808A2B /* World+DSL.swift */,
-				BE767B0372B41ADBAF7D353693F9FE96 /* XCTestSuite+QuickTestSuiteBuilder.m */,
-				07935ED61DACB8426444D9AC3DF5679E /* Support Files */,
-			);
-			name = Quick;
-			path = Quick;
-			sourceTree = "<group>";
-		};
-		DD07D75112F45D2D66C5D4B6364B1324 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				B1CC8AC7FE775ECA1A7DF19BE02AEA89 /* PathKit.modulemap */,
-				DD3D0599D67F5814B5C61A4D67EC22AC /* PathKit.xcconfig */,
-				F5C1CCB1B732E1F1EADAD88B59225CE9 /* PathKit-dummy.m */,
-				864682329DAF9796573B4E5CD92E8887 /* PathKit-Info.plist */,
-				8FE64A598784642BDF5075123E1B9B60 /* PathKit-prefix.pch */,
-				1E9E2DB7A5042619D513D7DC103CF2FF /* PathKit-umbrella.h */,
+				96F070C2246720CCAE9AE3B37172D6EF /* Yams.modulemap */,
+				FC5CB58922C0843CF71F3DB93AD04081 /* Yams.xcconfig */,
+				A8270EE942DB4D0FEE7B27BC88C5E218 /* Yams-dummy.m */,
+				A18F155424176FDF82BF07B5BF89E328 /* Yams-Info.plist */,
+				05F79EC5DB98C61ECC761E8DBD3B7F22 /* Yams-prefix.pch */,
+				3FB50CC17F9FD94FB51E0197CAF5CEFD /* Yams-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/PathKit";
+			path = "../Target Support Files/Yams";
 			sourceTree = "<group>";
 		};
-		F8F1EDBDCA18930E4EB4C9DA22338237 /* SWXMLHash */ = {
+		EBEAB2926D29158D75F202D50FAEEAAC /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				96519D90DBC67540EBD84E74F92E0C9B /* shim.swift */,
-				217DFEAE385C8455D78C79581176947D /* SWXMLHash.swift */,
-				1D8549DCEEA3EB5F3E62810186AC48ED /* SWXMLHash+TypeConversion.swift */,
-				6424C41F7432DC67A38C4656A380CDB5 /* Support Files */,
+				D602BB839E1A684EF2FF226DC72A684D /* AEXML */,
+				564EC4ADEC1176AC0FD6AC18F3D84D3C /* Commander */,
+				5F11E7256F1827AA4CCB61DC7962D70C /* Nimble */,
+				C6CAA125BC3B93F4E2CA158C84375DCB /* PathKit */,
+				51B1235DD8CA552AC98C21713E2DE56D /* Quick */,
+				AC8D6CAE2C7ABC83E7B0B9B7721573DB /* SourceKittenFramework */,
+				606B4A7EC46B48D33281657D5E71F5C7 /* Stencil */,
+				9828E24C05E1EA900B14651B1726DB68 /* StencilSwiftKit */,
+				40D7CE6CEC1FFEE1E319AF4C6438ECCC /* SwiftLint */,
+				FEA061AA812C82DF4810AEB3A755681B /* SWXMLHash */,
+				FA6BBD9704E1ACD90566766961EA5B7E /* xcproj */,
+				9647E4C42A9B459E9AC9D3A4C5C100B7 /* Yams */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		FA6BBD9704E1ACD90566766961EA5B7E /* xcproj */ = {
+			isa = PBXGroup;
+			children = (
+				9B50811A8539F4000B8902F066F142C0 /* AEXML+XcodeFormat.swift */,
+				4FD84D7615FBFA926D4817684600C668 /* Bool+Extras.swift */,
+				796BD1961FD3BBC2E779361F39420484 /* BuildPhase.swift */,
+				D1F1960B83B53A9E3DC7EB808A65ACBD /* BuildSettings.swift */,
+				9337F8EC7F37E67B0EB7C5AC854172AB /* CommentedString.swift */,
+				E396312C669D85CFB73C073295DD1B2A /* Decodable+Dictionary.swift */,
+				B6194EF134E0C05224BD731E84371A1A /* Dictionary+Extras.swift */,
+				A1F2B921FD32145CB67DFE1E9A25D8E0 /* JSONDecoding.swift */,
+				208F2AC1B3EEC8E298972FC244A869D4 /* KeyedDecodingContainer+Additions.swift */,
+				2983D1149015A22169081FF1DCCD005E /* ObjectReference.swift */,
+				87F6D32F8C58ADC0F5CD438C94827E31 /* PBXAggregateTarget.swift */,
+				9ECB41E90854ABC0D5EFF0192768A7FD /* PBXBuildFile.swift */,
+				F507997DE78AA048FB013D8C035C6382 /* PBXBuildPhase.swift */,
+				F9FEDC5CF1150B66BE9C52C34B9356C2 /* PBXBuildRule.swift */,
+				DF4357BB240F1789713BB70B06818909 /* PBXContainerItem.swift */,
+				D7986044B4C2171879E1A3278AAA1C58 /* PBXContainerItemProxy.swift */,
+				107F0C0381FF2D0AB3A27CCA54726050 /* PBXCopyFilesBuildPhase.swift */,
+				84D2AAC4A83087615D20A1842737DFF5 /* PBXFileElement.swift */,
+				69B71A8D3ECA5543E9021731E04C9EBC /* PBXFileReference.swift */,
+				39439BF6BD56E03232A70EC58067AE6E /* PBXFrameworksBuildPhase.swift */,
+				9C8338743B57A2D4C2844A2679D32DBF /* PBXGroup.swift */,
+				34C0BFAC05B9A7242C4FAC4FC03EDFBB /* PBXHeadersBuildPhase.swift */,
+				1A3C8037776850A97A97A642B8C0DB80 /* PBXLegacyTarget.swift */,
+				007B06C2452F605FD1357159F8638EC9 /* PBXNativeTarget.swift */,
+				CAA86889C80EF4E033C9C848E7B1B65B /* PBXObject.swift */,
+				24335BB778E4E8FABAE840F11DCA3E36 /* PBXProductType.swift */,
+				F32EA9241C6B88939BA00B98DBA1453F /* PBXProj.swift */,
+				1BB19424349984E1DD28537762814BAE /* PBXProj+Helpers.swift */,
+				B70EA8900B945F212B11AEBC26B42506 /* PBXProject.swift */,
+				3A792739B3AF780C10529B0333413DFF /* PBXProject+Deprecations.swift */,
+				76337E3F50337CB8E301F09E989DE4A1 /* PBXProjEncoder.swift */,
+				678B8FE171235792C83D131DB8383D44 /* PBXProjError.swift */,
+				1806E45C83E5F467B61754884CA3B6C9 /* PBXProjObjects+Helpers.swift */,
+				538B7D357DDE54A1EA611132E162F50A /* PBXReferenceProxy.swift */,
+				85B2A0588079756EDA937C1209E642B6 /* PBXResourcesBuildPhase.swift */,
+				4D39AF047186A4E80625CF64060E2E42 /* PBXRezBuildPhase.swift */,
+				B641481219EB1331EA9C9B440306F66B /* PBXShellScriptBuildPhase.swift */,
+				703E12109416B70D40F4802DA2D70108 /* PBXSourcesBuildPhase.swift */,
+				B2F9FE6422C2C76783DDEC35FD918D6F /* PBXSourceTree.swift */,
+				D8BD6F629FF8501670E09ACA487A7E2B /* PBXTarget.swift */,
+				9D7914CA125394D8F1EA05CCDFC2D30B /* PBXTargetDependency.swift */,
+				07AA80A72F470DD549A4C193F55B825B /* PBXVariantGroup.swift */,
+				3DD63A54B176B6B2034FB4AAC38FF5E1 /* PBXVariantGroup+Deprecations.swift */,
+				B5749A684FD4A16EF0D0EA5D8E321985 /* PlistValue.swift */,
+				B0A96B81F5168E3DC7FF81A91600035A /* Referenceable.swift */,
+				59A6888E3FD8334345910158E5C23EEC /* String+Extras.swift */,
+				DF7883F44838153A966BB457DFBE865A /* Writable.swift */,
+				405EF9A0D4830C181F450993D574880A /* XCBreakpointList.swift */,
+				F82B20DCED350CF321B30A93A67A9245 /* XCBuildConfiguration.swift */,
+				1D12D4009D505025D09CB822ECF53B04 /* XCConfig.swift */,
+				393A8301D8B2EB031C1A57A2B9863488 /* XCConfigurationList.swift */,
+				9646D60E4888A57E32E05DF58D9AAF5F /* XcodeProj.swift */,
+				F342B0918ABA45D405009CF98D78FB7B /* XCScheme.swift */,
+				0088E7AC0A863675177030D8A555B855 /* XCSharedData.swift */,
+				A630E9B19712F4E441412E4781FD66A6 /* XCVersionGroup.swift */,
+				D20C035F391F5A4BBEF2E37DB2215FD4 /* XCWorkspace.swift */,
+				C6854B654588CAE315C2957FFDA593BD /* XCWorkspaceData.swift */,
+				08E4F00F202414474386E1B939A0309A /* XCWorkspaceDataElement.swift */,
+				3959265D13A13963BBA7A3AF015B6DB7 /* XCWorkspaceDataElementLocationType.swift */,
+				C9E8353831309132DB8AD563989192C8 /* XCWorkspaceDataFileRef.swift */,
+				CB141316ECEC7EF5C2DEBA446C671A35 /* XCWorkspaceDataGroup.swift */,
+				424665A961E4459DB062A8BD6D7C0E03 /* Support Files */,
+			);
+			name = xcproj;
+			path = xcproj;
+			sourceTree = "<group>";
+		};
+		FEA061AA812C82DF4810AEB3A755681B /* SWXMLHash */ = {
+			isa = PBXGroup;
+			children = (
+				BABFDF969A7F032C33E684E67454FE92 /* shim.swift */,
+				1983ECE41D1BBE9C285E96C67BFC35A5 /* SWXMLHash.swift */,
+				F44719B431957647278C9C274C0CEE58 /* SWXMLHash+TypeConversion.swift */,
+				43147FE3CC74FE4AA87E3F49FAF4A089 /* Support Files */,
 			);
 			name = SWXMLHash;
 			path = SWXMLHash;
@@ -1995,22 +1998,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD4C4274D5F9351FEB8A57C834317A85 /* xcproj-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1254F19917E0E1C2D98427AA5F2BAE5A /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				028DF0FD8A2D44D80EB0313263408364 /* CwlCatchException.h in Headers */,
-				85A4019248D92500E641D01E1AD85724 /* CwlMachBadInstructionHandler.h in Headers */,
-				DE170038470E8DDDBC393195336A19B8 /* CwlPreconditionTesting.h in Headers */,
-				45B25D082BF52A41858126CE82885AD3 /* DSL.h in Headers */,
-				6193AAE31B8DDFE2B4FD667055CAE810 /* mach_excServer.h in Headers */,
-				BE9631B3CFF5881B6C29BBA43FD8B81E /* Nimble-umbrella.h in Headers */,
-				9C25BC723ED8C3D2AD876B9CAC53B173 /* Nimble.h in Headers */,
-				2B53456A071A2F00B3D1DF5F58E248E4 /* NMBExceptionCapture.h in Headers */,
-				77A0C071248147C59F2AD9EDE5D9025E /* NMBStringify.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2158,6 +2145,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				800C7A9A7A23A732BFC022F4575254C8 /* StencilSwiftKit-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F684E10CDA60BAC918A92251A0A1968A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1C5AE23F3288A2E8A13489165FD3FF2 /* CwlCatchException.h in Headers */,
+				05D6872E1E4C28423550C859B6E03820 /* CwlMachBadInstructionHandler.h in Headers */,
+				38FEA25D16ACC1E6F5C696CD95B41A69 /* CwlPreconditionTesting.h in Headers */,
+				9EEF9E84E580920E11E06170D25F65C3 /* DSL.h in Headers */,
+				6FC59CBB360B3EF8E45D151D945BCA54 /* mach_excServer.h in Headers */,
+				C0367D0510CE9E409A33E9B356422017 /* Nimble-umbrella.h in Headers */,
+				1FA0DEC9E883929115DD91352F570F3B /* Nimble.h in Headers */,
+				30966E26266F62432C8E914340871113 /* NMBExceptionCapture.h in Headers */,
+				74C4A30A55AC7DB057CE14BCA15299C4 /* NMBStringify.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2392,24 +2395,6 @@
 			productReference = 5CA7357EAEE8ACD683B18AFCB507CBF9 /* Pods_SourceryUtils.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		D4352C8CA6EDC802E8D85D2E61BC6173 /* Nimble */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F7696C5CA73833843928D0745738A604 /* Build configuration list for PBXNativeTarget "Nimble" */;
-			buildPhases = (
-				1254F19917E0E1C2D98427AA5F2BAE5A /* Headers */,
-				7EF0B1276B07BC36BB916E65618EDC6B /* Sources */,
-				8EFEC7DE8D9D8F72113B8C5107E46125 /* Frameworks */,
-				331EF7BDCF08FFF90F46CE9B1E24EFD5 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Nimble;
-			productName = Nimble;
-			productReference = 40F6AEA6F2463D0584AC6D61489A0A69 /* Nimble.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		DE04452FEC39ABEEDD58D299F7194C7C /* xcproj */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A00E5B25C8274180F127DD313411EC62 /* Build configuration list for PBXNativeTarget "xcproj" */;
@@ -2498,6 +2483,24 @@
 			productReference = 71C57F7EE59EE7846C41FF4DC26FB779 /* Pods_SourceryFramework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		F554EA343D656E7FB0C1ACC045EB2666 /* Nimble */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E3A98634DB5DA9D006BDFE48B5C34CB5 /* Build configuration list for PBXNativeTarget "Nimble" */;
+			buildPhases = (
+				F684E10CDA60BAC918A92251A0A1968A /* Headers */,
+				843204FEA6D0A77E8262CB3DE7F86658 /* Sources */,
+				E6B54F3471A343C63C3C9AAB30121A32 /* Frameworks */,
+				AD1799A208BE417CCE05899E167D813E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Nimble;
+			productName = Nimble;
+			productReference = 40F6AEA6F2463D0584AC6D61489A0A69 /* Nimble.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		F71934A728CF05C0F498CAF03E8793C8 /* Commander */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D7C411DED220E5D6AE5E2ABDC52C22AA /* Build configuration list for PBXNativeTarget "Commander" */;
@@ -2560,7 +2563,7 @@
 			targets = (
 				228D9AEE65C945E1274E1A5CEF6D53D3 /* AEXML */,
 				F71934A728CF05C0F498CAF03E8793C8 /* Commander */,
-				D4352C8CA6EDC802E8D85D2E61BC6173 /* Nimble */,
+				F554EA343D656E7FB0C1ACC045EB2666 /* Nimble */,
 				B27AF1C7A304278E2F62F9BEB0D8AA42 /* PathKit */,
 				8B334E14C1D8D9FD7A956AADCFE20E8E /* Pods-CodableContextTests */,
 				EAE38EEFE945CEAD43F3CB4DA641F5F4 /* Pods-Sourcery */,
@@ -2584,13 +2587,6 @@
 
 /* Begin PBXResourcesBuildPhase section */
 		1BA27C8917B2C9FA380AABBBCA26304A /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		331EF7BDCF08FFF90F46CE9B1E24EFD5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2682,6 +2678,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A2232BC22B1A0D98EFCD609851C06668 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AD1799A208BE417CCE05899E167D813E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2851,72 +2854,73 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7EF0B1276B07BC36BB916E65618EDC6B /* Sources */ = {
+		843204FEA6D0A77E8262CB3DE7F86658 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3213BCA3F1681716187C729AFB68D2BB /* AdapterProtocols.swift in Sources */,
-				509A11E46FC4BA03FD5E87D17A07CAF0 /* AllPass.swift in Sources */,
-				CAC04F7ABB34BA633376E24D40854B35 /* AssertionDispatcher.swift in Sources */,
-				B75B3A84CA2964056CB81372F60AFCFA /* AssertionRecorder.swift in Sources */,
-				57B2EE351263FFADF20988F2F4793E40 /* Async.swift in Sources */,
-				F7D9EA3149CC299C7F991E943F4C5969 /* Await.swift in Sources */,
-				89AD12601BEC4F7AF6B7937C48AB36DB /* BeAKindOf.swift in Sources */,
-				E48FADBC7C1C7D4341CCF7202913C1BD /* BeAnInstanceOf.swift in Sources */,
-				10D772422D8E6057D5A365EAD8A47449 /* BeCloseTo.swift in Sources */,
-				588A51D30421E419F273D9A95F097532 /* BeEmpty.swift in Sources */,
-				E9D17C4F7EA6064BB2BD29EFF0DB924D /* BeginWith.swift in Sources */,
-				B419964606930231BBB3C7E3415D7FA8 /* BeGreaterThan.swift in Sources */,
-				C78F8C0997E22AC93D8C81914125534E /* BeGreaterThanOrEqualTo.swift in Sources */,
-				ECF2A4C9FDE5520EB7FC4CC3305D6758 /* BeIdenticalTo.swift in Sources */,
-				D427386A796DA46156663B48FF1BD6BF /* BeLessThan.swift in Sources */,
-				69280C4BDE5FFAC1F4504EBD9E6DDC5D /* BeLessThanOrEqual.swift in Sources */,
-				0DE40D7C9194C933FCE0B4B58BCC7F70 /* BeLogical.swift in Sources */,
-				981CDDBBD5032667D1AEFA3B5A4E5225 /* BeNil.swift in Sources */,
-				270982656D24DD681EAF6E17A91641A8 /* BeVoid.swift in Sources */,
-				D7C454158BA609467D5388E02798CA50 /* Contain.swift in Sources */,
-				B5F56FD514193D7D9CEA4BCDC15341A9 /* ContainElementSatisfying.swift in Sources */,
-				F85EEBAFF5D86D2084153B870C863929 /* CwlBadInstructionException.swift in Sources */,
-				A7C40DD472FEDE062062BD1140C2E3D5 /* CwlCatchBadInstruction.swift in Sources */,
-				C0FB459DF79D0F76DD07319553A23F2F /* CwlCatchException.m in Sources */,
-				B9DE8A6720B0844D1F4D90AF9925D783 /* CwlCatchException.swift in Sources */,
-				65C489AC4103B1BA17415338BA7510FD /* CwlDarwinDefinitions.swift in Sources */,
-				496AA4210A5DEF4B4A687574E7A8E953 /* CwlMachBadInstructionHandler.m in Sources */,
-				9A23E38ABCC91B8DE80EABF78189917B /* DSL+Wait.swift in Sources */,
-				79F514934CA4B464AF0D30BE9EF1568C /* DSL.m in Sources */,
-				F6E3D19EC741BCCADB7337939E912D10 /* DSL.swift in Sources */,
-				F7CE4B877915D10D87476BE7126CA018 /* EndWith.swift in Sources */,
-				DFA921E207C666858CAEF0F04486EAA9 /* Equal.swift in Sources */,
-				D9339CFE5B6DC3355A106735785532EB /* Errors.swift in Sources */,
-				2DE60126ECE8E3343B78BC2508EACC95 /* Expectation.swift in Sources */,
-				59E843A7E787B4629448DE165F90A171 /* ExpectationMessage.swift in Sources */,
-				E4E976F3E27D9EBBC8E5ECE4FD8A5B40 /* Expression.swift in Sources */,
-				BB5DB37481529FC60A3A88C684480AAA /* FailureMessage.swift in Sources */,
-				DF94164F94832716774040482864FCC1 /* Functional.swift in Sources */,
-				4A6FBE120532A8F011A35FA4196A50F0 /* HaveCount.swift in Sources */,
-				4A5FA58F15831E265C46FB10208440DB /* mach_excServer.c in Sources */,
-				F0869F8049E2A6671E03CC9FCD2AF2DB /* Match.swift in Sources */,
-				5CB1024520B48AB9E6424232871A608F /* MatcherFunc.swift in Sources */,
-				75F889AC0EDB4563E381FE1016CEC80C /* MatcherProtocols.swift in Sources */,
-				24BD981C560FD8E42A233DC9225F15B2 /* MatchError.swift in Sources */,
-				4301C742FE4B509A8DC1504F367EEB99 /* Nimble-dummy.m in Sources */,
-				D95876C8DD357CD8E8EC4F528F33A101 /* NimbleEnvironment.swift in Sources */,
-				5ECBCAD56ED639E481ECFFA4B7DC2EDD /* NimbleXCTestHandler.swift in Sources */,
-				B668C90155CB7148D81121859024A5C6 /* NMBExceptionCapture.m in Sources */,
-				90D255CAD59F138EF8D4944BBF4A9C3F /* NMBExpectation.swift in Sources */,
-				C67AEBD682DFEF1D6EA4E35916FFF125 /* NMBObjCMatcher.swift in Sources */,
-				FAF1829CEB9F23B0A4947DD45218D53A /* NMBStringify.m in Sources */,
-				7E0E1424AD34CEEEB4AACF5AB446F487 /* PostNotification.swift in Sources */,
-				DCC52607A3CBD3315A2246F238224A8A /* Predicate.swift in Sources */,
-				9DE8DCDAD06D8264809B02E52B1F551F /* RaisesException.swift in Sources */,
-				7AB52BAA28E0CF687EFBE3B57F86CBC8 /* SatisfyAllOf.swift in Sources */,
-				64601AF2795A8956EF11860BC1C9A319 /* SatisfyAnyOf.swift in Sources */,
-				03B3E2CD5723D8959B54EA992BEC9A79 /* SourceLocation.swift in Sources */,
-				9EA2055AF46C7D60C37EDA35B2A16881 /* Stringers.swift in Sources */,
-				EF10779B25EF0204346E4579358F6FE0 /* ThrowAssertion.swift in Sources */,
-				DD154EF56D0E8175A848B7327A50C9F3 /* ThrowError.swift in Sources */,
-				026FD80ABF4A2E76CFC01778737E56A2 /* ToSucceed.swift in Sources */,
-				3F14099A8E8249B6D4DB2D6CA4EB8E36 /* XCTestObservationCenter+Register.m in Sources */,
+				5743FF7329B56548D14D7B2A1AFBF7F6 /* AdapterProtocols.swift in Sources */,
+				C6896BE181783C3F8E851E7F00DA94DC /* AllPass.swift in Sources */,
+				9580243E28D41834AB029756CC3A6DB5 /* AssertionDispatcher.swift in Sources */,
+				214D14BFA83B93F6D848C9326FC0D726 /* AssertionRecorder.swift in Sources */,
+				1ABE5B9FB33BB082AFF902EA8340B2C3 /* Async.swift in Sources */,
+				88357E2D0529CDAC8F4ABECD38806698 /* Await.swift in Sources */,
+				4BD911A2A7B3E67726EC7F9ED37AA039 /* BeAKindOf.swift in Sources */,
+				3CDF952F696CDAC9C3CAB48C46DB70D6 /* BeAnInstanceOf.swift in Sources */,
+				C6B35E7096035752B869D402FF356F8A /* BeCloseTo.swift in Sources */,
+				CC3FEA1AF258FA1BFE636FC5E33832BE /* BeEmpty.swift in Sources */,
+				0EE9B6EEBF5BB230595F217282D46032 /* BeginWith.swift in Sources */,
+				A3A7DA99F3721DBDEF9882648B76DEE2 /* BeGreaterThan.swift in Sources */,
+				4BD2ADE2BC4A13523C0BFA8AFDBA8E59 /* BeGreaterThanOrEqualTo.swift in Sources */,
+				F66C001C8423A79AFEC1AF3E6FD2B672 /* BeIdenticalTo.swift in Sources */,
+				EF4992DF97F700CFB21A392BEB0CEBEE /* BeLessThan.swift in Sources */,
+				EC47C10B81E393C9FE8C9DBCB06EFDC2 /* BeLessThanOrEqual.swift in Sources */,
+				B475D60EF423CD72EF0313769B13F827 /* BeLogical.swift in Sources */,
+				1446EB860E8C0BB7A521E542276F128B /* BeNil.swift in Sources */,
+				B88DBB55F98657F499C04004AB1779F8 /* BeVoid.swift in Sources */,
+				55E956B71E193B56CD0A991D90A3ECD4 /* Contain.swift in Sources */,
+				9B46353E3DA49638D67225C5C8252948 /* ContainElementSatisfying.swift in Sources */,
+				B99015D3DD07794A7BBE0CC5DECAFB6F /* CwlBadInstructionException.swift in Sources */,
+				F1153959599567CC9CE39D55C6E56D09 /* CwlCatchBadInstruction.swift in Sources */,
+				C3A770BF7DD23F88BC2D3AD4D353F056 /* CwlCatchException.m in Sources */,
+				9F6DF89F9DA63348B4C3C1007855C280 /* CwlCatchException.swift in Sources */,
+				05171847AE0AD245A8FB7E198CB37F67 /* CwlDarwinDefinitions.swift in Sources */,
+				C19575820B7C050B2C5D9157959A2FB5 /* CwlMachBadInstructionHandler.m in Sources */,
+				64B068AB5DE63BD37523623C9DF7D660 /* DSL+Wait.swift in Sources */,
+				4558F28C6C47E32E514A383C573950B8 /* DSL.m in Sources */,
+				1A085E4176BC047190EEA91CD2476BF5 /* DSL.swift in Sources */,
+				3944CFF682E0E0D190BACE0030F2F688 /* ElementsEqual.swift in Sources */,
+				3682F92CE2B1E6090151458EC19A66CB /* EndWith.swift in Sources */,
+				18780E4AAD9D40AAF8578D2EAB598F61 /* Equal.swift in Sources */,
+				B0B59C0EE722EF7D55EEE608CF9E7EAC /* Errors.swift in Sources */,
+				41DF10875D30076DBDC6DEC735432991 /* Expectation.swift in Sources */,
+				A5BC618B300BCFF8B7EBEDBF5E3F4D13 /* ExpectationMessage.swift in Sources */,
+				BC313B6D421A1582B26D7DC93716C764 /* Expression.swift in Sources */,
+				2B9F53611E87A6D73DE9E431483C3879 /* FailureMessage.swift in Sources */,
+				161E720928D40F7AFC6DFFEB74117DF0 /* Functional.swift in Sources */,
+				E7C1643EEC872F0846C469C27F8F472F /* HaveCount.swift in Sources */,
+				16F88764F808DBF7426CA911136DF8BF /* mach_excServer.c in Sources */,
+				EFC885EB354CF92ED473DD39D4F9EEBE /* Match.swift in Sources */,
+				AFE49E44F6FF8DCA7158EFBEAD4BD903 /* MatcherFunc.swift in Sources */,
+				2A12704AB9BB5CC0A6F8770F5232AEAD /* MatcherProtocols.swift in Sources */,
+				6A461D3D320E07CB0D716B63A4C011F3 /* MatchError.swift in Sources */,
+				DE41036F5CDFE75D351DEAC46ECD9FA9 /* Nimble-dummy.m in Sources */,
+				7BFDEE03EF96D7D10E8EFF5AEFD37141 /* NimbleEnvironment.swift in Sources */,
+				F5A05CFF71F2DC71BDEA235944F7B411 /* NimbleXCTestHandler.swift in Sources */,
+				01FD062E2941F8EE7EBC958B4A4C65A7 /* NMBExceptionCapture.m in Sources */,
+				C8F2AAC9FE9B6CF714AE4DC59C7DA89C /* NMBExpectation.swift in Sources */,
+				A8C022B0964489356E7C55DD10B9275F /* NMBObjCMatcher.swift in Sources */,
+				6ED8AF0AA71FEE9673E2416A84819113 /* NMBStringify.m in Sources */,
+				A745D105633763CF3E84DE4C1266EBB0 /* PostNotification.swift in Sources */,
+				538E4ED22D36FFD1337A7188062363EA /* Predicate.swift in Sources */,
+				41C7A7F1651FD1258E4C9D785F587A5F /* RaisesException.swift in Sources */,
+				785AD96A96C1FC1B38BF9A12F14D12B1 /* SatisfyAllOf.swift in Sources */,
+				6FCC1ADC65EDCFCD92DBDC767A0A4CB3 /* SatisfyAnyOf.swift in Sources */,
+				11EB5752E9F8CD62E8032D0925F50FDD /* SourceLocation.swift in Sources */,
+				E8646D84A32462D00B8B5CFD072B0A02 /* Stringers.swift in Sources */,
+				EFF004EE66DC9D90A6C6B9CFE15C3818 /* ThrowAssertion.swift in Sources */,
+				A92EA151E2D101A25C90284BF4C42D17 /* ThrowError.swift in Sources */,
+				D58E1282340D01DBD6484100AC9665E5 /* ToSucceed.swift in Sources */,
+				83D013225B8F78F6BDC290367C5CF602 /* XCTestObservationCenter+Register.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3156,7 +3160,7 @@
 		3F59E006806726514F0B8E4CA7FC6B28 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Nimble;
-			target = D4352C8CA6EDC802E8D85D2E61BC6173 /* Nimble */;
+			target = F554EA343D656E7FB0C1ACC045EB2666 /* Nimble */;
 			targetProxy = A6E1F85073C7CEAEFC7ECB96ED9B1B87 /* PBXContainerItemProxy */;
 		};
 		448E22E3E96A8B9B355D4E73310FE874 /* PBXTargetDependency */ = {
@@ -3198,7 +3202,7 @@
 		64F00ADFE97BAA7673E47C1A299946D5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Nimble;
-			target = D4352C8CA6EDC802E8D85D2E61BC6173 /* Nimble */;
+			target = F554EA343D656E7FB0C1ACC045EB2666 /* Nimble */;
 			targetProxy = 653BED3374392C9FF9E2AC8D0B060F16 /* PBXContainerItemProxy */;
 		};
 		669171D62746A3D53D37B4777E8D7060 /* PBXTargetDependency */ = {
@@ -3222,7 +3226,7 @@
 		94372235B294CFC2A34C76B73CCD665A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Nimble;
-			target = D4352C8CA6EDC802E8D85D2E61BC6173 /* Nimble */;
+			target = F554EA343D656E7FB0C1ACC045EB2666 /* Nimble */;
 			targetProxy = E01825DAE4D2AC4EB2E53A7EC385B1EF /* PBXContainerItemProxy */;
 		};
 		9AC92A289B3E9E398081DF067A4532AC /* PBXTargetDependency */ = {
@@ -3354,6 +3358,40 @@
 			};
 			name = Debug;
 		};
+		0C3D381D96BC160DC1383DB1F3BB8AA6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5EB2C6BA52D2F9008F424BF707BD705D /* Nimble.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Nimble/Nimble-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
+				PRODUCT_MODULE_NAME = Nimble;
+				PRODUCT_NAME = Nimble;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.2;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		1E8B8CDCECC0668051B1F2773F4C712A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9F4F329A9345D1A9604411CBCBC64878 /* Pods-CodableContextTests.debug.xcconfig */;
@@ -3392,7 +3430,7 @@
 		};
 		20261D2D412A9BE89C79CBB7FE22F2FC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E47534C344A9005D799E92586C7109B /* xcproj.xcconfig */;
+			baseConfigurationReference = 5E691F87F3E6C35990223C9C2A8E054B /* xcproj.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -3426,7 +3464,7 @@
 		};
 		35C4215DBB33619257BD542E76CE2AD1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4E0C2F46DA8110EBCD0CA344F9692F09 /* SWXMLHash.xcconfig */;
+			baseConfigurationReference = BC9482A58E11515F5A26F5163AB05522 /* SWXMLHash.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3459,7 +3497,7 @@
 		};
 		39B8474126589DC41BB9459F9229FE02 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5853CB726136CCDA26B65398F6A402BB /* Yams.xcconfig */;
+			baseConfigurationReference = FC5CB58922C0843CF71F3DB93AD04081 /* Yams.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3562,9 +3600,43 @@
 			};
 			name = Release;
 		};
+		3E19D4678A5770D78A847F76E94E6B5A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5EB2C6BA52D2F9008F424BF707BD705D /* Nimble.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Nimble/Nimble-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
+				PRODUCT_MODULE_NAME = Nimble;
+				PRODUCT_NAME = Nimble;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.2;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		497648C519B7C46882CEDD06B0908CC7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 706806B89DB516AD322A94BFA196E8AE /* SourceKittenFramework.xcconfig */;
+			baseConfigurationReference = C56F3EDBF4E0080BD8DE0B6888C89B0F /* SourceKittenFramework.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3597,7 +3669,7 @@
 		};
 		4D7969772FBA806AAEBB92B0086E3516 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3C720671DFE8CD58130BBD84CD649334 /* SwiftLint.xcconfig */;
+			baseConfigurationReference = 65C3F00E6F232CFAC24CCF450769DBBE /* SwiftLint.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -3648,7 +3720,7 @@
 		};
 		548E3A8017AE3A837E8A3C2160D9C15C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B030415E7290E7829C1A40D6CF40CA21 /* Commander.xcconfig */;
+			baseConfigurationReference = 92602C4E1DF04F0B4FB5ABEB64354C92 /* Commander.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3717,7 +3789,7 @@
 		};
 		5983DB3E81F39FDEFB64011DA308ED2A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DD3D0599D67F5814B5C61A4D67EC22AC /* PathKit.xcconfig */;
+			baseConfigurationReference = 1D6374ABF00E854BE449B574663DBA42 /* PathKit.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3750,7 +3822,7 @@
 		};
 		668DA9C6651058BBB37D06C9A77FB615 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6FE9D6ED53B6D6760800E1132AA84D64 /* Quick.xcconfig */;
+			baseConfigurationReference = 624AC30FE642D0BFA4427760733ADF42 /* Quick.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3772,40 +3844,6 @@
 				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
 				PRODUCT_MODULE_NAME = Quick;
 				PRODUCT_NAME = Quick;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.2;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		6C3625D9CDA1FFF41C93D3F36C821B6F /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 44697B5A6E94CE42393A5A5267BB5128 /* Nimble.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Nimble/Nimble-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
-				PRODUCT_MODULE_NAME = Nimble;
-				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -3853,7 +3891,7 @@
 		};
 		79052C127D14B1E65D34DA7B2C12AFF0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 706806B89DB516AD322A94BFA196E8AE /* SourceKittenFramework.xcconfig */;
+			baseConfigurationReference = C56F3EDBF4E0080BD8DE0B6888C89B0F /* SourceKittenFramework.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3886,7 +3924,7 @@
 		};
 		79D64A187AB61E39B44700FD7FB9A541 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B030415E7290E7829C1A40D6CF40CA21 /* Commander.xcconfig */;
+			baseConfigurationReference = 92602C4E1DF04F0B4FB5ABEB64354C92 /* Commander.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3919,7 +3957,7 @@
 		};
 		822BCE8A905504B799DDE8C1E0658E6A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4E0C2F46DA8110EBCD0CA344F9692F09 /* SWXMLHash.xcconfig */;
+			baseConfigurationReference = BC9482A58E11515F5A26F5163AB05522 /* SWXMLHash.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3952,7 +3990,7 @@
 		};
 		9CACED2F22E844B5B9BF6EA3F71CBC8B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 40DE6AF01D4B78ED69E7DB1865D32A4C /* Stencil.xcconfig */;
+			baseConfigurationReference = 7B66B070F558C8D96591917995D5090C /* Stencil.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3983,43 +4021,9 @@
 			};
 			name = Release;
 		};
-		9FAE6B2EA98D9D7FC42F366B44FB307B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 44697B5A6E94CE42393A5A5267BB5128 /* Nimble.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Nimble/Nimble-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
-				PRODUCT_MODULE_NAME = Nimble;
-				PRODUCT_NAME = Nimble;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.2;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		A5EC84C5290A75D761BAAC9E0C43007F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 10CEA2F11A704911B4DF5C348861887F /* AEXML.xcconfig */;
+			baseConfigurationReference = A3415853B20AD79A6FC57A3A85CA67CA /* AEXML.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4052,7 +4056,7 @@
 		};
 		AA1E70920B4D35AC4F02A5F07F5F48E8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A3BF4D477B9D113C3E2EF24CDE561742 /* StencilSwiftKit.xcconfig */;
+			baseConfigurationReference = 399DBC4458FA35BA737E37460B40A91E /* StencilSwiftKit.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4085,7 +4089,7 @@
 		};
 		B62469FB6C537E0258EF4C8FB5F4BA4B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5853CB726136CCDA26B65398F6A402BB /* Yams.xcconfig */;
+			baseConfigurationReference = FC5CB58922C0843CF71F3DB93AD04081 /* Yams.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4118,7 +4122,7 @@
 		};
 		B7A80907E970DC3BF1416033C33D42EA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E47534C344A9005D799E92586C7109B /* xcproj.xcconfig */;
+			baseConfigurationReference = 5E691F87F3E6C35990223C9C2A8E054B /* xcproj.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -4152,7 +4156,7 @@
 		};
 		BC6770CC304D4704FF7A445CE31D847A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 40DE6AF01D4B78ED69E7DB1865D32A4C /* Stencil.xcconfig */;
+			baseConfigurationReference = 7B66B070F558C8D96591917995D5090C /* Stencil.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4429,7 +4433,7 @@
 		};
 		C53B8E540C3657048E3F98E64B659703 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6FE9D6ED53B6D6760800E1132AA84D64 /* Quick.xcconfig */;
+			baseConfigurationReference = 624AC30FE642D0BFA4427760733ADF42 /* Quick.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4594,7 +4598,7 @@
 		};
 		DBD9E17DD8B31C1A2FC1342911D6DD74 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A3BF4D477B9D113C3E2EF24CDE561742 /* StencilSwiftKit.xcconfig */;
+			baseConfigurationReference = 399DBC4458FA35BA737E37460B40A91E /* StencilSwiftKit.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4663,7 +4667,7 @@
 		};
 		EAA01F0E790CD1FCE95BFC95DC33AD8D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 10CEA2F11A704911B4DF5C348861887F /* AEXML.xcconfig */;
+			baseConfigurationReference = A3415853B20AD79A6FC57A3A85CA67CA /* AEXML.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4696,7 +4700,7 @@
 		};
 		EACC88D5D1B0D09615CF1C3EB3D254B4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DD3D0599D67F5814B5C61A4D67EC22AC /* PathKit.xcconfig */;
+			baseConfigurationReference = 1D6374ABF00E854BE449B574663DBA42 /* PathKit.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4765,7 +4769,7 @@
 		};
 		FC48DD9859D26322E326F1EEB062C8F2 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3C720671DFE8CD58130BBD84CD649334 /* SwiftLint.xcconfig */;
+			baseConfigurationReference = 65C3F00E6F232CFAC24CCF450769DBBE /* SwiftLint.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -4961,11 +4965,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F7696C5CA73833843928D0745738A604 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
+		E3A98634DB5DA9D006BDFE48B5C34CB5 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9FAE6B2EA98D9D7FC42F366B44FB307B /* Debug */,
-				6C3625D9CDA1FFF41C93D3F36C821B6F /* Release */,
+				0C3D381D96BC160DC1383DB1F3BB8AA6 /* Debug */,
+				3E19D4678A5770D78A847F76E94E6B5A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pods/Target Support Files/Nimble/Nimble-Info.plist
+++ b/Pods/Target Support Files/Nimble/Nimble-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>7.3.1</string>
+  <string>8.0.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -1108,7 +1108,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Pixle;
 				TargetAttributes = {
 					0054C50322496806007F9AA7 = {
@@ -1153,6 +1153,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -1705,7 +1706,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1739,7 +1740,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -2074,6 +2075,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -2133,6 +2135,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -1153,7 +1153,6 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/Sourcery.xcodeproj/xcshareddata/xcschemes/Sourcery-Release.xcscheme
+++ b/Sourcery.xcodeproj/xcshareddata/xcschemes/Sourcery-Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sourcery.xcodeproj/xcshareddata/xcschemes/SourceryFramework.xcscheme
+++ b/Sourcery.xcodeproj/xcshareddata/xcschemes/SourceryFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sourcery.xcodeproj/xcshareddata/xcschemes/SourceryJS.xcscheme
+++ b/Sourcery.xcodeproj/xcshareddata/xcschemes/SourceryJS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sourcery.xcodeproj/xcshareddata/xcschemes/SourceryRuntime.xcscheme
+++ b/Sourcery.xcodeproj/xcshareddata/xcschemes/SourceryRuntime.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sourcery.xcodeproj/xcshareddata/xcschemes/SourcerySwift.xcscheme
+++ b/Sourcery.xcodeproj/xcshareddata/xcschemes/SourcerySwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sourcery.xcworkspace/xcshareddata/xcschemes/Sourcery.xcscheme
+++ b/Sourcery.xcworkspace/xcshareddata/xcschemes/Sourcery.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SourceryRuntime/Sources/Method.swift
+++ b/SourceryRuntime/Sources/Method.swift
@@ -171,7 +171,7 @@ public typealias SourceryMethod = Method
 
     // sourcery: skipEqaulitey, skipDescription, skipCoding, skipJSExport
     /// :nodoc:
-    @available(*, deprecated: 0.7, message: "Use isConvenienceInitializer instead") public var isConvenienceInitialiser: Bool {
+    @available(*, deprecated, message: "Use isConvenienceInitializer instead") public var isConvenienceInitialiser: Bool {
         return attributes[Attribute.Identifier.convenience.name] != nil
     }
 

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -2730,7 +2730,7 @@ public typealias SourceryMethod = Method
 
     // sourcery: skipEqaulitey, skipDescription, skipCoding, skipJSExport
     /// :nodoc:
-    @available(*, deprecated: 0.7, message: "Use isConvenienceInitializer instead") public var isConvenienceInitialiser: Bool {
+    @available(*, deprecated, message: "Use isConvenienceInitializer instead") public var isConvenienceInitialiser: Bool {
         return attributes[Attribute.Identifier.convenience.name] != nil
     }
 

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -16,6 +16,7 @@ import SourceryFramework
 @testable import SourcerySwift
 
 class SwiftTemplateTests: QuickSpec {
+    // swiftlint:disable function_body_length
     override func spec() {
         describe("SwiftTemplate") {
             let outputDir: Path = {

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -132,7 +132,7 @@ class SwiftTemplateTests: QuickSpec {
                     }
                     .to(throwError(closure: { (error) in
                         let path = Path.cleanTemporaryDir(name: "build").parent() + "SwiftTemplate/version/Sources/SwiftTemplate/main.swift"
-                        expect("\(error)").to(contain("\(path):9:11: error: expected expression in list of expressions\nprint(\"\\( )\", terminator: \"\");\n          ^\n"))
+                        expect("\(error)").to(contain("\(path):9:11: error: missing argument for parameter #1 in call\nprint(\"\\( )\", terminator: \"\");\n          ^\n"))
                     }))
             }
 

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -83,7 +83,7 @@ class ParserComposerSpec: QuickSpec {
                             input = "enum Foo { case A; func \(method.name) {} }; extension Foo { func \(defaultedMethod.name) {} }"
                             parsedResult = parse(input).first
                             originalType = Enum(name: "Foo", cases: [EnumCase(name: "A")], methods: [method, defaultedMethod])
-                            typeExtension = Type(name: "Foo", accessLevel: .none, isExtension: true, methods: [defaultedMethod])
+                            typeExtension = Type(name: "Foo", accessLevel: .internal, isExtension: true, methods: [defaultedMethod])
                         }
 
                         it("resolves methods definedInType") {
@@ -97,7 +97,7 @@ class ParserComposerSpec: QuickSpec {
                             input = "protocol Foo { func \(method.name) }; extension Foo { func \(defaultedMethod.name) {} }"
                             parsedResult = parse(input).first
                             originalType = Protocol(name: "Foo", methods: [method, defaultedMethod])
-                            typeExtension = Type(name: "Foo", accessLevel: .none, isExtension: true, methods: [defaultedMethod])
+                            typeExtension = Type(name: "Foo", accessLevel: .internal, isExtension: true, methods: [defaultedMethod])
                         }
 
                         it("resolves methods definedInType") {
@@ -111,7 +111,7 @@ class ParserComposerSpec: QuickSpec {
                             input = "class Foo { func \(method.name) {} }; extension Foo { func \(defaultedMethod.name) {} }"
                             parsedResult = parse(input).first
                             originalType = Class(name: "Foo", methods: [method, defaultedMethod])
-                            typeExtension = Type(name: "Foo", accessLevel: .none, isExtension: true, methods: [defaultedMethod])
+                            typeExtension = Type(name: "Foo", accessLevel: .internal, isExtension: true, methods: [defaultedMethod])
                         }
 
                         it("resolves methods definedInType") {
@@ -125,7 +125,7 @@ class ParserComposerSpec: QuickSpec {
                             input = "struct Foo { func \(method.name) {} }; extension Foo { func \(defaultedMethod.name) {} }"
                             parsedResult = parse(input).first
                             originalType = Struct(name: "Foo", methods: [method, defaultedMethod])
-                            typeExtension = Type(name: "Foo", accessLevel: .none, isExtension: true, methods: [defaultedMethod])
+                            typeExtension = Type(name: "Foo", accessLevel: .internal, isExtension: true, methods: [defaultedMethod])
                         }
 
                         it("resolves methods definedInType") {

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -160,7 +160,7 @@ class FileParserSpec: QuickSpec {
                     it("extracts extensions properly") {
                         expect(parse("protocol Foo { }; extension Bar: Foo { var x: Int { return 0 } }"))
                             .to(equal([
-                                Type(name: "Bar", accessLevel: .none, isExtension: true, variables: [Variable(name: "x", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true, definedInTypeName: TypeName("Bar"))], inheritedTypes: ["Foo"]),
+                                Type(name: "Bar", accessLevel: .internal, isExtension: true, variables: [Variable(name: "x", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true, definedInTypeName: TypeName("Bar"))], inheritedTypes: ["Foo"]),
                                 Protocol(name: "Foo")
                                 ]))
                     }

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -7,6 +7,7 @@ import xcproj
 
 private let version = "Major.Minor.Patch"
 
+// swiftlint:disable type_body_length
 class SourcerySpecTests: QuickSpec {
     // swiftlint:disable:next function_body_length
     override func spec() {

--- a/Templates/Templates.xcodeproj/project.pbxproj
+++ b/Templates/Templates.xcodeproj/project.pbxproj
@@ -376,7 +376,6 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/Templates/Templates.xcodeproj/project.pbxproj
+++ b/Templates/Templates.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Pixle;
 				TargetAttributes = {
 					63A4F4CC20964FB3000F8CDF = {
@@ -376,6 +376,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -666,6 +667,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -725,6 +727,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";

--- a/Templates/Templates.xcodeproj/xcshareddata/xcschemes/TemplatesTests.xcscheme
+++ b/Templates/Templates.xcodeproj/xcshareddata/xcschemes/TemplatesTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Hi!

This PR is aimed at updating project to Xcode 10.2 and does several things:

* Branch off master to include fix from #758
* Update Nimble, similar to #756
* Switches to Xcode 10.2.1 for CircleCI
* Fixes several tests, mostly for two failures - `.internal` access is now being reported for extensions on types, and String interpolation now reports compile error differently in `rethrows template parsing errors` test
* Update all projects to Xcode 10.2 recommended settings
* Fixes several warnings in unit tests
* Adds minimum deployment target for SPM package - macOS 10.11. Without this change SPM build fails because of NSKeyedArchiver API that was introduced in macOS 10.11(SPM chooses 10.10 by default) - for reference https://github.com/Alamofire/Alamofire/pull/2737 and https://github.com/Alamofire/Alamofire/pull/2736.


Overall changes seem backwards-compatible and non-breaking, however not 100% sure about that. @Liquidsoul maybe you can look into those and give your feedback?