### PR TITLE
Reintroduce new generic parsing system

### DIFF
--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -277,7 +277,7 @@ public struct Composer {
 
     private static func resolveProtocolCompositionTypes(_ protocolComposition: ProtocolComposition, resolve: TypeResolver) {
         let composedTypes = protocolComposition.composedTypeNames.compactMap { typeName in
-            resolve(typeName, protocolComposition)
+            resolve(typeName, protocolComposition, nil)
         }
 
         protocolComposition.composedTypes = composedTypes

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -88,6 +88,7 @@ public struct Composer {
             }
         }
 
+        updateTypeRelationships(types: Array(unique.values))
         let array = Array(unique.values)
         DispatchQueue.concurrentPerform(iterations: array.count) { (counter) in
             let type = array[counter]
@@ -120,7 +121,7 @@ public struct Composer {
 
         Log.benchmark("\tresolution took \(currentTimestamp() - resolutionStart)")
 
-        updateTypeRelationships(types: Array(unique.values))
+        
         return (
             types: unique.values.sorted { $0.name < $1.name },
             functions: functions.sorted { $0.name < $1.name }
@@ -149,14 +150,14 @@ public struct Composer {
         if let array = parseArrayType(lookupName) {
             lookupName.array = array
             array.elementType = resolveTypeWithName(array.elementTypeName, array.elementType)
-            lookupName.generic = GenericType(name: lookupName.name, typeParameters: [
+            lookupName.generic = GenericType(name: "Array", typeParameters: [
                 GenericTypeParameter(typeName: array.elementTypeName, type: array.elementType)
                 ])
         } else if let dictionary = parseDictionaryType(lookupName) {
             lookupName.dictionary = dictionary
             dictionary.valueType = resolveTypeWithName(dictionary.valueTypeName, dictionary.valueType)
             dictionary.keyType = resolveTypeWithName(dictionary.keyTypeName, dictionary.keyType)
-            lookupName.generic = GenericType(name: lookupName.name, typeParameters: [
+            lookupName.generic = GenericType(name: "Dictionary", typeParameters: [
                 GenericTypeParameter(typeName: dictionary.keyTypeName, type: dictionary.keyType),
                 GenericTypeParameter(typeName: dictionary.valueTypeName, type: dictionary.valueType)
                 ])

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -548,11 +548,11 @@ public struct Composer {
                     .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
 
                 if components.count == 1 {
-                    return MethodParameter(argumentLabel: nil, typeName: TypeName(components[0]))
+                    return MethodParameter(argumentLabel: nil, typeName: TypeName(components[0]), type: Type(name: components[0]))
                 } else {
                     let name = components[0].trimmingPrefix("_").stripped()
                     let typeName = components[1]
-                    return MethodParameter(argumentLabel: nil, name: name, typeName: TypeName(typeName))
+                    return MethodParameter(argumentLabel: nil, name: name, typeName: TypeName(typeName), type: Type(name: typeName))
                 }
             })
 

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -396,7 +396,7 @@ public struct Composer {
         }
     }
 
-    private func specializeType(_ type: Type?, with genericParameters: [GenericTypeParameter]) -> Type? {
+    private static func specializeType(_ type: Type?, with genericParameters: [GenericTypeParameter]) -> Type? {
         guard let type = type else { return nil }
         // This hack with keyed archivers serves only one goal - copy type to specialize it with generic parameters
         // We don't want to change original type, it should stay unspecialized

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -398,8 +398,10 @@ public struct Composer {
 
     private static func specializeType(_ type: Type?, with genericParameters: [GenericTypeParameter]) -> Type? {
         guard let type = type else { return nil }
+
         // This hack with keyed archivers serves only one goal - copy type to specialize it with generic parameters
         // We don't want to change original type, it should stay unspecialized
+        // TODO: Introduce our custom Copyable protocol and generate code for all subclasses of Type that would use plain init
         let data = NSKeyedArchiver.archivedData(withRootObject: type)
         let typeCopy = NSKeyedUnarchiver.unarchiveObject(with: data) as? Type
         typeCopy?.genericTypeParameters = genericParameters

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -796,7 +796,7 @@ extension FileParser {
         let `inout` = type.hasPrefix("inout ")
         let typeName = TypeName(type, attributes: parseTypeAttributes(type))
         let defaultValue = extractDefaultValue(type: type, from: source)
-        let parameter = MethodParameter(argumentLabel: argumentLabel, name: name, typeName: typeName, defaultValue: defaultValue, annotations: annotations.from(source), isInout: `inout`)
+        let parameter = MethodParameter(argumentLabel: argumentLabel, name: name, typeName: typeName, type: Type(name: type), defaultValue: defaultValue, annotations: annotations.from(source), isInout: `inout`)
         parameter.setSource(source)
         return parameter
     }

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -376,7 +376,7 @@ extension FileParser {
         let declaration = extractGenericsDeclaration(source: source)
         let typeName = extractGenericTypeName(source: source)
         guard declaration.contains("<") else {
-            return Type(name: typeName,
+            return Type(name: typeName.trimmingCharacters(in: .whitespacesAndNewlines),
                         genericTypeParameters: extractGenericTypeParameters(source: declaration))
         }
         

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -750,7 +750,7 @@ extension FileParser {
             }
         }
         
-        var genericPlaceholders: [GenericTypePlaceholder] = []
+        let genericPlaceholders: [GenericTypePlaceholder]
         if let genericSource = extract(.name, from: source),
             let parameterStartIndex = genericSource.index(of: "("),
             let whereClauseSource = nameSuffix {

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -173,7 +173,9 @@ public final class FileParser {
                 return nil
             }
 
-            type.isGeneric = isGeneric(source: source)
+            let TODO_PARSE_GENERICS = ""
+            // TODO: Parse generic type parameters and placeholders
+            
             type.annotations = annotations.from(source)
             type.attributes = parseDeclarationAttributes(source)
             type.bodyBytesRange = Substring.body.range(for: source).map { BytesRange(range: $0) }

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -304,6 +304,7 @@ extension FileParser {
     
     fileprivate func parseConcreteType(source: String) -> Type? {
         guard !source.isEmpty else { return nil }
+        
         let genericDeclaration = extractGenericsDeclaration(source: source)
         if genericDeclaration.isEmpty {
             return Type(name: source)

--- a/SourceryRuntime/Sources/Class.swift
+++ b/SourceryRuntime/Sources/Class.swift
@@ -24,7 +24,8 @@ import Foundation
                          typealiases: [Typealias] = [],
                          attributes: [String: Attribute] = [:],
                          annotations: [String: NSObject] = [:],
-                         isGeneric: Bool = false) {
+                         genericTypePlaceholders: [GenericTypePlaceholder] = [],
+                         genericTypeParameters: [GenericTypeParameter] = []) {
         super.init(
             name: name,
             parent: parent,
@@ -37,7 +38,8 @@ import Foundation
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            isGeneric: isGeneric
+            genericTypePlaceholders: genericTypePlaceholders,
+            genericTypeParameters: genericTypeParameters
         )
     }
 

--- a/SourceryRuntime/Sources/Coding.generated.swift
+++ b/SourceryRuntime/Sources/Coding.generated.swift
@@ -64,6 +64,8 @@ extension GenericType: NSCoding {}
 
 extension GenericTypeParameter: NSCoding {}
 
+extension GenericTypePlaceholder: NSCoding {}
+
 extension Method: NSCoding {}
 
 extension MethodParameter: NSCoding {}

--- a/SourceryRuntime/Sources/Description.generated.swift
+++ b/SourceryRuntime/Sources/Description.generated.swift
@@ -159,6 +159,7 @@ extension MethodParameter {
         string += "name = \(String(describing: self.name)), "
         string += "typeName = \(String(describing: self.typeName)), "
         string += "`inout` = \(String(describing: self.`inout`)), "
+        string += "type = \(String(describing: self.type)), "
         string += "typeAttributes = \(String(describing: self.typeAttributes)), "
         string += "defaultValue = \(String(describing: self.defaultValue)), "
         string += "genericTypeParameters = \(String(describing: self.genericTypeParameters)), "
@@ -201,6 +202,7 @@ extension Subscript {
         string += "parameters = \(String(describing: self.parameters)), "
         string += "returnTypeName = \(String(describing: self.returnTypeName)), "
         string += "actualReturnTypeName = \(String(describing: self.actualReturnTypeName)), "
+        string += "returnType = \(String(describing: self.returnType)), "
         string += "isFinal = \(String(describing: self.isFinal)), "
         string += "readAccess = \(String(describing: self.readAccess)), "
         string += "writeAccess = \(String(describing: self.writeAccess)), "
@@ -281,6 +283,7 @@ extension Typealias {
         var string = "\(Swift.type(of: self)): "
         string += "aliasName = \(String(describing: self.aliasName)), "
         string += "typeName = \(String(describing: self.typeName)), "
+        string += "type = \(String(describing: self.type)), "
         string += "parentName = \(String(describing: self.parentName)), "
         string += "name = \(String(describing: self.name))"
         return string

--- a/SourceryRuntime/Sources/Description.generated.swift
+++ b/SourceryRuntime/Sources/Description.generated.swift
@@ -121,6 +121,15 @@ extension GenericTypeParameter {
         return string
     }
 }
+extension GenericTypePlaceholder {
+    /// :nodoc:
+    override public var description: String {
+        var string = "\(Swift.type(of: self)): "
+        string += "placeholderName = \(String(describing: self.placeholderName)), "
+        string += "constraints = \(String(describing: self.constraints))"
+        return string
+    }
+}
 extension Method {
     /// :nodoc:
     override public var description: String {
@@ -137,7 +146,8 @@ extension Method {
         string += "isFailableInitializer = \(String(describing: self.isFailableInitializer)), "
         string += "annotations = \(String(describing: self.annotations)), "
         string += "definedInTypeName = \(String(describing: self.definedInTypeName)), "
-        string += "attributes = \(String(describing: self.attributes))"
+        string += "attributes = \(String(describing: self.attributes)), "
+        string += "genericTypePlaceholders = \(String(describing: self.genericTypePlaceholders))"
         return string
     }
 }
@@ -151,6 +161,7 @@ extension MethodParameter {
         string += "`inout` = \(String(describing: self.`inout`)), "
         string += "typeAttributes = \(String(describing: self.typeAttributes)), "
         string += "defaultValue = \(String(describing: self.defaultValue)), "
+        string += "genericTypeParameters = \(String(describing: self.genericTypeParameters)), "
         string += "annotations = \(String(describing: self.annotations))"
         return string
     }
@@ -240,6 +251,9 @@ extension Type {
         string += "accessLevel = \(String(describing: self.accessLevel)), "
         string += "name = \(String(describing: self.name)), "
         string += "isGeneric = \(String(describing: self.isGeneric)), "
+        string += "isConcreteGenericType = \(String(describing: self.isConcreteGenericType)), "
+        string += "genericTypePlaceholders = \(String(describing: self.genericTypePlaceholders)), "
+        string += "genericTypeParameters = \(String(describing: self.genericTypeParameters)), "
         string += "localName = \(String(describing: self.localName)), "
         string += "variables = \(String(describing: self.variables)), "
         string += "methods = \(String(describing: self.methods)), "

--- a/SourceryRuntime/Sources/Description.generated.swift
+++ b/SourceryRuntime/Sources/Description.generated.swift
@@ -300,6 +300,7 @@ extension Variable {
         var string = "\(Swift.type(of: self)): "
         string += "name = \(String(describing: self.name)), "
         string += "typeName = \(String(describing: self.typeName)), "
+        string += "type = \(String(describing: self.type)), "
         string += "isComputed = \(String(describing: self.isComputed)), "
         string += "isStatic = \(String(describing: self.isStatic)), "
         string += "readAccess = \(String(describing: self.readAccess)), "

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -161,6 +161,18 @@ extension GenericTypeParameter: Diffable {
         return results
     }
 }
+extension GenericTypePlaceholder: Diffable {
+    @objc func diffAgainst(_ object: Any?) -> DiffableResult {
+        let results = DiffableResult()
+        guard let castObject = object as? GenericTypePlaceholder else {
+            results.append("Incorrect type <expected: GenericTypePlaceholder, received: \(Swift.type(of: object))>")
+            return results
+        }
+        results.append(contentsOf: DiffableResult(identifier: "placeholderName").trackDifference(actual: self.placeholderName, expected: castObject.placeholderName))
+        results.append(contentsOf: DiffableResult(identifier: "constraints").trackDifference(actual: self.constraints, expected: castObject.constraints))
+        return results
+    }
+}
 extension Method: Diffable {
     @objc func diffAgainst(_ object: Any?) -> DiffableResult {
         let results = DiffableResult()
@@ -181,6 +193,7 @@ extension Method: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
+        results.append(contentsOf: DiffableResult(identifier: "genericTypePlaceholders").trackDifference(actual: self.genericTypePlaceholders, expected: castObject.genericTypePlaceholders))
         return results
     }
 }
@@ -196,6 +209,7 @@ extension MethodParameter: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
         results.append(contentsOf: DiffableResult(identifier: "`inout`").trackDifference(actual: self.`inout`, expected: castObject.`inout`))
         results.append(contentsOf: DiffableResult(identifier: "defaultValue").trackDifference(actual: self.defaultValue, expected: castObject.defaultValue))
+        results.append(contentsOf: DiffableResult(identifier: "genericTypeParameters").trackDifference(actual: self.genericTypeParameters, expected: castObject.genericTypeParameters))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         return results
     }
@@ -298,7 +312,8 @@ extension Type: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "isExtension").trackDifference(actual: self.isExtension, expected: castObject.isExtension))
         results.append(contentsOf: DiffableResult(identifier: "accessLevel").trackDifference(actual: self.accessLevel, expected: castObject.accessLevel))
-        results.append(contentsOf: DiffableResult(identifier: "isGeneric").trackDifference(actual: self.isGeneric, expected: castObject.isGeneric))
+        results.append(contentsOf: DiffableResult(identifier: "genericTypePlaceholders").trackDifference(actual: self.genericTypePlaceholders, expected: castObject.genericTypePlaceholders))
+        results.append(contentsOf: DiffableResult(identifier: "genericTypeParameters").trackDifference(actual: self.genericTypeParameters, expected: castObject.genericTypeParameters))
         results.append(contentsOf: DiffableResult(identifier: "localName").trackDifference(actual: self.localName, expected: castObject.localName))
         results.append(contentsOf: DiffableResult(identifier: "variables").trackDifference(actual: self.variables, expected: castObject.variables))
         results.append(contentsOf: DiffableResult(identifier: "methods").trackDifference(actual: self.methods, expected: castObject.methods))

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -377,6 +377,7 @@ extension Variable: Diffable {
         }
         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: castObject.name))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "type").trackDifference(actual: self.type, expected: castObject.type))
         results.append(contentsOf: DiffableResult(identifier: "isComputed").trackDifference(actual: self.isComputed, expected: castObject.isComputed))
         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: castObject.isStatic))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -208,6 +208,7 @@ extension MethodParameter: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: castObject.name))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
         results.append(contentsOf: DiffableResult(identifier: "`inout`").trackDifference(actual: self.`inout`, expected: castObject.`inout`))
+        results.append(contentsOf: DiffableResult(identifier: "type").trackDifference(actual: self.type, expected: castObject.type))
         results.append(contentsOf: DiffableResult(identifier: "defaultValue").trackDifference(actual: self.defaultValue, expected: castObject.defaultValue))
         results.append(contentsOf: DiffableResult(identifier: "genericTypeParameters").trackDifference(actual: self.genericTypeParameters, expected: castObject.genericTypeParameters))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
@@ -257,6 +258,7 @@ extension Subscript: Diffable {
         }
         results.append(contentsOf: DiffableResult(identifier: "parameters").trackDifference(actual: self.parameters, expected: castObject.parameters))
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
+        results.append(contentsOf: DiffableResult(identifier: "returnType").trackDifference(actual: self.returnType, expected: castObject.returnType))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
@@ -353,6 +355,7 @@ extension Typealias: Diffable {
         }
         results.append(contentsOf: DiffableResult(identifier: "aliasName").trackDifference(actual: self.aliasName, expected: castObject.aliasName))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "type").trackDifference(actual: self.type, expected: castObject.type))
         results.append(contentsOf: DiffableResult(identifier: "parentName").trackDifference(actual: self.parentName, expected: castObject.parentName))
         return results
     }

--- a/SourceryRuntime/Sources/Enum.swift
+++ b/SourceryRuntime/Sources/Enum.swift
@@ -187,13 +187,14 @@ import Foundation
                 typealiases: [Typealias] = [],
                 attributes: [String: Attribute] = [:],
                 annotations: [String: NSObject] = [:],
-                isGeneric: Bool = false) {
+                genericTypePlaceholders: [GenericTypePlaceholder] = [],
+                genericTypeParameters: [GenericTypeParameter] = []) {
 
         self.cases = cases
         self.rawTypeName = rawTypeName
         self.hasRawType = rawTypeName != nil || !inheritedTypes.isEmpty
 
-        super.init(name: name, parent: parent, accessLevel: accessLevel, isExtension: isExtension, variables: variables, methods: methods, inheritedTypes: inheritedTypes, containedTypes: containedTypes, typealiases: typealiases, attributes: attributes, annotations: annotations, isGeneric: isGeneric)
+        super.init(name: name, parent: parent, accessLevel: accessLevel, isExtension: isExtension, variables: variables, methods: methods, inheritedTypes: inheritedTypes, containedTypes: containedTypes, typealiases: typealiases, attributes: attributes, annotations: annotations, genericTypePlaceholders: genericTypePlaceholders, genericTypeParameters: genericTypeParameters)
 
         if let rawTypeName = rawTypeName?.name, let index = self.inheritedTypes.firstIndex(of: rawTypeName) {
             self.inheritedTypes.remove(at: index)

--- a/SourceryRuntime/Sources/Equality.generated.swift
+++ b/SourceryRuntime/Sources/Equality.generated.swift
@@ -133,6 +133,15 @@ extension GenericTypeParameter {
         return true
     }
 }
+extension GenericTypePlaceholder {
+    /// :nodoc:
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? GenericTypePlaceholder else { return false }
+        if self.placeholderName != rhs.placeholderName { return false }
+        if self.constraints != rhs.constraints { return false }
+        return true
+    }
+}
 extension Method {
     /// :nodoc:
     override public func isEqual(_ object: Any?) -> Bool {
@@ -150,6 +159,7 @@ extension Method {
         if self.annotations != rhs.annotations { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
         if self.attributes != rhs.attributes { return false }
+        if self.genericTypePlaceholders != rhs.genericTypePlaceholders { return false }
         return true
     }
 }
@@ -162,6 +172,7 @@ extension MethodParameter {
         if self.typeName != rhs.typeName { return false }
         if self.`inout` != rhs.`inout` { return false }
         if self.defaultValue != rhs.defaultValue { return false }
+        if self.genericTypeParameters != rhs.genericTypeParameters { return false }
         if self.annotations != rhs.annotations { return false }
         return true
     }
@@ -237,7 +248,8 @@ extension Type {
         if self.typealiases != rhs.typealiases { return false }
         if self.isExtension != rhs.isExtension { return false }
         if self.accessLevel != rhs.accessLevel { return false }
-        if self.isGeneric != rhs.isGeneric { return false }
+        if self.genericTypePlaceholders != rhs.genericTypePlaceholders { return false }
+        if self.genericTypeParameters != rhs.genericTypeParameters { return false }
         if self.localName != rhs.localName { return false }
         if self.variables != rhs.variables { return false }
         if self.methods != rhs.methods { return false }

--- a/SourceryRuntime/Sources/Equality.generated.swift
+++ b/SourceryRuntime/Sources/Equality.generated.swift
@@ -171,6 +171,7 @@ extension MethodParameter {
         if self.name != rhs.name { return false }
         if self.typeName != rhs.typeName { return false }
         if self.`inout` != rhs.`inout` { return false }
+        if self.type != rhs.type { return false }
         if self.defaultValue != rhs.defaultValue { return false }
         if self.genericTypeParameters != rhs.genericTypeParameters { return false }
         if self.annotations != rhs.annotations { return false }
@@ -205,6 +206,7 @@ extension Subscript {
         guard let rhs = object as? Subscript else { return false }
         if self.parameters != rhs.parameters { return false }
         if self.returnTypeName != rhs.returnTypeName { return false }
+        if self.returnType != rhs.returnType { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
         if self.annotations != rhs.annotations { return false }
@@ -284,6 +286,7 @@ extension Typealias {
         guard let rhs = object as? Typealias else { return false }
         if self.aliasName != rhs.aliasName { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.type != rhs.type { return false }
         if self.parentName != rhs.parentName { return false }
         return true
     }

--- a/SourceryRuntime/Sources/Equality.generated.swift
+++ b/SourceryRuntime/Sources/Equality.generated.swift
@@ -302,6 +302,7 @@ extension Variable {
         guard let rhs = object as? Variable else { return false }
         if self.name != rhs.name { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.type != rhs.type { return false }
         if self.isComputed != rhs.isComputed { return false }
         if self.isStatic != rhs.isStatic { return false }
         if self.readAccess != rhs.readAccess { return false }

--- a/SourceryRuntime/Sources/JSExport.generated.swift
+++ b/SourceryRuntime/Sources/JSExport.generated.swift
@@ -50,6 +50,9 @@ extension BytesRange: BytesRangeAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }
@@ -117,6 +120,9 @@ extension DictionaryType: DictionaryTypeAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }
@@ -171,6 +177,13 @@ extension GenericType: GenericTypeAutoJSExport {}
 
 extension GenericTypeParameter: GenericTypeParameterAutoJSExport {}
 
+@objc protocol GenericTypePlaceholderAutoJSExport: JSExport {
+    var placeholderName: TypeName { get }
+    var constraints: [Type] { get }
+}
+
+extension GenericTypePlaceholder: GenericTypePlaceholderAutoJSExport {}
+
 @objc protocol MethodAutoJSExport: JSExport {
     var name: String { get }
     var selectorName: String { get }
@@ -202,6 +215,7 @@ extension GenericTypeParameter: GenericTypeParameterAutoJSExport {}
     var actualDefinedInTypeName: TypeName? { get }
     var definedInType: Type? { get }
     var attributes: [String: Attribute] { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
 }
 
 extension Method: MethodAutoJSExport {}
@@ -214,6 +228,7 @@ extension Method: MethodAutoJSExport {}
     var type: Type? { get }
     var typeAttributes: [String: Attribute] { get }
     var defaultValue: String? { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var annotations: [String: NSObject] { get }
     var isOptional: Bool { get }
     var isImplicitlyUnwrappedOptional: Bool { get }
@@ -229,6 +244,9 @@ extension MethodParameter: MethodParameterAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }
@@ -268,6 +286,9 @@ extension Protocol: ProtocolAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }
@@ -354,6 +375,9 @@ extension TupleType: TupleTypeAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }

--- a/SourceryRuntime/Sources/Method.swift
+++ b/SourceryRuntime/Sources/Method.swift
@@ -29,6 +29,9 @@ public typealias SourceryMethod = Method
     /// Method parameter default value expression
     public var defaultValue: String?
 
+    /// Generic types with constraints
+    public var genericTypeParameters: [GenericTypeParameter]
+
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
     public var annotations: [String: NSObject] = [:]
 
@@ -38,7 +41,7 @@ public typealias SourceryMethod = Method
     public var __parserData: Any?
 
     /// :nodoc:
-    public init(argumentLabel: String?, name: String = "", typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false) {
+    public init(argumentLabel: String?, name: String = "", typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false, genericTypeParameters: [GenericTypeParameter] = []) {
         self.typeName = typeName
         self.argumentLabel = argumentLabel
         self.name = name
@@ -46,10 +49,11 @@ public typealias SourceryMethod = Method
         self.defaultValue = defaultValue
         self.annotations = annotations
         self.`inout` = isInout
+        self.genericTypeParameters = genericTypeParameters
     }
 
     /// :nodoc:
-    public init(name: String = "", typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false) {
+    public init(name: String = "", typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false, genericTypeParameters: [GenericTypeParameter] = []) {
         self.typeName = typeName
         self.argumentLabel = name
         self.name = name
@@ -57,6 +61,7 @@ public typealias SourceryMethod = Method
         self.defaultValue = defaultValue
         self.annotations = annotations
         self.`inout` = isInout
+        self.genericTypeParameters = genericTypeParameters
     }
 
 // sourcery:inline:MethodParameter.AutoCoding
@@ -68,6 +73,7 @@ public typealias SourceryMethod = Method
             self.`inout` = aDecoder.decode(forKey: "`inout`")
             self.type = aDecoder.decode(forKey: "type")
             self.defaultValue = aDecoder.decode(forKey: "defaultValue")
+            guard let genericTypeParameters: [GenericTypeParameter] = aDecoder.decode(forKey: "genericTypeParameters") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["genericTypeParameters"])); fatalError() }; self.genericTypeParameters = genericTypeParameters
             guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
         }
 
@@ -79,6 +85,7 @@ public typealias SourceryMethod = Method
             aCoder.encode(self.`inout`, forKey: "`inout`")
             aCoder.encode(self.type, forKey: "type")
             aCoder.encode(self.defaultValue, forKey: "defaultValue")
+            aCoder.encode(self.genericTypeParameters, forKey: "genericTypeParameters")
             aCoder.encode(self.annotations, forKey: "annotations")
         }
 // sourcery:end
@@ -232,6 +239,9 @@ public typealias SourceryMethod = Method
     /// Method attributes, i.e. `@discardableResult`
     public let attributes: [String: Attribute]
 
+    /// Generic type placeholders with constraints
+    public var genericTypePlaceholders: [GenericTypePlaceholder]
+
     // Underlying parser data, never to be used by anything else
     // sourcery: skipEquality, skipDescription, skipCoding, skipJSExport
     /// :nodoc:
@@ -250,7 +260,8 @@ public typealias SourceryMethod = Method
                 isFailableInitializer: Bool = false,
                 attributes: [String: Attribute] = [:],
                 annotations: [String: NSObject] = [:],
-                definedInTypeName: TypeName? = nil) {
+                definedInTypeName: TypeName? = nil,
+                genericTypePlaceholders: [GenericTypePlaceholder] = []) {
 
         self.name = name
         self.selectorName = selectorName ?? name
@@ -265,6 +276,7 @@ public typealias SourceryMethod = Method
         self.attributes = attributes
         self.annotations = annotations
         self.definedInTypeName = definedInTypeName
+        self.genericTypePlaceholders = genericTypePlaceholders
     }
 
 // sourcery:inline:Method.AutoCoding
@@ -285,6 +297,7 @@ public typealias SourceryMethod = Method
             self.definedInTypeName = aDecoder.decode(forKey: "definedInTypeName")
             self.definedInType = aDecoder.decode(forKey: "definedInType")
             guard let attributes: [String: Attribute] = aDecoder.decode(forKey: "attributes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["attributes"])); fatalError() }; self.attributes = attributes
+            guard let genericTypePlaceholders: [GenericTypePlaceholder] = aDecoder.decode(forKey: "genericTypePlaceholders") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["genericTypePlaceholders"])); fatalError() }; self.genericTypePlaceholders = genericTypePlaceholders
         }
 
         /// :nodoc:
@@ -304,6 +317,7 @@ public typealias SourceryMethod = Method
             aCoder.encode(self.definedInTypeName, forKey: "definedInTypeName")
             aCoder.encode(self.definedInType, forKey: "definedInType")
             aCoder.encode(self.attributes, forKey: "attributes")
+            aCoder.encode(self.genericTypePlaceholders, forKey: "genericTypePlaceholders")
         }
 // sourcery:end
 }

--- a/SourceryRuntime/Sources/Method.swift
+++ b/SourceryRuntime/Sources/Method.swift
@@ -17,7 +17,6 @@ public typealias SourceryMethod = Method
     /// Parameter flag whether it's inout or not
     public let `inout`: Bool
 
-    // sourcery: skipEquality, skipDescription
     /// Parameter type, if known
     public var type: Type?
 

--- a/SourceryRuntime/Sources/Protocol.swift
+++ b/SourceryRuntime/Sources/Protocol.swift
@@ -30,7 +30,8 @@ public typealias SourceryProtocol = Protocol
                          typealiases: [Typealias] = [],
                          attributes: [String: Attribute] = [:],
                          annotations: [String: NSObject] = [:],
-                         isGeneric: Bool = false) {
+                         genericTypePlaceholders: [GenericTypePlaceholder] = [],
+                         genericTypeParameters: [GenericTypeParameter] = []) {
         super.init(
             name: name,
             parent: parent,
@@ -43,7 +44,8 @@ public typealias SourceryProtocol = Protocol
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            isGeneric: isGeneric
+            genericTypePlaceholders: genericTypePlaceholders,
+            genericTypeParameters: genericTypeParameters
         )
     }
 

--- a/SourceryRuntime/Sources/ProtocolComposition.swift
+++ b/SourceryRuntime/Sources/ProtocolComposition.swift
@@ -46,7 +46,8 @@ import Foundation
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            isGeneric: isGeneric
+            genericTypePlaceholders: [],
+            genericTypeParameters: []
         )
     }
 

--- a/SourceryRuntime/Sources/Struct.swift
+++ b/SourceryRuntime/Sources/Struct.swift
@@ -28,7 +28,8 @@ import Foundation
                          typealiases: [Typealias] = [],
                          attributes: [String: Attribute] = [:],
                          annotations: [String: NSObject] = [:],
-                         isGeneric: Bool = false) {
+                         genericTypePlaceholders: [GenericTypePlaceholder] = [],
+                         genericTypeParameters: [GenericTypeParameter] = []) {
         super.init(
             name: name,
             parent: parent,
@@ -41,7 +42,8 @@ import Foundation
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            isGeneric: isGeneric
+            genericTypePlaceholders: genericTypePlaceholders,
+            genericTypeParameters: genericTypeParameters
         )
     }
 

--- a/SourceryRuntime/Sources/Subscript.swift
+++ b/SourceryRuntime/Sources/Subscript.swift
@@ -14,7 +14,6 @@ import Foundation
         return returnTypeName.actualTypeName ?? returnTypeName
     }
 
-    // sourcery: skipEquality, skipDescription
     /// Actual return value type, if known
     public var returnType: Type?
 

--- a/SourceryRuntime/Sources/Type.swift
+++ b/SourceryRuntime/Sources/Type.swift
@@ -44,7 +44,20 @@ import Foundation
     }
 
     /// Whether type is generic
-    public var isGeneric: Bool
+    public var isGeneric: Bool {
+        return !genericTypeParameters.isEmpty || !genericTypePlaceholders.isEmpty
+    }
+
+    /// Whether type has been concretely specified
+    public var isConcreteGenericType: Bool {
+        return isGeneric && !genericTypeParameters.isEmpty
+    }
+
+    // Generic type placeholders
+    public var genericTypePlaceholders: [GenericTypePlaceholder]
+
+    /// Generic type parameters
+    public var genericTypeParameters: [GenericTypeParameter]
 
     /// Type name in its own scope.
     public var localName: String
@@ -240,7 +253,8 @@ import Foundation
                 typealiases: [Typealias] = [],
                 attributes: [String: Attribute] = [:],
                 annotations: [String: NSObject] = [:],
-                isGeneric: Bool = false) {
+                genericTypePlaceholders: [GenericTypePlaceholder] = [],
+                genericTypeParameters: [GenericTypeParameter] = []) {
 
         self.localName = name
         self.accessLevel = accessLevel.rawValue
@@ -255,7 +269,8 @@ import Foundation
         self.parentName = parent?.name
         self.attributes = attributes
         self.annotations = annotations
-        self.isGeneric = isGeneric
+        self.genericTypeParameters = genericTypeParameters
+        self.genericTypePlaceholders = genericTypePlaceholders
 
         super.init()
         containedTypes.forEach {
@@ -291,7 +306,8 @@ import Foundation
             guard let typealiases: [String: Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             self.isExtension = aDecoder.decode(forKey: "isExtension")
             guard let accessLevel: String = aDecoder.decode(forKey: "accessLevel") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["accessLevel"])); fatalError() }; self.accessLevel = accessLevel
-            self.isGeneric = aDecoder.decode(forKey: "isGeneric")
+            guard let genericTypePlaceholders: [GenericTypePlaceholder] = aDecoder.decode(forKey: "genericTypePlaceholders") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["genericTypePlaceholders"])); fatalError() }; self.genericTypePlaceholders = genericTypePlaceholders
+            guard let genericTypeParameters: [GenericTypeParameter] = aDecoder.decode(forKey: "genericTypeParameters") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["genericTypeParameters"])); fatalError() }; self.genericTypeParameters = genericTypeParameters
             guard let localName: String = aDecoder.decode(forKey: "localName") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["localName"])); fatalError() }; self.localName = localName
             guard let variables: [Variable] = aDecoder.decode(forKey: "variables") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["variables"])); fatalError() }; self.variables = variables
             guard let methods: [Method] = aDecoder.decode(forKey: "methods") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["methods"])); fatalError() }; self.methods = methods
@@ -317,7 +333,8 @@ import Foundation
             aCoder.encode(self.typealiases, forKey: "typealiases")
             aCoder.encode(self.isExtension, forKey: "isExtension")
             aCoder.encode(self.accessLevel, forKey: "accessLevel")
-            aCoder.encode(self.isGeneric, forKey: "isGeneric")
+            aCoder.encode(self.genericTypePlaceholders, forKey: "genericTypePlaceholders")
+            aCoder.encode(self.genericTypeParameters, forKey: "genericTypeParameters")
             aCoder.encode(self.localName, forKey: "localName")
             aCoder.encode(self.variables, forKey: "variables")
             aCoder.encode(self.methods, forKey: "methods")

--- a/SourceryRuntime/Sources/Type.swift
+++ b/SourceryRuntime/Sources/Type.swift
@@ -53,7 +53,7 @@ import Foundation
         return isGeneric && !genericTypeParameters.isEmpty
     }
 
-    // Generic type placeholders
+    /// Generic type placeholders
     public var genericTypePlaceholders: [GenericTypePlaceholder]
 
     /// Generic type parameters

--- a/SourceryRuntime/Sources/TypeName.swift
+++ b/SourceryRuntime/Sources/TypeName.swift
@@ -264,6 +264,36 @@ public protocol Typed {
 // sourcery:end
 }
 
+// Describes Swift generic type placeholder
+@objcMembers public final class GenericTypePlaceholder: NSObject, SourceryModel {
+    /// Generic placeholder type name
+    public var placeholderName: TypeName
+
+    /// Generic type parameter constraints
+    public var constraints: [Type]
+
+    /// :nodoc:
+    public init(placeholderName: TypeName, constraints: [Type] = []) {
+        self.placeholderName = placeholderName
+        self.constraints = constraints
+    }
+
+    // sourcery:inline:GenericTypePlaceholder.AutoCoding
+            /// :nodoc:
+            required public init?(coder aDecoder: NSCoder) {
+                guard let placeholderName: TypeName = aDecoder.decode(forKey: "placeholderName") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["placeholderName"])); fatalError() }; self.placeholderName = placeholderName
+                guard let constraints: [Type] = aDecoder.decode(forKey: "constraints") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["constraints"])); fatalError() }; self.constraints = constraints
+            }
+
+            /// :nodoc:
+            public func encode(with aCoder: NSCoder) {
+                aCoder.encode(self.placeholderName, forKey: "placeholderName")
+                aCoder.encode(self.constraints, forKey: "constraints")
+            }
+
+    // sourcery:end
+}
+
 /// Descibes Swift generic type
 @objcMembers public final class GenericType: NSObject, SourceryModel {
     /// The name of the base type, i.e. `Array` for `Array<Int>`

--- a/SourceryRuntime/Sources/TypeName.swift
+++ b/SourceryRuntime/Sources/TypeName.swift
@@ -264,7 +264,7 @@ public protocol Typed {
 // sourcery:end
 }
 
-// Describes Swift generic type placeholder
+/// Describes Swift generic type placeholder
 @objcMembers public final class GenericTypePlaceholder: NSObject, SourceryModel {
     /// Generic placeholder type name
     public var placeholderName: TypeName

--- a/SourceryRuntime/Sources/Typealias.swift
+++ b/SourceryRuntime/Sources/Typealias.swift
@@ -9,7 +9,6 @@ import Foundation
     // Target name
     public let typeName: TypeName
 
-    // sourcery: skipEquality, skipDescription
     public var type: Type?
 
     // sourcery: skipEquality, skipDescription

--- a/SourceryRuntime/Sources/Variable.swift
+++ b/SourceryRuntime/Sources/Variable.swift
@@ -16,7 +16,6 @@ public typealias SourceryVariable = Variable
     /// Variable type name
     public let typeName: TypeName
 
-    // sourcery: skipEquality, skipDescription
     /// Variable type, if known, i.e. if the type is declared in the scanned sources.
     /// For explanation, see <https://cdn.rawgit.com/krzysztofzablocki/Sourcery/master/docs/writing-templates.html#what-are-em-known-em-and-em-unknown-em-types>
     public var type: Type?

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -381,6 +381,8 @@ extension GenericType: NSCoding {}
 
 extension GenericTypeParameter: NSCoding {}
 
+extension GenericTypePlaceholder: NSCoding {}
+
 extension Method: NSCoding {}
 
 extension MethodParameter: NSCoding {}
@@ -553,6 +555,15 @@ extension GenericTypeParameter {
         return string
     }
 }
+extension GenericTypePlaceholder {
+    /// :nodoc:
+    override public var description: String {
+        var string = "\\(Swift.type(of: self)): "
+        string += "placeholderName = \\(String(describing: self.placeholderName)), "
+        string += "constraints = \\(String(describing: self.constraints))"
+        return string
+    }
+}
 extension Method {
     /// :nodoc:
     override public var description: String {
@@ -569,7 +580,8 @@ extension Method {
         string += "isFailableInitializer = \\(String(describing: self.isFailableInitializer)), "
         string += "annotations = \\(String(describing: self.annotations)), "
         string += "definedInTypeName = \\(String(describing: self.definedInTypeName)), "
-        string += "attributes = \\(String(describing: self.attributes))"
+        string += "attributes = \\(String(describing: self.attributes)), "
+        string += "genericTypePlaceholders = \\(String(describing: self.genericTypePlaceholders))"
         return string
     }
 }
@@ -583,6 +595,7 @@ extension MethodParameter {
         string += "`inout` = \\(String(describing: self.`inout`)), "
         string += "typeAttributes = \\(String(describing: self.typeAttributes)), "
         string += "defaultValue = \\(String(describing: self.defaultValue)), "
+        string += "genericTypeParameters = \\(String(describing: self.genericTypeParameters)), "
         string += "annotations = \\(String(describing: self.annotations))"
         return string
     }
@@ -672,6 +685,9 @@ extension Type {
         string += "accessLevel = \\(String(describing: self.accessLevel)), "
         string += "name = \\(String(describing: self.name)), "
         string += "isGeneric = \\(String(describing: self.isGeneric)), "
+        string += "isConcreteGenericType = \\(String(describing: self.isConcreteGenericType)), "
+        string += "genericTypePlaceholders = \\(String(describing: self.genericTypePlaceholders)), "
+        string += "genericTypeParameters = \\(String(describing: self.genericTypeParameters)), "
         string += "localName = \\(String(describing: self.localName)), "
         string += "variables = \\(String(describing: self.variables)), "
         string += "methods = \\(String(describing: self.methods)), "
@@ -900,6 +916,18 @@ extension GenericTypeParameter: Diffable {
         return results
     }
 }
+extension GenericTypePlaceholder: Diffable {
+    @objc func diffAgainst(_ object: Any?) -> DiffableResult {
+        let results = DiffableResult()
+        guard let castObject = object as? GenericTypePlaceholder else {
+            results.append("Incorrect type <expected: GenericTypePlaceholder, received: \\(Swift.type(of: object))>")
+            return results
+        }
+        results.append(contentsOf: DiffableResult(identifier: "placeholderName").trackDifference(actual: self.placeholderName, expected: castObject.placeholderName))
+        results.append(contentsOf: DiffableResult(identifier: "constraints").trackDifference(actual: self.constraints, expected: castObject.constraints))
+        return results
+    }
+}
 extension Method: Diffable {
     @objc func diffAgainst(_ object: Any?) -> DiffableResult {
         let results = DiffableResult()
@@ -920,6 +948,7 @@ extension Method: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
+        results.append(contentsOf: DiffableResult(identifier: "genericTypePlaceholders").trackDifference(actual: self.genericTypePlaceholders, expected: castObject.genericTypePlaceholders))
         return results
     }
 }
@@ -935,6 +964,7 @@ extension MethodParameter: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
         results.append(contentsOf: DiffableResult(identifier: "`inout`").trackDifference(actual: self.`inout`, expected: castObject.`inout`))
         results.append(contentsOf: DiffableResult(identifier: "defaultValue").trackDifference(actual: self.defaultValue, expected: castObject.defaultValue))
+        results.append(contentsOf: DiffableResult(identifier: "genericTypeParameters").trackDifference(actual: self.genericTypeParameters, expected: castObject.genericTypeParameters))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         return results
     }
@@ -1037,7 +1067,8 @@ extension Type: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "isExtension").trackDifference(actual: self.isExtension, expected: castObject.isExtension))
         results.append(contentsOf: DiffableResult(identifier: "accessLevel").trackDifference(actual: self.accessLevel, expected: castObject.accessLevel))
-        results.append(contentsOf: DiffableResult(identifier: "isGeneric").trackDifference(actual: self.isGeneric, expected: castObject.isGeneric))
+        results.append(contentsOf: DiffableResult(identifier: "genericTypePlaceholders").trackDifference(actual: self.genericTypePlaceholders, expected: castObject.genericTypePlaceholders))
+        results.append(contentsOf: DiffableResult(identifier: "genericTypeParameters").trackDifference(actual: self.genericTypeParameters, expected: castObject.genericTypeParameters))
         results.append(contentsOf: DiffableResult(identifier: "localName").trackDifference(actual: self.localName, expected: castObject.localName))
         results.append(contentsOf: DiffableResult(identifier: "variables").trackDifference(actual: self.variables, expected: castObject.variables))
         results.append(contentsOf: DiffableResult(identifier: "methods").trackDifference(actual: self.methods, expected: castObject.methods))
@@ -1682,6 +1713,15 @@ extension GenericTypeParameter {
         return true
     }
 }
+extension GenericTypePlaceholder {
+    /// :nodoc:
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? GenericTypePlaceholder else { return false }
+        if self.placeholderName != rhs.placeholderName { return false }
+        if self.constraints != rhs.constraints { return false }
+        return true
+    }
+}
 extension Method {
     /// :nodoc:
     override public func isEqual(_ object: Any?) -> Bool {
@@ -1699,6 +1739,7 @@ extension Method {
         if self.annotations != rhs.annotations { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
         if self.attributes != rhs.attributes { return false }
+        if self.genericTypePlaceholders != rhs.genericTypePlaceholders { return false }
         return true
     }
 }
@@ -1711,6 +1752,7 @@ extension MethodParameter {
         if self.typeName != rhs.typeName { return false }
         if self.`inout` != rhs.`inout` { return false }
         if self.defaultValue != rhs.defaultValue { return false }
+        if self.genericTypeParameters != rhs.genericTypeParameters { return false }
         if self.annotations != rhs.annotations { return false }
         return true
     }
@@ -1786,7 +1828,8 @@ extension Type {
         if self.typealiases != rhs.typealiases { return false }
         if self.isExtension != rhs.isExtension { return false }
         if self.accessLevel != rhs.accessLevel { return false }
-        if self.isGeneric != rhs.isGeneric { return false }
+        if self.genericTypePlaceholders != rhs.genericTypePlaceholders { return false }
+        if self.genericTypeParameters != rhs.genericTypeParameters { return false }
         if self.localName != rhs.localName { return false }
         if self.variables != rhs.variables { return false }
         if self.methods != rhs.methods { return false }
@@ -2171,6 +2214,9 @@ extension BytesRange: BytesRangeAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }
@@ -2238,6 +2284,9 @@ extension DictionaryType: DictionaryTypeAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }
@@ -2292,6 +2341,13 @@ extension GenericType: GenericTypeAutoJSExport {}
 
 extension GenericTypeParameter: GenericTypeParameterAutoJSExport {}
 
+@objc protocol GenericTypePlaceholderAutoJSExport: JSExport {
+    var placeholderName: TypeName { get }
+    var constraints: [Type] { get }
+}
+
+extension GenericTypePlaceholder: GenericTypePlaceholderAutoJSExport {}
+
 @objc protocol MethodAutoJSExport: JSExport {
     var name: String { get }
     var selectorName: String { get }
@@ -2323,6 +2379,7 @@ extension GenericTypeParameter: GenericTypeParameterAutoJSExport {}
     var actualDefinedInTypeName: TypeName? { get }
     var definedInType: Type? { get }
     var attributes: [String: Attribute] { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
 }
 
 extension Method: MethodAutoJSExport {}
@@ -2335,6 +2392,7 @@ extension Method: MethodAutoJSExport {}
     var type: Type? { get }
     var typeAttributes: [String: Attribute] { get }
     var defaultValue: String? { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var annotations: [String: NSObject] { get }
     var isOptional: Bool { get }
     var isImplicitlyUnwrappedOptional: Bool { get }
@@ -2350,6 +2408,9 @@ extension MethodParameter: MethodParameterAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }
@@ -2389,6 +2450,9 @@ extension Protocol: ProtocolAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }
@@ -2475,6 +2539,9 @@ extension TupleType: TupleTypeAutoJSExport {}
     var name: String { get }
     var globalName: String { get }
     var isGeneric: Bool { get }
+    var isConcreteGenericType: Bool { get }
+    var genericTypePlaceholders: [GenericTypePlaceholder] { get }
+    var genericTypeParameters: [GenericTypeParameter] { get }
     var localName: String { get }
     var variables: [Variable] { get }
     var allVariables: [Variable] { get }

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -593,6 +593,7 @@ extension MethodParameter {
         string += "name = \\(String(describing: self.name)), "
         string += "typeName = \\(String(describing: self.typeName)), "
         string += "`inout` = \\(String(describing: self.`inout`)), "
+        string += "type = \\(String(describing: self.type)), "
         string += "typeAttributes = \\(String(describing: self.typeAttributes)), "
         string += "defaultValue = \\(String(describing: self.defaultValue)), "
         string += "genericTypeParameters = \\(String(describing: self.genericTypeParameters)), "
@@ -635,6 +636,7 @@ extension Subscript {
         string += "parameters = \\(String(describing: self.parameters)), "
         string += "returnTypeName = \\(String(describing: self.returnTypeName)), "
         string += "actualReturnTypeName = \\(String(describing: self.actualReturnTypeName)), "
+        string += "returnType = \\(String(describing: self.returnType)), "
         string += "isFinal = \\(String(describing: self.isFinal)), "
         string += "readAccess = \\(String(describing: self.readAccess)), "
         string += "writeAccess = \\(String(describing: self.writeAccess)), "
@@ -715,6 +717,7 @@ extension Typealias {
         var string = "\\(Swift.type(of: self)): "
         string += "aliasName = \\(String(describing: self.aliasName)), "
         string += "typeName = \\(String(describing: self.typeName)), "
+        string += "type = \\(String(describing: self.type)), "
         string += "parentName = \\(String(describing: self.parentName)), "
         string += "name = \\(String(describing: self.name))"
         return string
@@ -964,6 +967,7 @@ extension MethodParameter: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: castObject.name))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
         results.append(contentsOf: DiffableResult(identifier: "`inout`").trackDifference(actual: self.`inout`, expected: castObject.`inout`))
+        results.append(contentsOf: DiffableResult(identifier: "type").trackDifference(actual: self.type, expected: castObject.type))
         results.append(contentsOf: DiffableResult(identifier: "defaultValue").trackDifference(actual: self.defaultValue, expected: castObject.defaultValue))
         results.append(contentsOf: DiffableResult(identifier: "genericTypeParameters").trackDifference(actual: self.genericTypeParameters, expected: castObject.genericTypeParameters))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
@@ -1013,6 +1017,7 @@ extension Subscript: Diffable {
         }
         results.append(contentsOf: DiffableResult(identifier: "parameters").trackDifference(actual: self.parameters, expected: castObject.parameters))
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
+        results.append(contentsOf: DiffableResult(identifier: "returnType").trackDifference(actual: self.returnType, expected: castObject.returnType))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
@@ -1109,6 +1114,7 @@ extension Typealias: Diffable {
         }
         results.append(contentsOf: DiffableResult(identifier: "aliasName").trackDifference(actual: self.aliasName, expected: castObject.aliasName))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "type").trackDifference(actual: self.type, expected: castObject.type))
         results.append(contentsOf: DiffableResult(identifier: "parentName").trackDifference(actual: self.parentName, expected: castObject.parentName))
         return results
     }
@@ -1753,6 +1759,7 @@ extension MethodParameter {
         if self.name != rhs.name { return false }
         if self.typeName != rhs.typeName { return false }
         if self.`inout` != rhs.`inout` { return false }
+        if self.type != rhs.type { return false }
         if self.defaultValue != rhs.defaultValue { return false }
         if self.genericTypeParameters != rhs.genericTypeParameters { return false }
         if self.annotations != rhs.annotations { return false }
@@ -1787,6 +1794,7 @@ extension Subscript {
         guard let rhs = object as? Subscript else { return false }
         if self.parameters != rhs.parameters { return false }
         if self.returnTypeName != rhs.returnTypeName { return false }
+        if self.returnType != rhs.returnType { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
         if self.annotations != rhs.annotations { return false }
@@ -1866,6 +1874,7 @@ extension Typealias {
         guard let rhs = object as? Typealias else { return false }
         if self.aliasName != rhs.aliasName { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.type != rhs.type { return false }
         if self.parentName != rhs.parentName { return false }
         return true
     }
@@ -2707,7 +2716,6 @@ public typealias SourceryMethod = Method
     /// Parameter flag whether it's inout or not
     public let `inout`: Bool
 
-    // sourcery: skipEquality, skipDescription
     /// Parameter type, if known
     public var type: Type?
 
@@ -3270,7 +3278,6 @@ import Foundation
         return returnTypeName.actualTypeName ?? returnTypeName
     }
 
-    // sourcery: skipEquality, skipDescription
     /// Actual return value type, if known
     public var returnType: Type?
 
@@ -4573,7 +4580,6 @@ import Foundation
     // Target name
     public let typeName: TypeName
 
-    // sourcery: skipEquality, skipDescription
     public var type: Type?
 
     // sourcery: skipEquality, skipDescription

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -3172,8 +3172,8 @@ import Foundation
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            genericTypePlaceholders: genericTypePlaceholders,
-            genericTypeParameters: genericTypeParameters
+            genericTypePlaceholders: [],
+            genericTypeParameters: []
         )
     }
 
@@ -3242,7 +3242,8 @@ import Foundation
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            isGeneric: isGeneric
+            genericTypePlaceholders: genericTypePlaceholders,
+            genericTypeParameters: genericTypeParameters
         )
     }
 

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -734,6 +734,7 @@ extension Variable {
         var string = "\\(Swift.type(of: self)): "
         string += "name = \\(String(describing: self.name)), "
         string += "typeName = \\(String(describing: self.typeName)), "
+        string += "type = \\(String(describing: self.type)), "
         string += "isComputed = \\(String(describing: self.isComputed)), "
         string += "isStatic = \\(String(describing: self.isStatic)), "
         string += "readAccess = \\(String(describing: self.readAccess)), "
@@ -1132,6 +1133,7 @@ extension Variable: Diffable {
         }
         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: castObject.name))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "type").trackDifference(actual: self.type, expected: castObject.type))
         results.append(contentsOf: DiffableResult(identifier: "isComputed").trackDifference(actual: self.isComputed, expected: castObject.isComputed))
         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: castObject.isStatic))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
@@ -1882,6 +1884,7 @@ extension Variable {
         guard let rhs = object as? Variable else { return false }
         if self.name != rhs.name { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.type != rhs.type { return false }
         if self.isComputed != rhs.isComputed { return false }
         if self.isStatic != rhs.isStatic { return false }
         if self.readAccess != rhs.readAccess { return false }
@@ -4741,7 +4744,6 @@ public typealias SourceryVariable = Variable
     /// Variable type name
     public let typeName: TypeName
 
-    // sourcery: skipEquality, skipDescription
     /// Variable type, if known, i.e. if the type is declared in the scanned sources.
     /// For explanation, see <https://cdn.rawgit.com/krzysztofzablocki/Sourcery/master/docs/writing-templates.html#what-are-em-known-em-and-em-unknown-em-types>
     public var type: Type?

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -3698,7 +3698,7 @@ import Foundation
         return isGeneric && !genericTypeParameters.isEmpty
     }
 
-    // Generic type placeholders
+    /// Generic type placeholders
     public var genericTypePlaceholders: [GenericTypePlaceholder]
 
     /// Generic type parameters
@@ -4279,7 +4279,7 @@ public protocol Typed {
 // sourcery:end
 }
 
-// Describes Swift generic type placeholder
+/// Describes Swift generic type placeholder
 @objcMembers public final class GenericTypePlaceholder: NSObject, SourceryModel {
     /// Generic placeholder type name
     public var placeholderName: TypeName

--- a/SourceryTests/Models/TypeSpec.swift
+++ b/SourceryTests/Models/TypeSpec.swift
@@ -75,14 +75,6 @@ class TypeSpec: QuickSpec {
             }
 
             describe("isGeneric") {
-                context("given generic type") {
-                    it("recognizes correctly for simple generic") {
-                        let sut = Type(name: "Foo", isGeneric: true)
-
-                        expect(sut.isGeneric).to(beTrue())
-                    }
-                }
-
                 context("given non-generic type") {
                     it("recognizes correctly for simple type") {
                         let sut = Type(name: "Foo")

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -274,8 +274,8 @@ class ParserComposerSpec: QuickSpec {
                         let variable = types.first?.variables.first
                         let tuple = variable?.typeName.tuple
 
-                        let stringToFloatDictGeneric = GenericType(name: "Dictionary<String, Float>", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
-                        let stringToFloatDictGenericLiteral = GenericType(name: "[String: Float]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
+                        let stringToFloatDictGeneric = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
+                        let stringToFloatDictGenericLiteral = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
 
                         let stringToFloatDict = DictionaryType(name: "Dictionary<String, Float>", valueTypeName: TypeName("Float"), keyTypeName: TypeName("String"))
                         let stringToFloatDictLiteral = DictionaryType(name: "[String: Float]", valueTypeName: TypeName("Float"), keyTypeName: TypeName("String"))
@@ -285,10 +285,10 @@ class ParserComposerSpec: QuickSpec {
                         expect(tuple?.elements[2]).to(equal(TupleElement(name: "2", typeName: TypeName("String"))))
                         expect(tuple?.elements[3]).to(equal(TupleElement(name: "3", typeName: TypeName("Float"))))
                         expect(tuple?.elements[4]).to(equal(
-                            TupleElement(name: "literal", typeName: TypeName("[String: [String: Float]]", dictionary: DictionaryType(name: "[String: [String: Float]]", valueTypeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral), keyTypeName: TypeName("String")), generic: GenericType(name: "[String: [String: Float]]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral))])))
+                            TupleElement(name: "literal", typeName: TypeName("[String: [String: Float]]", dictionary: DictionaryType(name: "[String: [String: Float]]", valueTypeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral))])))
                         ))
                         expect(tuple?.elements[5]).to(equal(
-                            TupleElement(name: "generic", typeName: TypeName("Dictionary<String, Dictionary<String, Float>>", dictionary: DictionaryType(name: "Dictionary<String, Dictionary<String, Float>>", valueTypeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary<String, Dictionary<String, Float>>", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric))])))
+                            TupleElement(name: "generic", typeName: TypeName("Dictionary<String, Dictionary<String, Float>>", dictionary: DictionaryType(name: "Dictionary<String, Dictionary<String, Float>>", valueTypeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric))])))
                         ))
                         expect(tuple?.elements[6]).to(equal(
                             TupleElement(name: "closure", typeName: TypeName("(Int) -> (Int -> Int)", closure: ClosureType(name: "(Int) -> (Int -> Int)", parameters: [
@@ -320,7 +320,7 @@ class ParserComposerSpec: QuickSpec {
                                     ])))
                         ))
                         expect(variables?[2].typeName.array).to(equal(
-                            ArrayType(name: "[[Int]]", elementTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                            ArrayType(name: "[[Int]]", elementTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[3].typeName.array).to(equal(
                             ArrayType(name: "[()->()]", elementTypeName: TypeName("()->()", closure: ClosureType(name: "() -> ()", parameters: [], returnTypeName: TypeName("()"))))
@@ -343,7 +343,7 @@ class ParserComposerSpec: QuickSpec {
                                     ])))
                         ))
                         expect(variables?[2].typeName.array).to(equal(
-                            ArrayType(name: "Array<Array<Int>>", elementTypeName: TypeName("Array<Int>", array: ArrayType(name: "Array<Int>", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array<Int>", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                            ArrayType(name: "Array<Array<Int>>", elementTypeName: TypeName("Array<Int>", array: ArrayType(name: "Array<Int>", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[3].typeName.array).to(equal(
                             ArrayType(name: "Array<()->()>", elementTypeName: TypeName("()->()", closure: ClosureType(name: "() -> ()", parameters: [], returnTypeName: TypeName("()"))))
@@ -364,11 +364,11 @@ class ParserComposerSpec: QuickSpec {
                                            valueTypeName: TypeName("[String]",
                                                                    array: ArrayType(name: "[String]",
                                                                                     elementTypeName: TypeName("String")),
-                                                                   generic: GenericType(name: "[String]",
+                                                                   generic: GenericType(name: "Array",
                                                                                         typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])),
                                            keyTypeName: TypeName("[Int]",
                                                                  array:
-                                ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                                ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[2].typeName.dictionary).to(equal(
                             DictionaryType(name: "Dictionary<Int, [Int: String]>",
@@ -376,7 +376,7 @@ class ParserComposerSpec: QuickSpec {
                                                                    dictionary: DictionaryType(name: "[Int: String]",
                                                                                               valueTypeName: TypeName("String"),
                                                                                               keyTypeName: TypeName("Int")),
-                                                                   generic: GenericType(name: "[Int: String]",
+                                                                   generic: GenericType(name: "Dictionary",
                                                                                         typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])),
                                            keyTypeName: TypeName("Int"))
                         ))
@@ -408,7 +408,6 @@ class ParserComposerSpec: QuickSpec {
                             """)
                         let bar = SourceryProtocol.init(name: "Bar")
                         let variables = types[3].variables
-                        // FIXME: The reason why this test is failing, is currently GenericType.name for Array<Int> is "Array<Int>" instead of Array, as outlined in documentation for this property
                         expect(variables[0].type?.implements["Bar"]).to(equal(bar))
                         expect(variables[1].type?.implements["Bar"]).to(equal(bar))
                         expect(variables[2].type?.implements["Bar"]).to(equal(bar))
@@ -426,13 +425,13 @@ class ParserComposerSpec: QuickSpec {
                         ))
                         expect(variables?[1].typeName.dictionary).to(equal(
                             DictionaryType(name: "[[Int]: [String]]",
-                                           valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "[String]", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])),
-                                           keyTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))]))
+                                           valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])),
+                                           keyTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))]))
                             )
                         ))
                         expect(variables?[2].typeName.dictionary).to(equal(
                             DictionaryType(name: "[Int: [Int: String]]",
-                                           valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "[Int: String]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])),
+                                           valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])),
                                            keyTypeName: TypeName("Int")
                             )
                         ))
@@ -802,7 +801,7 @@ class ParserComposerSpec: QuickSpec {
                         it("replaces associated value alias type with actual dictionary type name") {
                             var expectedTypeName = TypeName("[String: Any]")
                             expectedTypeName.dictionary = DictionaryType(name: "[String: Any]", valueTypeName: TypeName("Any"), valueType: nil, keyTypeName: TypeName("String"), keyType: nil)
-                            expectedTypeName.generic = GenericType(name: "[String: Any]", typeParameters: [GenericTypeParameter(typeName: TypeName("String"), type: nil), GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
+                            expectedTypeName.generic = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String"), type: nil), GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
 
                             let expectedAssociatedValue = AssociatedValue(typeName: TypeName("JSON", actualTypeName: expectedTypeName, dictionary: expectedTypeName.dictionary, generic: expectedTypeName.generic), type: nil)
 
@@ -816,7 +815,7 @@ class ParserComposerSpec: QuickSpec {
                         it("replaces associated value alias type with actual array type name") {
                             let expectedTypeName = TypeName("[Any]")
                             expectedTypeName.array = ArrayType(name: "[Any]", elementTypeName: TypeName("Any"), elementType: nil)
-                            expectedTypeName.generic = GenericType(name: "[Any]", typeParameters: [GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
+                            expectedTypeName.generic = GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
 
                             let expectedAssociatedValue = AssociatedValue(typeName: TypeName("JSON", actualTypeName: expectedTypeName, array: expectedTypeName.array, generic: expectedTypeName.generic), type: nil)
 
@@ -1027,7 +1026,7 @@ class ParserComposerSpec: QuickSpec {
                         let expectedBlah = Struct(name: "Blah", containedTypes: [Struct(name: "Foo"), Struct(name: "Bar", variables: [expectedVariable])])
                         expectedActualTypeName.array = ArrayType(name: "[Blah.Foo]?", elementTypeName: TypeName("Blah.Foo"), elementType: Struct(name: "Foo", parent: expectedBlah))
                         expectedVariable.typeName.array = expectedActualTypeName.array
-                        expectedActualTypeName.generic = GenericType(name: "[Blah.Foo]?", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
+                        expectedActualTypeName.generic = GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
                         expectedVariable.typeName.generic = expectedActualTypeName.generic
 
                         let types = parse("struct Blah { struct Foo {}; struct Bar { let foo: [Foo]? }}")
@@ -1045,7 +1044,7 @@ class ParserComposerSpec: QuickSpec {
                         let expectedBlah = Struct(name: "Blah", containedTypes: [Struct(name: "Foo"), Struct(name: "Bar", variables: [expectedVariable])])
                         expectedActualTypeName.dictionary = DictionaryType(name: "[Blah.Foo: Blah.Foo]?", valueTypeName: TypeName("Blah.Foo"), valueType: Struct(name: "Foo", parent: expectedBlah), keyTypeName: TypeName("Blah.Foo"), keyType: Struct(name: "Foo", parent: expectedBlah))
                         expectedVariable.typeName.dictionary = expectedActualTypeName.dictionary
-                        expectedActualTypeName.generic = GenericType(name: "[Blah.Foo: Blah.Foo]?", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah)), GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
+                        expectedActualTypeName.generic = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah)), GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
                         expectedVariable.typeName.generic = expectedActualTypeName.generic
 
                         let types = parse("struct Blah { struct Foo {}; struct Bar { let foo: [Foo: Foo]? }}")

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -73,12 +73,14 @@ class ParserComposerSpec: QuickSpec {
                     beforeEach {
                         method = Method(name: "fooMethod(bar: String)", selectorName: "fooMethod(bar:)",
                                         parameters: [MethodParameter(name: "bar",
-                                                                     typeName: TypeName("String"))],
+                                                                     typeName: TypeName("String"),
+                                                                     type: Type(name: "String"))],
                                         returnTypeName: TypeName("Void"),
                                         definedInTypeName: TypeName("Foo"))
                         defaultedMethod = Method(name: "fooMethod(bar: String = \"Baz\")", selectorName: "fooMethod(bar:)",
                                                  parameters: [MethodParameter(name: "bar",
                                                                               typeName: TypeName("String"),
+                                                                              type: Type(name: "String"),
                                                                               defaultValue: "\"Baz\"")],
                                                  returnTypeName: TypeName("Void"),
                                                  definedInTypeName: TypeName("Foo"))
@@ -207,7 +209,8 @@ class ParserComposerSpec: QuickSpec {
                                                                                 definedInTypeName: TypeName("Foo"))],
                                                            methods: [Method(name: "init?(rawValue: String)", selectorName: "init(rawValue:)",
                                                                             parameters: [MethodParameter(name: "rawValue",
-                                                                                                         typeName: TypeName("String"))],
+                                                                                                         typeName: TypeName("String"),
+                                                                                                         type: Type(name: "String"))],
                                                                             returnTypeName: TypeName("Foo?"),
                                                                             isFailableInitializer: true,
                                                                             definedInTypeName: TypeName("Foo"))]
@@ -231,7 +234,7 @@ class ParserComposerSpec: QuickSpec {
                                                                                 isStatic: false,
                                                                                 definedInTypeName: TypeName("Foo"))],
                                                            methods: [Method(name: "init?(rawValue: RawValue)", selectorName: "init(rawValue:)",
-                                                                            parameters: [MethodParameter(name: "rawValue", typeName: TypeName("RawValue"))],
+                                                                            parameters: [MethodParameter(name: "rawValue", typeName: TypeName("RawValue"), type: Type(name: "RawValue"))],
                                                                             returnTypeName: TypeName("Foo?"),
                                                                             isFailableInitializer: true,
                                                                             definedInTypeName: TypeName("Foo"))],
@@ -255,7 +258,7 @@ class ParserComposerSpec: QuickSpec {
                                                                                 isStatic: false,
                                                                                 definedInTypeName: TypeName("Foo"))],
                                                            methods: [Method(name: "init?(rawValue: RawValue)", selectorName: "init(rawValue:)",
-                                                                            parameters: [MethodParameter(name: "rawValue", typeName: TypeName("RawValue"))],
+                                                                            parameters: [MethodParameter(name: "rawValue", typeName: TypeName("RawValue"), type: Type(name: "RawValue"))],
                                                                             returnTypeName: TypeName("Foo?"),
                                                                             isFailableInitializer: true,
                                                                             definedInTypeName: TypeName("Foo"))],
@@ -289,9 +292,9 @@ class ParserComposerSpec: QuickSpec {
                         ))
                         expect(tuple?.elements[6]).to(equal(
                             TupleElement(name: "closure", typeName: TypeName("(Int) -> (Int -> Int)", closure: ClosureType(name: "(Int) -> (Int -> Int)", parameters: [
-                                MethodParameter(argumentLabel: nil, typeName: TypeName("Int"))
+                                MethodParameter(argumentLabel: nil, typeName: TypeName("Int"), type: Type(name: "Int"))
                                 ], returnTypeName: TypeName("(Int -> Int)", closure: ClosureType(name: "(Int) -> Int", parameters: [
-                                    MethodParameter(argumentLabel: nil, typeName: TypeName("Int"))
+                                    MethodParameter(argumentLabel: nil, typeName: TypeName("Int"), type: Type(name: "Int"))
                                     ], returnTypeName: TypeName("Int"))))))
                         ))
                         expect(tuple?.elements[7]).to(equal(TupleElement(name: "tuple", typeName: TypeName("(Int, Int)", tuple:
@@ -498,7 +501,7 @@ class ParserComposerSpec: QuickSpec {
 
                         expect(variables?[0].typeName.closure).to(equal(
                             ClosureType(name: "() -> Int throws -> Int", parameters: [], returnTypeName: TypeName("Int throws -> Int", closure: ClosureType(name: "(Int) throws -> Int", parameters: [
-                                MethodParameter(argumentLabel: nil, typeName: TypeName("Int"))
+                                MethodParameter(argumentLabel: nil, typeName: TypeName("Int"), type: Type(name: "Int"))
                                 ], returnTypeName: TypeName("Int"), throws: true
                             )))
                         ))
@@ -528,10 +531,10 @@ class ParserComposerSpec: QuickSpec {
 
                         expect(variables?[0].typeName.closure).to(equal(
                             ClosureType(name: "(Int, Int -> Int) -> Int", parameters: [
-                                MethodParameter(argumentLabel: nil, typeName: TypeName("Int")),
+                                MethodParameter(argumentLabel: nil, typeName: TypeName("Int"), type: Type(name: "Int")),
                                 MethodParameter(argumentLabel: nil, typeName: TypeName("Int -> Int", closure: ClosureType(name: "(Int) -> Int", parameters: [
-                                    MethodParameter(argumentLabel: nil, typeName: TypeName("Int"))
-                                    ], returnTypeName: TypeName("Int"))))
+                                    MethodParameter(argumentLabel: nil, typeName: TypeName("Int"), type: Type(name: "Int"))
+                                    ], returnTypeName: TypeName("Int"))), type: Type(name: "Int -> Int"))
                                 ], returnTypeName: TypeName("Int")
                             )
                         ))
@@ -687,7 +690,7 @@ class ParserComposerSpec: QuickSpec {
                                 TupleElement(name: "0", typeName: TypeName("Foo"), type: Class(name: "Foo")),
                                 TupleElement(name: "1", typeName: TypeName("Int"))
                                 ])
-                            let expectedMethodParameter = MethodParameter(name: "foo", typeName: TypeName("(FooAlias, Int)", actualTypeName: expectedActualTypeName, tuple: expectedActualTypeName.tuple))
+                            let expectedMethodParameter = MethodParameter(name: "foo", typeName: TypeName("(FooAlias, Int)", actualTypeName: expectedActualTypeName, tuple: expectedActualTypeName.tuple), type: Type(name: "(FooAlias, Int)"))
 
                             let types = parse("typealias FooAlias = Foo; class Foo {}; class Bar { func some(foo: (FooAlias, Int)) }")
                             let methodParameter = types.first?.methods.first?.parameters.first
@@ -704,7 +707,11 @@ class ParserComposerSpec: QuickSpec {
                                 TupleElement(name: "0", typeName: TypeName("Foo"), type: Class(name: "Foo")),
                                 TupleElement(name: "1", typeName: TypeName("Int"))
                                 ])
-                            let expectedMethodParameter = MethodParameter(name: "foo", typeName: TypeName("GlobalAlias", actualTypeName: expectedActualTypeName, tuple: expectedActualTypeName.tuple))
+                            let expectedMethodParameter = MethodParameter(name: "foo",
+                                                                          typeName: TypeName("GlobalAlias",
+                                                                                             actualTypeName: expectedActualTypeName,
+                                                                                             tuple: expectedActualTypeName.tuple),
+                                                                          type: Type(name: "GlobalAlias"))
 
                             let types = parse("typealias GlobalAlias = (Foo, Int); class Foo {}; class Bar { func some(foo: GlobalAlias) }")
                             let methodParameter = types.first?.methods.first?.parameters.first
@@ -791,7 +798,7 @@ class ParserComposerSpec: QuickSpec {
                         it("replaces associated value alias type with actual closure type name") {
                             let expectedTypeName = TypeName("(String) -> Any")
                             expectedTypeName.closure = ClosureType(name: "(String) -> Any", parameters: [
-                                MethodParameter(argumentLabel: nil, typeName: TypeName("String"))
+                                MethodParameter(argumentLabel: nil, typeName: TypeName("String"), type: Type(name: "String"))
                                 ], returnTypeName: TypeName("Any")
                             )
 

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -455,7 +455,23 @@ class ParserComposerSpec: QuickSpec {
                                                        genericTypeParameters: [GenericTypeParameter(typeName: TypeName("Int"), type: Type(name: "Int"))])
                         let placeholder = GenericTypePlaceholder(placeholderName: TypeName("U"), constraints: [specializedGeneric])
                         let specialized = Class(name: "Specialized", genericTypePlaceholders: [placeholder])
-                        expect(result).to(equal([ generic, specialized]))
+                        expect(result).to(equal([generic, specialized]))
+                    }
+
+                    it("resolves inherited types for generic placeholders with generic restriction") {
+                        let result = parse("""
+                            protocol Bar {}
+                            class Generic<T: Bar> {}
+                            class Specialized<U: Generic<Int>> {}
+                        """)
+                        let protokol = Protocol(name: "Bar")
+                        let generic = Class(name: "Generic", genericTypePlaceholders: [ GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [protokol]) ])
+                        let specializedGeneric = Class(name: "Generic",
+                                                       genericTypePlaceholders: [GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [protokol])],
+                                                       genericTypeParameters: [GenericTypeParameter(typeName: TypeName("Int"), type: Type(name: "Int"))])
+                        let placeholder = GenericTypePlaceholder(placeholderName: TypeName("U"), constraints: [specializedGeneric])
+                        let specialized = Class(name: "Specialized", genericTypePlaceholders: [placeholder])
+                        expect(result).to(equal([protokol, generic, specialized]))
                     }
                 }
 

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -408,6 +408,7 @@ class ParserComposerSpec: QuickSpec {
                             """)
                         let bar = SourceryProtocol.init(name: "Bar")
                         let variables = types[3].variables
+                        // FIXME: The reason why this test is failing, is currently GenericType.name for Array<Int> is "Array<Int>" instead of Array, as outlined in documentation for this property
                         expect(variables[0].type?.implements["Bar"]).to(equal(bar))
                         expect(variables[1].type?.implements["Bar"]).to(equal(bar))
                         expect(variables[2].type?.implements["Bar"]).to(equal(bar))

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -440,7 +440,8 @@ class ParserComposerSpec: QuickSpec {
                         """)
                         let generic = Class(name: "Generic", genericTypePlaceholders: [ GenericTypePlaceholder(placeholderName: TypeName("T")) ])
                         let specialized = Class(name: "Specialized", inheritedTypes: ["Generic<Int>"])
-                        expect(result).to(equal([ generic, specialized]))
+
+                        expect(result).to(equal([generic, specialized]))
                     }
 
                     it("resolves inherited types for generic placeholders") {

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -274,8 +274,8 @@ class ParserComposerSpec: QuickSpec {
                         let variable = types.first?.variables.first
                         let tuple = variable?.typeName.tuple
 
-                        let stringToFloatDictGeneric = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
-                        let stringToFloatDictGenericLiteral = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
+                        let stringToFloatDictGeneric = GenericType(name: "Dictionary<String, Float>", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
+                        let stringToFloatDictGenericLiteral = GenericType(name: "[String: Float]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
 
                         let stringToFloatDict = DictionaryType(name: "Dictionary<String, Float>", valueTypeName: TypeName("Float"), keyTypeName: TypeName("String"))
                         let stringToFloatDictLiteral = DictionaryType(name: "[String: Float]", valueTypeName: TypeName("Float"), keyTypeName: TypeName("String"))
@@ -285,10 +285,10 @@ class ParserComposerSpec: QuickSpec {
                         expect(tuple?.elements[2]).to(equal(TupleElement(name: "2", typeName: TypeName("String"))))
                         expect(tuple?.elements[3]).to(equal(TupleElement(name: "3", typeName: TypeName("Float"))))
                         expect(tuple?.elements[4]).to(equal(
-                            TupleElement(name: "literal", typeName: TypeName("[String: [String: Float]]", dictionary: DictionaryType(name: "[String: [String: Float]]", valueTypeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral))])))
+                            TupleElement(name: "literal", typeName: TypeName("[String: [String: Float]]", dictionary: DictionaryType(name: "[String: [String: Float]]", valueTypeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral), keyTypeName: TypeName("String")), generic: GenericType(name: "[String: [String: Float]]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral))])))
                         ))
                         expect(tuple?.elements[5]).to(equal(
-                            TupleElement(name: "generic", typeName: TypeName("Dictionary<String, Dictionary<String, Float>>", dictionary: DictionaryType(name: "Dictionary<String, Dictionary<String, Float>>", valueTypeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric))])))
+                            TupleElement(name: "generic", typeName: TypeName("Dictionary<String, Dictionary<String, Float>>", dictionary: DictionaryType(name: "Dictionary<String, Dictionary<String, Float>>", valueTypeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary<String, Dictionary<String, Float>>", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric))])))
                         ))
                         expect(tuple?.elements[6]).to(equal(
                             TupleElement(name: "closure", typeName: TypeName("(Int) -> (Int -> Int)", closure: ClosureType(name: "(Int) -> (Int -> Int)", parameters: [
@@ -320,7 +320,7 @@ class ParserComposerSpec: QuickSpec {
                                     ])))
                         ))
                         expect(variables?[2].typeName.array).to(equal(
-                            ArrayType(name: "[[Int]]", elementTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                            ArrayType(name: "[[Int]]", elementTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[3].typeName.array).to(equal(
                             ArrayType(name: "[()->()]", elementTypeName: TypeName("()->()", closure: ClosureType(name: "() -> ()", parameters: [], returnTypeName: TypeName("()"))))
@@ -343,7 +343,7 @@ class ParserComposerSpec: QuickSpec {
                                     ])))
                         ))
                         expect(variables?[2].typeName.array).to(equal(
-                            ArrayType(name: "Array<Array<Int>>", elementTypeName: TypeName("Array<Int>", array: ArrayType(name: "Array<Int>", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                            ArrayType(name: "Array<Array<Int>>", elementTypeName: TypeName("Array<Int>", array: ArrayType(name: "Array<Int>", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array<Int>", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[3].typeName.array).to(equal(
                             ArrayType(name: "Array<()->()>", elementTypeName: TypeName("()->()", closure: ClosureType(name: "() -> ()", parameters: [], returnTypeName: TypeName("()"))))
@@ -360,11 +360,25 @@ class ParserComposerSpec: QuickSpec {
                             DictionaryType(name: "Dictionary<Int, String>", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int"))
                         ))
                         expect(variables?[1].typeName.dictionary).to(equal(
-                            DictionaryType(name: "Dictionary<[Int], [String]>", valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])), keyTypeName: TypeName("[Int]", array:
-                                ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                            DictionaryType(name: "Dictionary<[Int], [String]>",
+                                           valueTypeName: TypeName("[String]",
+                                                                   array: ArrayType(name: "[String]",
+                                                                                    elementTypeName: TypeName("String")),
+                                                                   generic: GenericType(name: "[String]",
+                                                                                        typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])),
+                                           keyTypeName: TypeName("[Int]",
+                                                                 array:
+                                ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[2].typeName.dictionary).to(equal(
-                            DictionaryType(name: "Dictionary<Int, [Int: String]>", valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])), keyTypeName: TypeName("Int"))
+                            DictionaryType(name: "Dictionary<Int, [Int: String]>",
+                                           valueTypeName: TypeName("[Int: String]",
+                                                                   dictionary: DictionaryType(name: "[Int: String]",
+                                                                                              valueTypeName: TypeName("String"),
+                                                                                              keyTypeName: TypeName("Int")),
+                                                                   generic: GenericType(name: "[Int: String]",
+                                                                                        typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])),
+                                           keyTypeName: TypeName("Int"))
                         ))
                         expect(variables?[3].typeName.dictionary).to(equal(
                             DictionaryType(name: "Dictionary<Int, (String, String)>",
@@ -411,13 +425,13 @@ class ParserComposerSpec: QuickSpec {
                         ))
                         expect(variables?[1].typeName.dictionary).to(equal(
                             DictionaryType(name: "[[Int]: [String]]",
-                                           valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])),
-                                           keyTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))]))
+                                           valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "[String]", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])),
+                                           keyTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))]))
                             )
                         ))
                         expect(variables?[2].typeName.dictionary).to(equal(
                             DictionaryType(name: "[Int: [Int: String]]",
-                                           valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])),
+                                           valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "[Int: String]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])),
                                            keyTypeName: TypeName("Int")
                             )
                         ))
@@ -787,7 +801,7 @@ class ParserComposerSpec: QuickSpec {
                         it("replaces associated value alias type with actual dictionary type name") {
                             var expectedTypeName = TypeName("[String: Any]")
                             expectedTypeName.dictionary = DictionaryType(name: "[String: Any]", valueTypeName: TypeName("Any"), valueType: nil, keyTypeName: TypeName("String"), keyType: nil)
-                            expectedTypeName.generic = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String"), type: nil), GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
+                            expectedTypeName.generic = GenericType(name: "[String: Any]", typeParameters: [GenericTypeParameter(typeName: TypeName("String"), type: nil), GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
 
                             let expectedAssociatedValue = AssociatedValue(typeName: TypeName("JSON", actualTypeName: expectedTypeName, dictionary: expectedTypeName.dictionary, generic: expectedTypeName.generic), type: nil)
 
@@ -801,7 +815,7 @@ class ParserComposerSpec: QuickSpec {
                         it("replaces associated value alias type with actual array type name") {
                             let expectedTypeName = TypeName("[Any]")
                             expectedTypeName.array = ArrayType(name: "[Any]", elementTypeName: TypeName("Any"), elementType: nil)
-                            expectedTypeName.generic = GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
+                            expectedTypeName.generic = GenericType(name: "[Any]", typeParameters: [GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
 
                             let expectedAssociatedValue = AssociatedValue(typeName: TypeName("JSON", actualTypeName: expectedTypeName, array: expectedTypeName.array, generic: expectedTypeName.generic), type: nil)
 
@@ -1012,7 +1026,7 @@ class ParserComposerSpec: QuickSpec {
                         let expectedBlah = Struct(name: "Blah", containedTypes: [Struct(name: "Foo"), Struct(name: "Bar", variables: [expectedVariable])])
                         expectedActualTypeName.array = ArrayType(name: "[Blah.Foo]?", elementTypeName: TypeName("Blah.Foo"), elementType: Struct(name: "Foo", parent: expectedBlah))
                         expectedVariable.typeName.array = expectedActualTypeName.array
-                        expectedActualTypeName.generic = GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
+                        expectedActualTypeName.generic = GenericType(name: "[Blah.Foo]?", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
                         expectedVariable.typeName.generic = expectedActualTypeName.generic
 
                         let types = parse("struct Blah { struct Foo {}; struct Bar { let foo: [Foo]? }}")
@@ -1030,7 +1044,7 @@ class ParserComposerSpec: QuickSpec {
                         let expectedBlah = Struct(name: "Blah", containedTypes: [Struct(name: "Foo"), Struct(name: "Bar", variables: [expectedVariable])])
                         expectedActualTypeName.dictionary = DictionaryType(name: "[Blah.Foo: Blah.Foo]?", valueTypeName: TypeName("Blah.Foo"), valueType: Struct(name: "Foo", parent: expectedBlah), keyTypeName: TypeName("Blah.Foo"), keyType: Struct(name: "Foo", parent: expectedBlah))
                         expectedVariable.typeName.dictionary = expectedActualTypeName.dictionary
-                        expectedActualTypeName.generic = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah)), GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
+                        expectedActualTypeName.generic = GenericType(name: "[Blah.Foo: Blah.Foo]?", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah)), GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
                         expectedVariable.typeName.generic = expectedActualTypeName.generic
 
                         let types = parse("struct Blah { struct Foo {}; struct Bar { let foo: [Foo: Foo]? }}")

--- a/SourceryTests/Parsing/FileParser + MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser + MethodsSpec.swift
@@ -39,13 +39,22 @@ class FileParserMethodsSpec: QuickSpec {
                     """)[0].methods
 
                     expect(methods[0]).to(equal(Method(name: "init()", selectorName: "init", parameters: [], returnTypeName: TypeName("Foo"), throws: true, definedInTypeName: TypeName("Foo"))))
-                    expect(methods[1]).to(equal(Method(name: "bar(some: Int)", selectorName: "bar(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName("Int"))], returnTypeName: TypeName("Bar"), throws: true, definedInTypeName: TypeName("Foo"))))
+                    expect(methods[1]).to(equal(Method(name: "bar(some: Int)",
+                                                       selectorName: "bar(some:)",
+                                                       parameters: [
+                                                        MethodParameter(name: "some",
+                                                                        typeName: TypeName("Int"),
+                                                                        type: Type(name: "Int"))
+                                                       ],
+                                                       returnTypeName: TypeName("Bar"),
+                                                       throws: true,
+                                                       definedInTypeName: TypeName("Foo"))))
                     expect(methods[2]).to(equal(Method(name: "foo()", selectorName: "foo", returnTypeName: TypeName("Foo"), attributes: ["discardableResult": Attribute(name: "discardableResult")], definedInTypeName: TypeName("Foo"))))
                     expect(methods[3]).to(equal(Method(name: "fooBar()", selectorName: "fooBar", returnTypeName: TypeName("Void"), throws: false, rethrows: true, definedInTypeName: TypeName("Foo"))))
                     expect(methods[4]).to(equal(Method(name: "fooVoid()", selectorName: "fooVoid", returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))))
                     expect(methods[5]).to(equal(Method(name: "fooInOut(some: Int, anotherSome: inout String)", selectorName: "fooInOut(some:anotherSome:)", parameters: [
-                    MethodParameter(name: "some", typeName: TypeName("Int")),
-                    MethodParameter(name: "anotherSome", typeName: TypeName("inout String"), isInout: true)
+                    MethodParameter(name: "some", typeName: TypeName("Int"), type: Type(name: "Int")),
+                    MethodParameter(name: "anotherSome", typeName: TypeName("inout String"), type: Type(name: "inout String"), isInout: true)
                     ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))))
                     expect(methods[6]).to(equal(Method(name: "deinit", selectorName: "deinit", definedInTypeName: TypeName("Foo"))))
                 }
@@ -61,14 +70,14 @@ class FileParserMethodsSpec: QuickSpec {
                     """)[0].methods
                     expect(methods[0]).to(equal(Method(name: "init()", selectorName: "init", parameters: [], returnTypeName: TypeName("Foo"), throws: true, definedInTypeName: TypeName("Foo"))))
                     expect(methods[1]).to(equal(Method(name: "bar(some: Int)", selectorName: "bar(some:)", parameters: [
-                        MethodParameter(name: "some", typeName: TypeName("Int"))
+                        MethodParameter(name: "some", typeName: TypeName("Int"), type: Type(name: "Int"))
                         ], returnTypeName: TypeName("Bar"), throws: true, definedInTypeName: TypeName("Foo"))))
                     expect(methods[2]).to(equal(Method(name: "foo()", selectorName: "foo", returnTypeName: TypeName("Foo"), attributes: ["discardableResult": Attribute(name: "discardableResult")], definedInTypeName: TypeName("Foo"))))
                     expect(methods[3]).to(equal(Method(name: "fooBar()", selectorName: "fooBar", returnTypeName: TypeName("Void"), throws: false, rethrows: true, definedInTypeName: TypeName("Foo"))))
                     expect(methods[4]).to(equal(Method(name: "fooVoid()", selectorName: "fooVoid", returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))))
                     expect(methods[5]).to(equal(Method(name: "fooInOut(some: Int, anotherSome: inout String)", selectorName: "fooInOut(some:anotherSome:)", parameters: [
-                        MethodParameter(name: "some", typeName: TypeName("Int")),
-                        MethodParameter(name: "anotherSome", typeName: TypeName("inout String"), isInout: true)
+                        MethodParameter(name: "some", typeName: TypeName("Int"), type: Type(name: "Int")),
+                        MethodParameter(name: "anotherSome", typeName: TypeName("inout String"), type: Type(name: "inout String"), isInout: true)
                         ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))))
                 }
 
@@ -127,7 +136,7 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(bar: Int) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(bar: Int)", selectorName: "foo(bar:)", parameters: [
-                                    MethodParameter(name: "bar", typeName: TypeName("Int"))], definedInTypeName: TypeName("Foo"))
+                                    MethodParameter(name: "bar", typeName: TypeName("Int"), type: Type(name: "Int"))], definedInTypeName: TypeName("Foo"))
                                 ])
                             ]))
                     }
@@ -136,8 +145,8 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo( bar:   Int,   foo : String  ) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo( bar:   Int,   foo : String  )", selectorName: "foo(bar:foo:)", parameters: [
-                                    MethodParameter(name: "bar", typeName: TypeName("Int")),
-                                    MethodParameter(name: "foo", typeName: TypeName("String"))
+                                    MethodParameter(name: "bar", typeName: TypeName("Int"), type: Type(name: "Int")),
+                                    MethodParameter(name: "foo", typeName: TypeName("String"), type: Type(name: "String"))
                                     ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))
                                 ])
                             ]))
@@ -148,12 +157,26 @@ class FileParserMethodsSpec: QuickSpec {
                             .to(equal([
                                 Class(name: "Foo", methods: [
                                     Method(name: "foo( bar: [String: String],   foo : ((String, String) -> Void), other: Optional<String>)", selectorName: "foo(bar:foo:other:)", parameters: [
-                                        MethodParameter(name: "bar", typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))]))),
-                                        MethodParameter(name: "foo", typeName: TypeName("((String, String) -> Void)", closure: ClosureType(name: "(String, String) -> Void", parameters: [
-                                            MethodParameter(argumentLabel: nil, typeName: TypeName("String")),
-                                            MethodParameter(argumentLabel: nil, typeName: TypeName("String"))
-                                            ], returnTypeName: TypeName("Void")))),
-                                        MethodParameter(name: "other", typeName: TypeName("Optional<String>"))
+                                        MethodParameter(name: "bar",
+                                                        typeName: TypeName("[String: String]",
+                                                                           dictionary: DictionaryType(name: "[String: String]",
+                                                                                                      valueTypeName: TypeName("String"),
+                                                                                                      keyTypeName: TypeName("String")),
+                                                                           generic: GenericType(name: "[String: String]",
+                                                                                                typeParameters: [
+                                                                                                    GenericTypeParameter(typeName: TypeName("String")),
+                                                                                                    GenericTypeParameter(typeName: TypeName("String"))])),
+                                                        type: Type(name: "[String: String]")),
+                                        MethodParameter(name: "foo",
+                                                        typeName: TypeName("((String, String) -> Void)",
+                                                                           closure: ClosureType(name: "(String, String) -> Void",
+                                                                                                parameters: [
+                                                                                                    MethodParameter(argumentLabel: nil, typeName: TypeName("String"), type: Type(name: "String")),
+                                                                                                    MethodParameter(argumentLabel: nil, typeName: TypeName("String"), type: Type(name: "String"))
+                                            ],
+                                                                                                returnTypeName: TypeName("Void"))),
+                                                        type: Type(name: "((String, String) -> Void)")),
+                                        MethodParameter(name: "other", typeName: TypeName("Optional<String>"), type: Type(name: "Optional<String>"))
                                         ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))
                                     ])
                                 ]))
@@ -163,12 +186,13 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(bar Bar: Int, _ foo: Int, fooBar: (_ a: Int, _ b: Int) -> ()) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(bar Bar: Int, _ foo: Int, fooBar: (_ a: Int, _ b: Int) -> ())", selectorName: "foo(bar:_:fooBar:)", parameters: [
-                                    MethodParameter(argumentLabel: "bar", name: "Bar", typeName: TypeName("Int")),
-                                    MethodParameter(argumentLabel: nil, name: "foo", typeName: TypeName("Int")),
+                                    MethodParameter(argumentLabel: "bar", name: "Bar", typeName: TypeName("Int"), type: Type(name: "Int")),
+                                    MethodParameter(argumentLabel: nil, name: "foo", typeName: TypeName("Int"), type: Type(name: "Int")),
                                     MethodParameter(name: "fooBar", typeName: TypeName("(_ a: Int, _ b: Int) -> ()", closure: ClosureType(name: "(_ a: Int, _ b: Int) -> ()", parameters: [
-                                        MethodParameter(argumentLabel: nil, name: "a", typeName: TypeName("Int")),
-                                        MethodParameter(argumentLabel: nil, name: "b", typeName: TypeName("Int"))
-                                        ], returnTypeName: TypeName("()"))))
+                                        MethodParameter(argumentLabel: nil, name: "a", typeName: TypeName("Int"), type: Type(name: "Int")),
+                                        MethodParameter(argumentLabel: nil, name: "b", typeName: TypeName("Int"), type: Type(name: "Int"))
+                                        ], returnTypeName: TypeName("()"))),
+                                                    type: Type(name: "(_ a: Int, _ b: Int) -> ()"))
                                     ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))
                                 ])
                             ]))
@@ -178,7 +202,7 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(a: Int) { let handler = { (b:Int) in } } }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(a: Int)", selectorName: "foo(a:)", parameters: [
-                                    MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName("Int"))
+                                    MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName("Int"), type: Type(name: "Int"))
                                     ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))
                                 ])
                             ]))
@@ -189,7 +213,7 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(a: inout Int) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(a: inout Int)", selectorName: "foo(a:)", parameters: [
-                                    MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName("inout Int"), isInout: true)
+                                    MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName("inout Int"), type: Type(name: "inout Int"), isInout: true)
                                     ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))
                                 ])
                             ]))
@@ -200,7 +224,7 @@ class FileParserMethodsSpec: QuickSpec {
                             expect(parse("class Foo { func foo(a: Int? = nil) {} }")).to(equal([
                                 Class(name: "Foo", methods: [
                                     Method(name: "foo(a: Int? = nil)", selectorName: "foo(a:)", parameters: [
-                                        MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName("Int?"), defaultValue: "nil")
+                                        MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName("Int?"), type: Type(name: "Int?"), defaultValue: "nil")
                                         ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))
                                     ])
                                 ]))
@@ -210,7 +234,7 @@ class FileParserMethodsSpec: QuickSpec {
                             expect(parse("class Foo { func foo(a: Int? = \n\t{ return nil } \n\t ) {} }")).to(equal([
                                 Class(name: "Foo", methods: [
                                     Method(name: "foo(a: Int? = \t{ return nil } \t )", selectorName: "foo(a:)", parameters: [
-                                        MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName("Int?"), defaultValue: "{ return nil }")
+                                        MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName("Int?"), type: Type(name: "Int?"), defaultValue: "{ return nil }")
                                         ], returnTypeName: TypeName("Void"), definedInTypeName: TypeName("Foo"))
                                     ])
                                 ]))
@@ -298,8 +322,8 @@ class FileParserMethodsSpec: QuickSpec {
 
                         expect(method?.returnTypeName).to(equal(TypeName("(Int, Int) -> ()", closure: ClosureType(name: "(Int, Int) -> ()", parameters: [
 
-                            MethodParameter(argumentLabel: nil, typeName: TypeName("Int")),
-                            MethodParameter(argumentLabel: nil, typeName: TypeName("Int"))
+                            MethodParameter(argumentLabel: nil, typeName: TypeName("Int"), type: Type(name: "Int")),
+                            MethodParameter(argumentLabel: nil, typeName: TypeName("Int"), type: Type(name: "Int"))
                             ], returnTypeName: TypeName("()")))))
                     }
                 }
@@ -360,12 +384,12 @@ class FileParserMethodsSpec: QuickSpec {
                     expect(parse("class Foo {\n //sourcery: foo\nfunc foo(\n// sourcery: annotationA\na: Int,\n// sourcery: annotationB\nb: Int) {}\n//sourcery: bar\nfunc bar(\n// sourcery: annotationA\na: Int,\n// sourcery: annotationB\nb: Int) {} }")).to(equal([
                         Class(name: "Foo", methods: [
                             Method(name: "foo(a: Int,b: Int)", selectorName: "foo(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true)])
+                                MethodParameter(name: "a", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: ["annotationA": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: ["annotationB": NSNumber(value: true)])
                                 ], annotations: ["foo": NSNumber(value: true)], definedInTypeName: TypeName("Foo")),
                             Method(name: "bar(a: Int,b: Int)", selectorName: "bar(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true)])
+                                MethodParameter(name: "a", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: ["annotationA": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: ["annotationB": NSNumber(value: true)])
                                 ], annotations: ["bar": NSNumber(value: true)], definedInTypeName: TypeName("Foo"))
                             ])
                         ]))
@@ -375,12 +399,12 @@ class FileParserMethodsSpec: QuickSpec {
                     expect(parse("class Foo {\n//sourcery:begin:func\n //sourcery: foo\nfunc foo(/* sourcery: annotationA */a: Int, /* sourcery: annotationB*/b: Int) {}\n//sourcery: bar\nfunc bar(/* sourcery: annotationA */a: Int, /* sourcery: annotationB*/b: Int) {}\n//sourcery:end}")).to(equal([
                         Class(name: "Foo", methods: [
                             Method(name: "foo(a: Int, b: Int)", selectorName: "foo(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
+                                MethodParameter(name: "a", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
                                 ], annotations: ["foo": NSNumber(value: true), "func": NSNumber(value: true)], definedInTypeName: TypeName("Foo")),
                             Method(name: "bar(a: Int, b: Int)", selectorName: "bar(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName("Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName("Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
+                                MethodParameter(name: "a", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
+                                MethodParameter(name: "b", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
                                 ], annotations: ["bar": NSNumber(value: true), "func": NSNumber(value: true)], definedInTypeName: TypeName("Foo"))
                             ])
                         ]))

--- a/SourceryTests/Parsing/FileParser + MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser + MethodsSpec.swift
@@ -162,7 +162,7 @@ class FileParserMethodsSpec: QuickSpec {
                                                                            dictionary: DictionaryType(name: "[String: String]",
                                                                                                       valueTypeName: TypeName("String"),
                                                                                                       keyTypeName: TypeName("String")),
-                                                                           generic: GenericType(name: "[String: String]",
+                                                                           generic: GenericType(name: "Dictionary",
                                                                                                 typeParameters: [
                                                                                                     GenericTypeParameter(typeName: TypeName("String")),
                                                                                                     GenericTypeParameter(typeName: TypeName("String"))])),

--- a/SourceryTests/Parsing/FileParser + VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser + VariableSpec.swift
@@ -120,7 +120,8 @@ class FileParserVariableSpec: QuickSpec {
                     expect(parse("let name: Observable<Int>")).to(equal(Variable(name: "name",
                                                                                  typeName: TypeName("Observable<Int>"),
                                                                                  type: Type(name: "Observable", genericTypeParameters: [
-                                                                                    GenericTypeParameter(typeName: TypeName("Int"))
+                                                                                    GenericTypeParameter(typeName: TypeName("Int"),
+                                                                                                         type: Type(name: "Int"))
                                                                                     ]),
                                                                                  accessLevel: (read: .internal, write: .none), isComputed: false)))
 

--- a/SourceryTests/Parsing/FileParser + VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser + VariableSpec.swift
@@ -34,7 +34,7 @@ class FileParserVariableSpec: QuickSpec {
                 }
 
                 it("extracts standard property correctly") {
-                    expect(parse("var name: String")).to(equal(Variable(name: "name", typeName: TypeName("String"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
+                    expect(parse("var name: String")).to(equal(Variable(name: "name", typeName: TypeName("String"), type: Type(name: "String"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
                 }
 
                 context("given variable with initial value") {
@@ -104,26 +104,32 @@ class FileParserVariableSpec: QuickSpec {
 
                 it("extracts standard let property correctly") {
                     let r = parse("let name: String")
-                    expect(r).to(equal(Variable(name: "name", typeName: TypeName("String"), accessLevel: (read: .internal, write: .none), isComputed: false)))
+                    expect(r).to(equal(Variable(name: "name", typeName: TypeName("String"), type: Type(name: "String"), accessLevel: (read: .internal, write: .none), isComputed: false)))
                 }
 
                 it("extracts computed property correctly") {
-                    expect(parse("var name: Int { return 2 }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true)))
-                    expect(parse("let name: Int")).to(equal(Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: false)))
-                    expect(parse("var name: Int")).to(equal(Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
-                    expect(parse("var name: Int { get { return 0 } set {} }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: true)))
-                    expect(parse("var name: Int { willSet { } }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
-                    expect(parse("var name: Int { didSet {} }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
+                    expect(parse("var name: Int { return 2 }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true)))
+                    expect(parse("let name: Int")).to(equal(Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: false)))
+                    expect(parse("var name: Int")).to(equal(Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
+                    expect(parse("var name: Int { get { return 0 } set {} }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .internal), isComputed: true)))
+                    expect(parse("var name: Int { willSet { } }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
+                    expect(parse("var name: Int { didSet {} }")).to(equal(Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .internal), isComputed: false)))
                 }
 
                 it("extracts generic property correctly") {
-                    expect(parse("let name: Observable<Int>")).to(equal(Variable(name: "name", typeName: TypeName("Observable<Int>"), accessLevel: (read: .internal, write: .none), isComputed: false)))
+                    expect(parse("let name: Observable<Int>")).to(equal(Variable(name: "name",
+                                                                                 typeName: TypeName("Observable<Int>"),
+                                                                                 type: Type(name: "Observable", genericTypeParameters: [
+                                                                                    GenericTypeParameter(typeName: TypeName("Int"))
+                                                                                    ]),
+                                                                                 accessLevel: (read: .internal, write: .none), isComputed: false)))
+
                 }
 
                 context("given it has sourcery annotations") {
 
                     it("extracts single annotation") {
-                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["skipEquability"] = NSNumber(value: true)
 
                         expect(parse("// sourcery: skipEquability\n" +
@@ -131,7 +137,7 @@ class FileParserVariableSpec: QuickSpec {
                     }
 
                     it("extracts multiple annotations on the same line") {
-                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["skipEquability"] = NSNumber(value: true)
                         expectedVariable.annotations["jsonKey"] = "json_key" as NSString
 
@@ -140,7 +146,7 @@ class FileParserVariableSpec: QuickSpec {
                     }
 
                     it("extracts multi-line annotations, including numbers") {
-                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["skipEquability"] = NSNumber(value: true)
                         expectedVariable.annotations["jsonKey"] = "json_key" as NSString
                         expectedVariable.annotations["thirdProperty"] = NSNumber(value: -3)
@@ -152,7 +158,7 @@ class FileParserVariableSpec: QuickSpec {
                     }
 
                     it("extracts annotations interleaved with comments") {
-                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["isSet"] = NSNumber(value: true)
                         expectedVariable.annotations["numberOfIterations"] = NSNumber(value: 2)
 
@@ -164,7 +170,7 @@ class FileParserVariableSpec: QuickSpec {
                     }
 
                     it("stops extracting annotations if it encounters a non-comment line") {
-                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
+                        let expectedVariable = Variable(name: "name", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
                         expectedVariable.annotations["numberOfIterations"] = NSNumber(value: 2)
 
                         let result = parse(        "// sourcery: isSet\n" +

--- a/SourceryTests/Parsing/FileParser+SubscriptsSpec.swift
+++ b/SourceryTests/Parsing/FileParser+SubscriptsSpec.swift
@@ -17,29 +17,31 @@ class FileParserSubscriptsSpec: QuickSpec {
                 }
 
                 it("extracts subscripts properly") {
-                    let subscripts = parse("class Foo { final private subscript(\n_ index: Int, a: String\n) -> Int { get { return 0 } set { do {} } }; public private(set) subscript(b b: Int) -> String { get { return \"\"} } set { } } }").first?.subscripts
+                    let subscripts = parse("protocol Interoo {}\n extension Int: Interoo {}\n class Foo { final private subscript(\n_ index: Int, a: String\n) -> Int { get { return 0 } set { do {} } }; public private(set) subscript(b b: Int) -> String { get { return \"\"} } set { } } }").first?.subscripts
 
-                    expect(subscripts?[0]).to(equal(
-                        Subscript(
-                            parameters: [
-                                MethodParameter(argumentLabel: nil, name: "index", typeName: TypeName("Int"), type: Type(name: "Int")),
-                                MethodParameter(argumentLabel: nil, name: "a", typeName: TypeName("String"), type: Type(name: "String"))
-                            ],
-                            returnTypeName: TypeName("Int"),
-                            accessLevel: (.private, .private),
-                            attributes: [
-                                "final": Attribute(name: "final", description: "final"),
-                                "private": Attribute(name: "private", description: "private")
-                            ],
-                            annotations: [:],
-                            definedInTypeName: TypeName("Foo")
-                        )
-                    ))
+                    let intType = Type(name: "Int", isExtension: true, inheritedTypes: ["Interoo"])
+
+                    let expectedSubscript0 = Subscript(
+                        parameters: [
+                            MethodParameter(argumentLabel: nil, name: "index", typeName: TypeName("Int"), type: intType),
+                            MethodParameter(argumentLabel: nil, name: "a", typeName: TypeName("String"), type: Type(name: "String"))
+                        ],
+                        returnTypeName: TypeName("Int"),
+                        accessLevel: (.private, .private),
+                        attributes: [
+                            "final": Attribute(name: "final", description: "final"),
+                            "private": Attribute(name: "private", description: "private")
+                        ],
+                        annotations: [:],
+                        definedInTypeName: TypeName("Foo")
+                    )
+                    expectedSubscript0.returnType = intType
+                    expect(subscripts?[0]).to(equal(expectedSubscript0))
 
                     expect(subscripts?[1]).to(equal(
                         Subscript(
                             parameters: [
-                                MethodParameter(argumentLabel: "b", name: "b", typeName: TypeName("Int"), type: Type(name: "Int"))
+                                MethodParameter(argumentLabel: "b", name: "b", typeName: TypeName("Int"), type: intType)
                             ],
                             returnTypeName: TypeName("String"),
                             accessLevel: (.public, .private),

--- a/SourceryTests/Parsing/FileParser+SubscriptsSpec.swift
+++ b/SourceryTests/Parsing/FileParser+SubscriptsSpec.swift
@@ -22,8 +22,8 @@ class FileParserSubscriptsSpec: QuickSpec {
                     expect(subscripts?[0]).to(equal(
                         Subscript(
                             parameters: [
-                                MethodParameter(argumentLabel: nil, name: "index", typeName: TypeName("Int")),
-                                MethodParameter(argumentLabel: nil, name: "a", typeName: TypeName("String"))
+                                MethodParameter(argumentLabel: nil, name: "index", typeName: TypeName("Int"), type: Type(name: "Int")),
+                                MethodParameter(argumentLabel: nil, name: "a", typeName: TypeName("String"), type: Type(name: "String"))
                             ],
                             returnTypeName: TypeName("Int"),
                             accessLevel: (.private, .private),
@@ -39,7 +39,7 @@ class FileParserSubscriptsSpec: QuickSpec {
                     expect(subscripts?[1]).to(equal(
                         Subscript(
                             parameters: [
-                                MethodParameter(argumentLabel: "b", name: "b", typeName: TypeName("Int"))
+                                MethodParameter(argumentLabel: "b", name: "b", typeName: TypeName("Int"), type: Type(name: "Int"))
                             ],
                             returnTypeName: TypeName("String"),
                             accessLevel: (.public, .private),

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -676,7 +676,7 @@ class FileParserSpec: QuickSpec {
                                                 AssociatedValue(localName: nil, externalName: "2", typeName: TypeName("Int"))
                                                 ]),
                                             EnumCase(name: "optionC", associatedValues: [
-                                                AssociatedValue(localName: "dict", externalName: nil, typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))])))
+                                                AssociatedValue(localName: "dict", externalName: nil, typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "[String: String]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))])))
                                                 ])
                                         ])
                                 ]))

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -260,7 +260,7 @@ class FileParserSpec: QuickSpec {
 
                     it("parses generic methods of generic class") {
                         let result = parse("class Foo<T:Equatable> { func bar(_ argument: T) {} }")
-                        let parameter = MethodParameter(argumentLabel: nil, name: "argument", typeName: TypeName("T"), type: nil)
+                        let parameter = MethodParameter(argumentLabel: nil, name: "argument", typeName: TypeName("T"), type: Type(name: "T"))
                         let method = SourceryRuntime.Method(name: "bar(_ argument: T)", selectorName: "bar(_:)", parameters: [parameter], definedInTypeName: TypeName("Foo"))
                         let genericPlaceholders = [GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [Type(name: "Equatable")])]
                         let type = Class(name: "Foo", methods: [method], genericTypePlaceholders: genericPlaceholders)
@@ -295,7 +295,7 @@ class FileParserSpec: QuickSpec {
                             ])
                         let method = Method(name: "f<T : Codable>(_ t : T)",
                                             selectorName: "f(_:)",
-                                            parameters: [MethodParameter(argumentLabel: nil, name: "t", typeName: TypeName("T"), type: nil, defaultValue: nil, annotations: [:], isInout: false)],
+                                            parameters: [MethodParameter(argumentLabel: nil, name: "t", typeName: TypeName("T"), type: Type(name: "T"), defaultValue: nil, annotations: [:], isInout: false)],
                                             returnTypeName: TypeName("T where T : Equatable"),
                                             throws: false, rethrows: false, accessLevel: .internal, isStatic: false, isClass: false,
                                             isFailableInitializer: false, definedInTypeName: TypeName("Foo"),
@@ -806,7 +806,8 @@ class FileParserSpec: QuickSpec {
                                             parameters: [
                                                 MethodParameter(argumentLabel: nil,
                                                                 name: "value",
-                                                                typeName: TypeName("T"))
+                                                                typeName: TypeName("T"),
+                                                                type: Type(name: "T"))
                             ],
                                             returnTypeName: TypeName("Int where T : Equatable"),
                                             definedInTypeName: TypeName("Foo"),

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -86,7 +86,9 @@ class FileParserSpec: QuickSpec {
                     it("extracts generic struct properly") {
                         expect(parse("struct Foo<Something> { }"))
                                 .to(equal([
-                                    Struct(name: "Foo", isGeneric: true)
+                                    Struct(name: "Foo"
+//                                        , genericTypePlaceholders: [ .init(placeholderName: TypeName("Something"))]
+                                    )
                                           ]))
                     }
 

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -180,7 +180,8 @@ class FileParserSpec: QuickSpec {
                     it("Extracts protocol information for generic type arguments") {
                         let result = parse("protocol Test {}; class Foo<T:Test> : Bar<T> {}")
                         let expected = Class(name: "Foo", genericTypePlaceholders: [
-                            GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [ Protocol(name: "Test") ])
+                            // FIXME: After composing types, Test should be Protocol instead of Type
+                            GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [ Type(name: "Test") ])
                             ])
                         expected.inheritedTypes = [ "Bar<T>"]
                         expect(result).to(equal([expected, Protocol(name: "Test")]))
@@ -233,12 +234,14 @@ class FileParserSpec: QuickSpec {
                         let protokol = Protocol(name: "Bar")
                         let strukt = Struct(name: "Foo", genericTypePlaceholders: [
                             GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [
-                                Class(name: "Ancestor")
+                                // FIXME: AFter composing this should resolve to class instead of Type.
+                                Type(name: "Ancestor")
                                 ])
                             ])
                         let specializedStruct = Struct(name: "Foo", genericTypePlaceholders: [
                             GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [
-                                Class(name: "Ancestor")
+                                // FIXME: AFter composing this should resolve to class instead of Type.
+                                Type(name: "Ancestor")
                                 ])
                             ], genericTypeParameters: [GenericTypeParameter(typeName: TypeName("Sibling"),
                                                                             type: Class(name: "Sibling",

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -676,7 +676,7 @@ class FileParserSpec: QuickSpec {
                                                 AssociatedValue(localName: nil, externalName: "2", typeName: TypeName("Int"))
                                                 ]),
                                             EnumCase(name: "optionC", associatedValues: [
-                                                AssociatedValue(localName: "dict", externalName: nil, typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "[String: String]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))])))
+                                                AssociatedValue(localName: "dict", externalName: nil, typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))])))
                                                 ])
                                         ])
                                 ]))

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -180,8 +180,7 @@ class FileParserSpec: QuickSpec {
                     it("Extracts protocol information for generic type arguments") {
                         let result = parse("protocol Test {}; class Foo<T:Test> : Bar<T> {}")
                         let expected = Class(name: "Foo", genericTypePlaceholders: [
-                            // FIXME: After composing types, Test should be Protocol instead of Type
-                            GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [ Type(name: "Test") ])
+                            GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [ Protocol(name: "Test") ])
                             ])
                         expected.inheritedTypes = [ "Bar<T>"]
                         expect(result).to(equal([expected, Protocol(name: "Test")]))
@@ -234,14 +233,12 @@ class FileParserSpec: QuickSpec {
                         let protokol = Protocol(name: "Bar")
                         let strukt = Struct(name: "Foo", genericTypePlaceholders: [
                             GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [
-                                // FIXME: AFter composing this should resolve to class instead of Type.
-                                Type(name: "Ancestor")
+                                    Class(name: "Ancestor")
                                 ])
                             ])
                         let specializedStruct = Struct(name: "Foo", genericTypePlaceholders: [
                             GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [
-                                // FIXME: AFter composing this should resolve to class instead of Type.
-                                Type(name: "Ancestor")
+                                    Class(name: "Ancestor")
                                 ])
                             ], genericTypeParameters: [GenericTypeParameter(typeName: TypeName("Sibling"),
                                                                             type: Class(name: "Sibling",

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -37,7 +37,7 @@ class FileParserSpec: QuickSpec {
                                 [:]
                         ]
                         let expectedVariables = (1...3)
-                                .map { Variable(name: "property\($0)", typeName: TypeName("Int"), annotations: annotations[$0 - 1], definedInTypeName: TypeName("Foo")) }
+                                .map { Variable(name: "property\($0)", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: annotations[$0 - 1], definedInTypeName: TypeName("Foo")) }
                         let expectedType = Class(name: "Foo", variables: expectedVariables, annotations: ["skipEquality": NSNumber(value: true)])
 
                         let result = parse("// sourcery:begin: skipEquality\n\n\n\n" +
@@ -58,7 +58,7 @@ class FileParserSpec: QuickSpec {
                             ["fileAnnotation": NSNumber(value: true)]
                         ]
                         let expectedVariables = (1...3)
-                            .map { Variable(name: "property\($0)", typeName: TypeName("Int"), annotations: annotations[$0 - 1], definedInTypeName: TypeName("Foo")) }
+                            .map { Variable(name: "property\($0)", typeName: TypeName("Int"), type: Type(name: "Int"), annotations: annotations[$0 - 1], definedInTypeName: TypeName("Foo")) }
                         let expectedType = Class(name: "Foo", variables: expectedVariables, annotations: ["fileAnnotation": NSNumber(value: true), "skipEquality": NSNumber(value: true)])
 
                         let result = parse("// sourcery:file: fileAnnotation\n" +
@@ -115,7 +115,7 @@ class FileParserSpec: QuickSpec {
                     it("extracts instance variables properly") {
                         expect(parse("struct Foo { var x: Int }"))
                                 .to(equal([
-                                    Struct(name: "Foo", accessLevel: .internal, isExtension: false, variables: [Variable(name: "x", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: false, definedInTypeName: TypeName("Foo"))])
+                                    Struct(name: "Foo", accessLevel: .internal, isExtension: false, variables: [Variable(name: "x", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .internal), isComputed: false, definedInTypeName: TypeName("Foo"))])
                                           ]))
                     }
 
@@ -123,8 +123,8 @@ class FileParserSpec: QuickSpec {
                         expect(parse("struct Foo { static var x: Int { return 2 }; class var y: Int = 0 }"))
                                 .to(equal([
                                     Struct(name: "Foo", accessLevel: .internal, isExtension: false, variables: [
-                                        Variable(name: "x", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: true, definedInTypeName: TypeName("Foo")),
-                                        Variable(name: "y", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: false, isStatic: true, defaultValue: "0", definedInTypeName: TypeName("Foo"))
+                                        Variable(name: "x", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true, isStatic: true, definedInTypeName: TypeName("Foo")),
+                                        Variable(name: "y", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .internal), isComputed: false, isStatic: true, defaultValue: "0", definedInTypeName: TypeName("Foo"))
                                         ])
                                     ]))
                     }
@@ -157,7 +157,7 @@ class FileParserSpec: QuickSpec {
                     it("extracts variables properly") {
                         expect(parse("class Foo { }; extension Foo { var x: Int }"))
                                 .to(equal([
-                                        Class(name: "Foo", accessLevel: .internal, isExtension: false, variables: [Variable(name: "x", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .internal), isComputed: false, definedInTypeName: TypeName("Foo"))])
+                                        Class(name: "Foo", accessLevel: .internal, isExtension: false, variables: [Variable(name: "x", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .internal), isComputed: false, definedInTypeName: TypeName("Foo"))])
                                 ]))
                     }
 
@@ -323,7 +323,7 @@ class FileParserSpec: QuickSpec {
                     it("extracts extensions properly") {
                         expect(parse("protocol Foo { }; extension Bar: Foo { var x: Int { return 0 } }"))
                             .to(equal([
-                                Type(name: "Bar", accessLevel: .internal, isExtension: true, variables: [Variable(name: "x", typeName: TypeName("Int"), accessLevel: (read: .internal, write: .none), isComputed: true, definedInTypeName: TypeName("Bar"))], inheritedTypes: ["Foo"]),
+                                Type(name: "Bar", accessLevel: .internal, isExtension: true, variables: [Variable(name: "x", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true, definedInTypeName: TypeName("Bar"))], inheritedTypes: ["Foo"]),
                                 Protocol(name: "Foo")
                                 ]))
                     }
@@ -574,8 +574,8 @@ class FileParserSpec: QuickSpec {
                                             ]),
                                         EnumCase(name: "optionC")
                                         ], variables: [
-                                            Variable(name: "first", typeName: TypeName("Int"), accessLevel: (.internal, .none), isComputed: true, annotations: [ "var": NSNumber(value: true) ], definedInTypeName: TypeName("Foo")),
-                                            Variable(name: "second", typeName: TypeName("Int"), accessLevel: (.internal, .none), isComputed: true, annotations: [ "var": NSNumber(value: true) ], definedInTypeName: TypeName("Foo"))
+                                            Variable(name: "first", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (.internal, .none), isComputed: true, annotations: [ "var": NSNumber(value: true) ], definedInTypeName: TypeName("Foo")),
+                                            Variable(name: "second", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (.internal, .none), isComputed: true, annotations: [ "var": NSNumber(value: true) ], definedInTypeName: TypeName("Foo"))
                                         ])
                                     ]))
                         }
@@ -612,7 +612,7 @@ class FileParserSpec: QuickSpec {
                     it("extracts variables properly") {
                         expect(parse("enum Foo { var x: Int { return 1 } }"))
                                 .to(equal([
-                                        Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [], variables: [Variable(name: "x", typeName: TypeName("Int"), accessLevel: (.internal, .none), isComputed: true, definedInTypeName: TypeName("Foo"))])
+                                        Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases: [], variables: [Variable(name: "x", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (.internal, .none), isComputed: true, definedInTypeName: TypeName("Foo"))])
                                 ]))
                     }
 
@@ -783,14 +783,14 @@ class FileParserSpec: QuickSpec {
                     it("does not consider protocol variables as computed") {
                         expect(parse("protocol Foo { var some: Int { get } }"))
                             .to(equal([
-                                Protocol(name: "Foo", variables: [Variable(name: "some", typeName: TypeName("Int"), accessLevel: (.internal, .none), isComputed: false, definedInTypeName: TypeName("Foo"))])
+                                Protocol(name: "Foo", variables: [Variable(name: "some", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (.internal, .none), isComputed: false, definedInTypeName: TypeName("Foo"))])
                                 ]))
                     }
 
                     it("does consider type variables as computed when they are, even if they adhere to protocol") {
                         expect(parse("protocol Foo { var some: Int { get } }\nclass Bar: Foo { var some: Int { return 2 } }").first)
                             .to(equal(
-                                Class(name: "Bar", variables: [Variable(name: "some", typeName: TypeName("Int"), accessLevel: (.internal, .none), isComputed: true, definedInTypeName: TypeName("Bar"))], inheritedTypes: ["Foo"])
+                                Class(name: "Bar", variables: [Variable(name: "some", typeName: TypeName("Int"), type: Type(name: "Int"), accessLevel: (.internal, .none), isComputed: true, definedInTypeName: TypeName("Bar"))], inheritedTypes: ["Foo"])
                                 ))
                     }
 

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -260,7 +260,7 @@ class FileParserSpec: QuickSpec {
 
                     it("parses generic methods of generic class") {
                         let result = parse("class Foo<T:Equatable> { func bar(_ argument: T) {} }")
-                        let parameter = MethodParameter(argumentLabel: nil, name: "argument", typeName: TypeName("T"), type: Type(name: "T"))
+                        let parameter = MethodParameter(argumentLabel: nil, name: "argument", typeName: TypeName("T"), type: nil)
                         let method = SourceryRuntime.Method(name: "bar(_ argument: T)", selectorName: "bar(_:)", parameters: [parameter], definedInTypeName: TypeName("Foo"))
                         let genericPlaceholders = [GenericTypePlaceholder(placeholderName: TypeName("T"), constraints: [Type(name: "Equatable")])]
                         let type = Class(name: "Foo", methods: [method], genericTypePlaceholders: genericPlaceholders)


### PR DESCRIPTION
This PR is a restart of #707, and a first step towards better generics handling by Sourcery.

Changes are intentionally smaller in scope than in the original, and are almost backwards-compatible. In fact, the only truly breaking change I see is `Type.isGeneric` property that became computed (previously it was passed in initializer), but it's unlikely that this change will break someone's usage of the framework.

This PR follows glossary and terminology proposed in #707, so it's better to read full explanation provided in that PR.

Brief summary of changes that were implemented here:
* Introduce `Type.genericTypePlaceholders` and `Type.genericTypeParameters` properties, fill them on FileParser and Composer level
* Introduce `Method.genericTypeParameters` property
* Preserve `Type` knowledge wherever possible, even if types are unknown - in scope of objects, that are related to generics
* Implement type specialization(for example `Observable<Element>` can be a template class, and `Observable<Int>` can be a specialized version of that class, that contains both generic type placeholder `Element` and generic type parameter `Int`)

Even though this PR is only the first step, and does not finish generics parsing fundamentally, it was designed to be a good incremental improvement to not turn this PR into breaking monster it was previously.
 
/cc @ilyapuchka @truizlop