### PR TITLE
Migrate Sourcery code to Swift 5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -93,7 +93,7 @@
       },
       {
         "package": "Stencil",
-        "repositoryURL": "https://github.com/kylef/Stencil.git",
+        "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
           "revision": "0e9a78d6584e3812cd9c09494d5c7b483e8f533c",

--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,8 @@ let package = Package(
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
         .package(url: "https://github.com/kylef/PathKit.git", .exact("0.9.2")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .exact("0.21.2")),
-        .package(url: "https://github.com/kylef/Stencil.git", .exact("0.13.1")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.7.0")),
         .package(url: "https://github.com/tuist/xcodeproj", .exact("4.3.1")),
-        .package(url: "https://github.com/tadija/AEXML.git", .exact("4.3.3")),
     ],
     targets: [
         .target(name: "Sourcery", dependencies: [

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -1795,7 +1795,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1827,7 +1826,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Pixle.SourceryUtils;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2035,7 +2033,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2067,7 +2064,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Pixle.SourceryFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2129,7 +2125,7 @@
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -2180,7 +2176,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -1153,7 +1153,7 @@
 			};
 			buildConfigurationList = CD754C861D853F000082B512 /* Build configuration list for PBXProject "Sourcery" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -327,7 +327,7 @@ public struct Composer {
                     let valueName = self.actualTypeName(for: TypeName(types[1]), containingType: containingType, unique: unique, typealiases: typealiases)
                     actualTypeName = "[\(keyName ?? types[0]): \(valueName ?? types[1])]"
                 }
-            } else if let genericStartIndex = unwrappedTypeName.index(of: "<"), unwrappedTypeName.last == ">" {
+            } else if let genericStartIndex = unwrappedTypeName.firstIndex(of: "<"), unwrappedTypeName.last == ">" {
                 let genericTypeNameString = String(unwrappedTypeName.prefix(upTo: genericStartIndex))
                 let genericTypeName = self.actualTypeName(for: TypeName(genericTypeNameString), containingType: containingType, unique: unique, typealiases: typealiases)
 

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -278,7 +278,7 @@ extension FileParser {
         guard let kind = (dict[SwiftDocKey.kind.rawValue] as? String).flatMap({ SwiftDeclarationKind(rawValue: $0) }),
               var name = dict[SwiftDocKey.name.rawValue] as? String else { return nil }
 
-        if case .enumelement = kind, let colon = name.index(of: "(") {
+        if case .enumelement = kind, let colon = name.firstIndex(of: "(") {
             name = String(name[..<colon])
         }
 
@@ -737,7 +737,7 @@ extension FileParser {
         guard let attributeString = string.trimmingCharacters(in: .whitespaces)
             .components(separatedBy: " ", excludingDelimiterBetween: ("(", ")")).first else { return nil }
 
-        if let openIndex = attributeString.index(of: "(") {
+        if let openIndex = attributeString.firstIndex(of: "(") {
             let name = String(attributeString.prefix(upTo: openIndex))
             guard let identifier = identifier ?? Attribute.Identifier.from(string: name) else { return nil }
 

--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -320,7 +320,7 @@ extension String {
         if lines.isEmpty {
             return 0
         }
-        let index = lines.index(where: { NSLocationInRange(byteOffset, $0.byteRange) })
+        let index = lines.firstIndex(where: { NSLocationInRange(byteOffset, $0.byteRange) })
         // byteOffset may be out of bounds when sourcekitd points end of string.
         guard let line = (index.map { lines[$0] } ?? lines.last) else {
             fatalError()

--- a/SourceryRuntime/Sources/Enum.swift
+++ b/SourceryRuntime/Sources/Enum.swift
@@ -128,7 +128,7 @@ import Foundation
         didSet {
             if let rawTypeName = rawTypeName {
                 hasRawType = true
-                if let index = inheritedTypes.index(of: rawTypeName.name) {
+                if let index = inheritedTypes.firstIndex(of: rawTypeName.name) {
                     inheritedTypes.remove(at: index)
                 }
                 if based[rawTypeName.name] != nil {
@@ -183,7 +183,7 @@ import Foundation
 
         super.init(name: name, parent: parent, accessLevel: accessLevel, isExtension: isExtension, variables: variables, methods: methods, inheritedTypes: inheritedTypes, containedTypes: containedTypes, typealiases: typealiases, attributes: attributes, annotations: annotations, isGeneric: isGeneric)
 
-        if let rawTypeName = rawTypeName?.name, let index = self.inheritedTypes.index(of: rawTypeName) {
+        if let rawTypeName = rawTypeName?.name, let index = self.inheritedTypes.firstIndex(of: rawTypeName) {
             self.inheritedTypes.remove(at: index)
         }
     }

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -1423,7 +1423,7 @@ import Foundation
         didSet {
             if let rawTypeName = rawTypeName {
                 hasRawType = true
-                if let index = inheritedTypes.index(of: rawTypeName.name) {
+                if let index = inheritedTypes.firstIndex(of: rawTypeName.name) {
                     inheritedTypes.remove(at: index)
                 }
                 if based[rawTypeName.name] != nil {
@@ -1478,7 +1478,7 @@ import Foundation
 
         super.init(name: name, parent: parent, accessLevel: accessLevel, isExtension: isExtension, variables: variables, methods: methods, inheritedTypes: inheritedTypes, containedTypes: containedTypes, typealiases: typealiases, attributes: attributes, annotations: annotations, isGeneric: isGeneric)
 
-        if let rawTypeName = rawTypeName?.name, let index = self.inheritedTypes.index(of: rawTypeName) {
+        if let rawTypeName = rawTypeName?.name, let index = self.inheritedTypes.firstIndex(of: rawTypeName) {
             self.inheritedTypes.remove(at: index)
         }
     }

--- a/SourceryUtils/Sources/Sha.swift
+++ b/SourceryUtils/Sources/Sha.swift
@@ -9,10 +9,10 @@ import CommonCrypto
 extension Data {
     public func sha256() -> Data {
         var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        self.withUnsafeBytes {
-            _ = CC_SHA256($0, CC_LONG(self.count), &hash)
+        self.withUnsafeBytes { (pointer) -> Void in
+            _ = CC_SHA256(pointer.baseAddress, CC_LONG(pointer.count), &hash)
         }
-        return Data(bytes: hash)
+        return Data(hash)
     }
 }
 


### PR DESCRIPTION
- Set `SWIFT_VERSION` to `5.0` in the Xcode project
- Fix the resulting warnings
- Remove some superfluous dependencies from the SPM manifest

Closes #767
Note that we still have warnings when building using SPM from our dependencies.