### PR TITLE
Add test to demonstrate case generation bug, re #759

### DIFF
--- a/SourceryTests/Generating/StencilTemplateSpec.swift
+++ b/SourceryTests/Generating/StencilTemplateSpec.swift
@@ -220,6 +220,29 @@ class StencilTemplateSpec: QuickSpec {
                 expect(result).to(equal(expectedResult))
             }
 
+            it("generates cases") {
+                var outputDir = Path("/tmp")
+                outputDir = Stubs.cleanTemporarySourceryDir()
+
+                let templatePath = Stubs.templateDirectory + Path("CaseGenerator.stencil")
+                let expectedResult = """
+                // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
+                // DO NOT EDIT
+
+                extension ExampleStruct {
+                    enum GeneratedCases {
+                        case one
+                        case two
+                    }
+                }
+                """
+
+                expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: Output(outputDir)) }.toNot(throwError())
+
+                let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                expect(result).to(equal(expectedResult))
+            }
+
         }
     }
 }

--- a/SourceryTests/Stub/Source/GenerateCases.swift
+++ b/SourceryTests/Stub/Source/GenerateCases.swift
@@ -1,0 +1,11 @@
+protocol ShouldGenerateCases {
+    associatedtype DefinedCases
+    associatedtype GeneratedCases
+}
+
+struct ExampleStruct: ShouldGenerateCases {
+    enum DefinedCases {
+        case one
+        case two
+    }
+}

--- a/SourceryTests/Stub/Templates/CaseGenerator.stencil
+++ b/SourceryTests/Stub/Templates/CaseGenerator.stencil
@@ -1,0 +1,11 @@
+{% for type in types.implementing.ShouldGenerateCases %}
+
+extension {{type.name}} {
+    enum GeneratedCases {
+    {% for c in type.DefinedCases.cases %}
+    case {{c.name}}
+    {% endfor %}
+    }
+}
+
+{% endfor %}


### PR DESCRIPTION
Per request from @ilyapuchka in #759, this demonstrates the issue where Sourcery will generate several empty case statements when only a few valid case statements are expected. I don't know enough about Sourcery to fix this issue myself, but I hope this helps resolve it.

Basically, I'm getting:

```swift
extension ExampleStruct {
    enum GeneratedCases {
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
        case
    }
}
```

When I expect:
```swift
extension ExampleStruct {
    enum GeneratedCases {
        case one
        case two
    }
}
```
