### PR TITLE
Improve performance by parallelizing and changing cache logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### Internal Changes
 
+- Parallelized combining phase that yields 5-10x speed improvement for New York Times codebase
+- Switched cache logic to rely on file modification date instead of content Sha256
+- Additional benchmark logs showing how long does each phase take 
 - update dependencies to fix cocoapods setup when using Swift 5.0 everywhere. Update Quick to 2.1.0, SourceKitten to 0.23.1 and Yams to 2.0.0
 
 ## 0.16.2

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		CD53EE681D897D2900F5886C /* Templates in Resources */ = {isa = PBXBuildFile; fileRef = CD53EE671D897D2900F5886C /* Templates */; };
 		CD83A1861EA4C5D7003E0E7D /* Errors in Resources */ = {isa = PBXBuildFile; fileRef = CD83A1851EA4C5D7003E0E7D /* Errors */; };
 		CD9C459D1DFAF76D00161C2C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9C459C1DFAF76D00161C2C /* main.swift */; };
+		CDAB7CFC231E412C00ED8A32 /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAB7CFB231E412C00ED8A32 /* Time.swift */; };
 		CDBEC15C1E242B9E0090E881 /* StencilTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBEC15B1E242B9E0090E881 /* StencilTemplate.swift */; };
 		CDE812ED1E1127FF00F1FF97 /* Sourcery+PerformanceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE812EC1E1127FF00F1FF97 /* Sourcery+PerformanceSpec.swift */; };
 		CDE812EF1E112CC700F1FF97 /* Performance-Code in Resources */ = {isa = PBXBuildFile; fileRef = CDE812EE1E112CC700F1FF97 /* Performance-Code */; };
@@ -322,6 +323,7 @@
 		CD754CA01D853F000082B512 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CD83A1851EA4C5D7003E0E7D /* Errors */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Errors; sourceTree = "<group>"; };
 		CD9C459C1DFAF76D00161C2C /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		CDAB7CFB231E412C00ED8A32 /* Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Time.swift; sourceTree = "<group>"; };
 		CDBD141D1DFFC2CC00FF9F21 /* Description.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Description.stencil; sourceTree = "<group>"; };
 		CDBD141E1DFFC2CC00FF9F21 /* Equality.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Equality.stencil; sourceTree = "<group>"; };
 		CDBEC15B1E242B9E0090E881 /* StencilTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StencilTemplate.swift; sourceTree = "<group>"; };
@@ -659,6 +661,7 @@
 				B5BCFA0D21D1623D009DF652 /* Substring.swift */,
 				B5BCFA0E21D1623D009DF652 /* InlineParser.swift */,
 				B5BCFA0F21D1623D009DF652 /* AnnotationsParser.swift */,
+				CDAB7CFB231E412C00ED8A32 /* Time.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1590,6 +1593,7 @@
 				B5BCFA1421D1623D009DF652 /* Verifier.swift in Sources */,
 				B5BCFA1521D1623D009DF652 /* Substring.swift in Sources */,
 				B5BCFA1621D1623D009DF652 /* InlineParser.swift in Sources */,
+				CDAB7CFC231E412C00ED8A32 /* Time.swift in Sources */,
 				B5BCFA1321D1623D009DF652 /* FileParser.swift in Sources */,
 				B5BCFA1221D1623D009DF652 /* Template.swift in Sources */,
 			);

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -309,7 +309,7 @@ extension Sourcery {
         let uniqueTypeStart = CACurrentMediaTime()
 
         //! All files have been scanned, time to join extensions with base class
-        let types = Composer().uniqueTypes(parserResult)
+        let types = Composer.uniqueTypes(parserResult)
 
         print("\tcombiningTypes: \(CACurrentMediaTime() - uniqueTypeStart)\n\ttotal: \(CACurrentMediaTime() - startScan)")
         Log.info("Found \(types.count) types.")
@@ -327,8 +327,8 @@ extension Sourcery {
         let artifacts = cachesPath + "\(pathString.hash).srf"
 
         guard artifacts.exists,
-            let contentSha = parser.initialContents.sha256(),
-            let unarchived = load(artifacts: artifacts.string, contentSha: contentSha) else {
+            let modifiedDate = parser.modifiedDate,
+            let unarchived = load(artifacts: artifacts.string, modifiedDate: modifiedDate) else {
 
             let result = try parser.parse()
 
@@ -345,12 +345,12 @@ extension Sourcery {
         return unarchived
     }
 
-    private func load(artifacts: String, contentSha: String) -> FileParserResult? {
+    private func load(artifacts: String, modifiedDate: Date) -> FileParserResult? {
         var unarchivedResult: FileParserResult?
         SwiftTryCatch.try({
 
             if let unarchived = NSKeyedUnarchiver.unarchiveObject(withFile: artifacts) as? FileParserResult {
-                if unarchived.sourceryVersion == Sourcery.version, unarchived.contentSha == contentSha {
+                if unarchived.sourceryVersion == Sourcery.version, unarchived.modifiedDate == modifiedDate {
                     unarchivedResult = unarchived
                 }
             }

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -38,9 +38,6 @@ class Sourcery {
     fileprivate var fileAnnotatedContent: [Path: [String]] = [:]
 
     /// Creates Sourcery processor
-    ///
-    /// - Parameter verbose: Whether to turn on verbose logs.
-    /// - Parameter arguments: Additional arguments to pass to templates.
     init(verbose: Bool = false, watcherEnabled: Bool = false, cacheDisabled: Bool = false, cacheBasePath: Path? = nil, prune: Bool = false, arguments: [String: NSObject] = [:]) {
         self.verbose = verbose
         self.arguments = arguments
@@ -295,7 +292,7 @@ extension Sourcery {
             allResults.append(contentsOf: results)
         }
 
-        print("\tloadOrParse: \(CACurrentMediaTime() - startScan)")
+        Log.benchmark("\tloadOrParse: \(CACurrentMediaTime() - startScan)")
 
         let parserResult = allResults.reduce(FileParserResult(path: nil, module: nil, types: [], typealiases: [])) { acc, next in
             acc.typealiases += next.typealiases
@@ -311,7 +308,7 @@ extension Sourcery {
         //! All files have been scanned, time to join extensions with base class
         let types = Composer.uniqueTypes(parserResult)
 
-        print("\tcombiningTypes: \(CACurrentMediaTime() - uniqueTypeStart)\n\ttotal: \(CACurrentMediaTime() - startScan)")
+        Log.benchmark("\tcombiningTypes: \(CACurrentMediaTime() - uniqueTypeStart)\n\ttotal: \(CACurrentMediaTime() - startScan)")
         Log.info("Found \(types.count) types.")
         return (Types(types: types), inlineRanges)
     }
@@ -371,7 +368,7 @@ extension Sourcery {
         Log.info("Loading templates...")
         let allTemplates = try templates(from: templatePaths)
         Log.info("Loaded \(allTemplates.count) templates.")
-        print("\tLoading took \(CACurrentMediaTime() - generationStart)")
+        Log.benchmark("\tLoading took \(CACurrentMediaTime() - generationStart)")
 
         Log.info("Generating code...")
         status = ""
@@ -409,7 +406,7 @@ extension Sourcery {
             try linkTo.project.writePBXProj(path: linkTo.projectPath)
         }
 
-        print("\tGeneration took \(CACurrentMediaTime() - generationStart)")
+        Log.benchmark("\tGeneration took \(CACurrentMediaTime() - generationStart)")
         Log.info("Finished.")
     }
 
@@ -462,7 +459,7 @@ extension Sourcery {
         guard watcherEnabled else {
             let generationStart = CACurrentMediaTime()
             let result = try Generator.generate(parsingResult.types, template: template, arguments: self.arguments)
-            print("\tGenerating \(template.sourcePath.lastComponent) took \(CACurrentMediaTime() - generationStart)")
+            Log.benchmark("\tGenerating \(template.sourcePath.lastComponent) took \(CACurrentMediaTime() - generationStart)")
 
             return try processRanges(in: parsingResult, result: result, outputPath: outputPath)
         }
@@ -480,7 +477,7 @@ extension Sourcery {
     private func processRanges(in parsingResult: ParsingResult, result: String, outputPath: Path) throws -> String {
         let start = CACurrentMediaTime()
         defer {
-            print("\t\tProcessing Ranges took \(CACurrentMediaTime() - start)")
+            Log.benchmark("\t\tProcessing Ranges took \(CACurrentMediaTime() - start)")
         }
         var result = result
         result = processFileRanges(for: parsingResult, in: result, outputPath: outputPath)

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -237,7 +237,7 @@ extension Sourcery {
             precondition(from.count == modules.count, "There should be module for each file to parse")
         }
 
-        let startScan = CACurrentMediaTime()
+        let startScan = currentTimestamp()
         Log.info("Scanning sources...")
 
         var inlineRanges = [(file: String, ranges: [String: NSRange], indentations: [String: String])]()
@@ -292,7 +292,7 @@ extension Sourcery {
             allResults.append(contentsOf: results)
         }
 
-        Log.benchmark("\tloadOrParse: \(CACurrentMediaTime() - startScan)")
+        Log.benchmark("\tloadOrParse: \(currentTimestamp() - startScan)")
 
         let parserResult = allResults.reduce(FileParserResult(path: nil, module: nil, types: [], typealiases: [])) { acc, next in
             acc.typealiases += next.typealiases
@@ -303,12 +303,12 @@ extension Sourcery {
             return acc
         }
 
-        let uniqueTypeStart = CACurrentMediaTime()
+        let uniqueTypeStart = currentTimestamp()
 
         //! All files have been scanned, time to join extensions with base class
         let types = Composer.uniqueTypes(parserResult)
 
-        Log.benchmark("\tcombiningTypes: \(CACurrentMediaTime() - uniqueTypeStart)\n\ttotal: \(CACurrentMediaTime() - startScan)")
+        Log.benchmark("\tcombiningTypes: \(currentTimestamp() - uniqueTypeStart)\n\ttotal: \(currentTimestamp() - startScan)")
         Log.info("Found \(types.count) types.")
         return (Types(types: types), inlineRanges)
     }
@@ -363,12 +363,12 @@ extension Sourcery {
 extension Sourcery {
 
     fileprivate func generate(source: Source, templatePaths: Paths, output: Output, parsingResult: ParsingResult) throws {
-        let generationStart = CACurrentMediaTime()
+        let generationStart = currentTimestamp()
 
         Log.info("Loading templates...")
         let allTemplates = try templates(from: templatePaths)
         Log.info("Loaded \(allTemplates.count) templates.")
-        Log.benchmark("\tLoading took \(CACurrentMediaTime() - generationStart)")
+        Log.benchmark("\tLoading took \(currentTimestamp() - generationStart)")
 
         Log.info("Generating code...")
         status = ""
@@ -406,7 +406,7 @@ extension Sourcery {
             try linkTo.project.writePBXProj(path: linkTo.projectPath)
         }
 
-        Log.benchmark("\tGeneration took \(CACurrentMediaTime() - generationStart)")
+        Log.benchmark("\tGeneration took \(currentTimestamp() - generationStart)")
         Log.info("Finished.")
     }
 
@@ -457,9 +457,9 @@ extension Sourcery {
 
     private func generate(_ template: Template, forParsingResult parsingResult: ParsingResult, outputPath: Path) throws -> String {
         guard watcherEnabled else {
-            let generationStart = CACurrentMediaTime()
+            let generationStart = currentTimestamp()
             let result = try Generator.generate(parsingResult.types, template: template, arguments: self.arguments)
-            Log.benchmark("\tGenerating \(template.sourcePath.lastComponent) took \(CACurrentMediaTime() - generationStart)")
+            Log.benchmark("\tGenerating \(template.sourcePath.lastComponent) took \(currentTimestamp() - generationStart)")
 
             return try processRanges(in: parsingResult, result: result, outputPath: outputPath)
         }
@@ -475,9 +475,9 @@ extension Sourcery {
     }
 
     private func processRanges(in parsingResult: ParsingResult, result: String, outputPath: Path) throws -> String {
-        let start = CACurrentMediaTime()
+        let start = currentTimestamp()
         defer {
-            Log.benchmark("\t\tProcessing Ranges took \(CACurrentMediaTime() - start)")
+            Log.benchmark("\t\tProcessing Ranges took \(currentTimestamp() - start)")
         }
         var result = result
         result = processFileRanges(for: parsingResult, in: result, outputPath: outputPath)

--- a/Sourcery/main.swift
+++ b/Sourcery/main.swift
@@ -104,6 +104,7 @@ func runCLI() {
     ) { watcherEnabled, disableCache, verboseLogging, quiet, prune, sources, excludeSources, templates, excludeTemplates, output, configPath, forceParse, args, ejsPath in
         do {
             Log.level = verboseLogging ? .verbose : quiet ? .errors : .info
+            Log.logBenchmarks = quiet ? false : true
 
             // if ejsPath is not provided use default value or executable path
             EJSTemplate.ejsPath = ejsPath.string.isEmpty

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -74,7 +74,7 @@ public struct Composer {
             unique[current.name] = current
         }
 
-        let resolutionStart = CACurrentMediaTime()
+        let resolutionStart = currentTimestamp()
 
         let resolveType = { (typeName: TypeName, containingType: Type?) -> Type? in
             return self.resolveType(typeName: typeName, containingType: containingType, unique: unique, modules: modules, typealiases: typealiases)
@@ -101,7 +101,7 @@ public struct Composer {
             }
         }
 
-        Log.benchmark("\tresolution took \(CACurrentMediaTime() - resolutionStart)")
+        Log.benchmark("\tresolution took \(currentTimestamp() - resolutionStart)")
 
         updateTypeRelationships(types: Array(unique.values))
         return unique.values.sorted { $0.name < $1.name }

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -101,7 +101,7 @@ public struct Composer {
             }
         }
 
-        print("\tresolution took \(CACurrentMediaTime() - resolutionStart)")
+        Log.benchmark("\tresolution took \(CACurrentMediaTime() - resolutionStart)")
 
         updateTypeRelationships(types: Array(unique.values))
         return unique.values.sorted { $0.name < $1.name }

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -49,6 +49,7 @@ public final class FileParser {
 
     public let path: String?
     public let module: String?
+    public let modifiedDate: Date?
     public let initialContents: String
 
     fileprivate var contents: String!
@@ -69,6 +70,7 @@ public final class FileParser {
     /// - Throws: parsing errors.
     public init(contents: String, path: Path? = nil, module: String? = nil) throws {
         self.path = path?.string
+        self.modifiedDate = path.flatMap({ (try? FileManager.default.attributesOfItem(atPath: $0.string)[.modificationDate]) as? Date })
         self.module = module
         self.initialContents = contents
     }
@@ -102,7 +104,7 @@ public final class FileParser {
         let source = try Structure(file: file).dictionary
 
         let (types, typealiases) = try parseTypes(source)
-        return FileParserResult(path: path, module: module, types: types, typealiases: typealiases, inlineRanges: inlineRanges, inlineIndentations: inlineIndentations, contentSha: initialContents.sha256() ?? "", sourceryVersion: SourceryVersion.current.value)
+        return FileParserResult(path: path, module: module, types: types, typealiases: typealiases, inlineRanges: inlineRanges, inlineIndentations: inlineIndentations, modifiedDate: modifiedDate ?? Date(), sourceryVersion: SourceryVersion.current.value)
     }
 
     internal func parseTypes(_ source: [String: SourceKitRepresentable]) throws -> ([Type], [Typealias]) {

--- a/SourceryFramework/Sources/Parsing/Utils/Time.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/Time.swift
@@ -1,0 +1,13 @@
+//
+//  Time.swift
+//  SourceryFramework
+//
+//  Created by merowing on 03/09/2019.
+//  Copyright © 2019 Pixle. All rights reserved.
+//
+import Foundation
+
+/// Returns current timestamp interval
+public func currentTimestamp() -> TimeInterval {
+    return CFAbsoluteTimeGetCurrent()
+}

--- a/SourceryRuntime/Sources/Description.generated.swift
+++ b/SourceryRuntime/Sources/Description.generated.swift
@@ -98,7 +98,7 @@ extension FileParserResult {
         string += "typealiases = \(String(describing: self.typealiases)), "
         string += "inlineRanges = \(String(describing: self.inlineRanges)), "
         string += "inlineIndentations = \(String(describing: self.inlineIndentations)), "
-        string += "contentSha = \(String(describing: self.contentSha)), "
+        string += "modifiedDate = \(String(describing: self.modifiedDate)), "
         string += "sourceryVersion = \(String(describing: self.sourceryVersion))"
         return string
     }

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -132,7 +132,7 @@ extension FileParserResult: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "inlineRanges").trackDifference(actual: self.inlineRanges, expected: castObject.inlineRanges))
         results.append(contentsOf: DiffableResult(identifier: "inlineIndentations").trackDifference(actual: self.inlineIndentations, expected: castObject.inlineIndentations))
-        results.append(contentsOf: DiffableResult(identifier: "contentSha").trackDifference(actual: self.contentSha, expected: castObject.contentSha))
+        results.append(contentsOf: DiffableResult(identifier: "contentSha").trackDifference(actual: self.modifiedDate, expected: castObject.modifiedDate))
         results.append(contentsOf: DiffableResult(identifier: "sourceryVersion").trackDifference(actual: self.sourceryVersion, expected: castObject.sourceryVersion))
         return results
     }

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -132,7 +132,7 @@ extension FileParserResult: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "inlineRanges").trackDifference(actual: self.inlineRanges, expected: castObject.inlineRanges))
         results.append(contentsOf: DiffableResult(identifier: "inlineIndentations").trackDifference(actual: self.inlineIndentations, expected: castObject.inlineIndentations))
-        results.append(contentsOf: DiffableResult(identifier: "contentSha").trackDifference(actual: self.modifiedDate, expected: castObject.modifiedDate))
+        results.append(contentsOf: DiffableResult(identifier: "modifiedDate").trackDifference(actual: self.modifiedDate, expected: castObject.modifiedDate))
         results.append(contentsOf: DiffableResult(identifier: "sourceryVersion").trackDifference(actual: self.sourceryVersion, expected: castObject.sourceryVersion))
         return results
     }

--- a/SourceryRuntime/Sources/Equality.generated.swift
+++ b/SourceryRuntime/Sources/Equality.generated.swift
@@ -109,7 +109,7 @@ extension FileParserResult {
         if self.typealiases != rhs.typealiases { return false }
         if self.inlineRanges != rhs.inlineRanges { return false }
         if self.inlineIndentations != rhs.inlineIndentations { return false }
-        if self.contentSha != rhs.contentSha { return false }
+        if self.modifiedDate != rhs.modifiedDate { return false }
         if self.sourceryVersion != rhs.sourceryVersion { return false }
         return true
     }

--- a/SourceryRuntime/Sources/FileParserResult.swift
+++ b/SourceryRuntime/Sources/FileParserResult.swift
@@ -25,17 +25,17 @@ import Foundation
     public var inlineRanges = [String: NSRange]()
     public var inlineIndentations = [String: String]()
 
-    public var contentSha: String?
+    public var modifiedDate: Date
     public var sourceryVersion: String
 
-    public init(path: String?, module: String?, types: [Type], typealiases: [Typealias] = [], inlineRanges: [String: NSRange] = [:], inlineIndentations: [String: String] = [:], contentSha: String = "", sourceryVersion: String = "") {
+    public init(path: String?, module: String?, types: [Type], typealiases: [Typealias] = [], inlineRanges: [String: NSRange] = [:], inlineIndentations: [String: String] = [:], modifiedDate: Date = Date(), sourceryVersion: String = "") {
         self.path = path
         self.module = module
         self.types = types
         self.typealiases = typealiases
         self.inlineRanges = inlineRanges
         self.inlineIndentations = inlineIndentations
-        self.contentSha = contentSha
+        self.modifiedDate = modifiedDate
         self.sourceryVersion = sourceryVersion
 
         types.forEach { type in type.module = module }
@@ -50,7 +50,8 @@ import Foundation
             guard let typealiases: [Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             guard let inlineRanges: [String: NSRange] = aDecoder.decode(forKey: "inlineRanges") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineRanges"])); fatalError() }; self.inlineRanges = inlineRanges
             guard let inlineIndentations: [String: String] = aDecoder.decode(forKey: "inlineIndentations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineIndentations"])); fatalError() }; self.inlineIndentations = inlineIndentations
-            self.contentSha = aDecoder.decode(forKey: "contentSha")
+            guard let modifiedDate: Date = aDecoder.decode(forKey: "modifiedDate") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["modifiedDate"])); fatalError()  }
+            self.modifiedDate = modifiedDate
             guard let sourceryVersion: String = aDecoder.decode(forKey: "sourceryVersion") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["sourceryVersion"])); fatalError() }; self.sourceryVersion = sourceryVersion
         }
 
@@ -62,7 +63,7 @@ import Foundation
             aCoder.encode(self.typealiases, forKey: "typealiases")
             aCoder.encode(self.inlineRanges, forKey: "inlineRanges")
             aCoder.encode(self.inlineIndentations, forKey: "inlineIndentations")
-            aCoder.encode(self.contentSha, forKey: "contentSha")
+            aCoder.encode(self.modifiedDate, forKey: "modifiedDate")
             aCoder.encode(self.sourceryVersion, forKey: "sourceryVersion")
         }
 // sourcery:end

--- a/SourceryRuntime/Sources/FileParserResult.swift
+++ b/SourceryRuntime/Sources/FileParserResult.swift
@@ -50,8 +50,7 @@ import Foundation
             guard let typealiases: [Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             guard let inlineRanges: [String: NSRange] = aDecoder.decode(forKey: "inlineRanges") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineRanges"])); fatalError() }; self.inlineRanges = inlineRanges
             guard let inlineIndentations: [String: String] = aDecoder.decode(forKey: "inlineIndentations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineIndentations"])); fatalError() }; self.inlineIndentations = inlineIndentations
-            guard let modifiedDate: Date = aDecoder.decode(forKey: "modifiedDate") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["modifiedDate"])); fatalError()  }
-            self.modifiedDate = modifiedDate
+            guard let modifiedDate: Date = aDecoder.decode(forKey: "modifiedDate") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["modifiedDate"])); fatalError() }; self.modifiedDate = modifiedDate
             guard let sourceryVersion: String = aDecoder.decode(forKey: "sourceryVersion") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["sourceryVersion"])); fatalError() }; self.sourceryVersion = sourceryVersion
         }
 

--- a/SourceryRuntime/Sources/Log.swift
+++ b/SourceryRuntime/Sources/Log.swift
@@ -12,6 +12,7 @@ public enum Log {
     }
 
     public static var level: Level = .warnings
+    public static var logBenchmarks: Bool = false
 
     public static func error(_ message: Any) {
         log(level: .errors, "error: \(message)")
@@ -31,6 +32,11 @@ public enum Log {
 
     public static func info(_ message: Any) {
         log(level: .info, message)
+    }
+
+    public static func benchmark(_ message: Any) {
+        guard logBenchmarks else { return }
+        print(message)
     }
 
     private static func log(level logLevel: Level, _ message: Any) {

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -857,7 +857,7 @@ extension FileParserResult: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "inlineRanges").trackDifference(actual: self.inlineRanges, expected: castObject.inlineRanges))
         results.append(contentsOf: DiffableResult(identifier: "inlineIndentations").trackDifference(actual: self.inlineIndentations, expected: castObject.inlineIndentations))
-        results.append(contentsOf: DiffableResult(identifier: "contentSha").trackDifference(actual: self.modifiedDate, expected: castObject.modifiedDate))
+        results.append(contentsOf: DiffableResult(identifier: "modifiedDate").trackDifference(actual: self.modifiedDate, expected: castObject.modifiedDate))
         results.append(contentsOf: DiffableResult(identifier: "sourceryVersion").trackDifference(actual: self.sourceryVersion, expected: castObject.sourceryVersion))
         return results
     }
@@ -2044,8 +2044,7 @@ import Foundation
             guard let typealiases: [Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             guard let inlineRanges: [String: NSRange] = aDecoder.decode(forKey: "inlineRanges") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineRanges"])); fatalError() }; self.inlineRanges = inlineRanges
             guard let inlineIndentations: [String: String] = aDecoder.decode(forKey: "inlineIndentations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineIndentations"])); fatalError() }; self.inlineIndentations = inlineIndentations
-            guard let modifiedDate: Date = aDecoder.decode(forKey: "modifiedDate") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["modifiedDate"])); fatalError()  }
-            self.modifiedDate = modifiedDate
+            guard let modifiedDate: Date = aDecoder.decode(forKey: "modifiedDate") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["modifiedDate"])); fatalError() }; self.modifiedDate = modifiedDate
             guard let sourceryVersion: String = aDecoder.decode(forKey: "sourceryVersion") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["sourceryVersion"])); fatalError() }; self.sourceryVersion = sourceryVersion
         }
 

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -2523,6 +2523,7 @@ public enum Log {
     }
 
     public static var level: Level = .warnings
+    public static var logBenchmarks: Bool = false
 
     public static func error(_ message: Any) {
         log(level: .errors, "error: \\(message)")
@@ -2542,6 +2543,11 @@ public enum Log {
 
     public static func info(_ message: Any) {
         log(level: .info, message)
+    }
+
+    public static func benchmark(_ message: Any) {
+        guard logBenchmarks else { return }
+        print(message)
     }
 
     private static func log(level logLevel: Level, _ message: Any) {

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -527,7 +527,7 @@ extension FileParserResult {
         string += "typealiases = \\(String(describing: self.typealiases)), "
         string += "inlineRanges = \\(String(describing: self.inlineRanges)), "
         string += "inlineIndentations = \\(String(describing: self.inlineIndentations)), "
-        string += "contentSha = \\(String(describing: self.contentSha)), "
+        string += "modifiedDate = \\(String(describing: self.modifiedDate)), "
         string += "sourceryVersion = \\(String(describing: self.sourceryVersion))"
         return string
     }
@@ -857,7 +857,7 @@ extension FileParserResult: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "inlineRanges").trackDifference(actual: self.inlineRanges, expected: castObject.inlineRanges))
         results.append(contentsOf: DiffableResult(identifier: "inlineIndentations").trackDifference(actual: self.inlineIndentations, expected: castObject.inlineIndentations))
-        results.append(contentsOf: DiffableResult(identifier: "contentSha").trackDifference(actual: self.contentSha, expected: castObject.contentSha))
+        results.append(contentsOf: DiffableResult(identifier: "contentSha").trackDifference(actual: self.modifiedDate, expected: castObject.modifiedDate))
         results.append(contentsOf: DiffableResult(identifier: "sourceryVersion").trackDifference(actual: self.sourceryVersion, expected: castObject.sourceryVersion))
         return results
     }
@@ -1618,7 +1618,7 @@ extension FileParserResult {
         if self.typealiases != rhs.typealiases { return false }
         if self.inlineRanges != rhs.inlineRanges { return false }
         if self.inlineIndentations != rhs.inlineIndentations { return false }
-        if self.contentSha != rhs.contentSha { return false }
+        if self.modifiedDate != rhs.modifiedDate { return false }
         if self.sourceryVersion != rhs.sourceryVersion { return false }
         return true
     }
@@ -2019,17 +2019,17 @@ import Foundation
     public var inlineRanges = [String: NSRange]()
     public var inlineIndentations = [String: String]()
 
-    public var contentSha: String?
+    public var modifiedDate: Date
     public var sourceryVersion: String
 
-    public init(path: String?, module: String?, types: [Type], typealiases: [Typealias] = [], inlineRanges: [String: NSRange] = [:], inlineIndentations: [String: String] = [:], contentSha: String = "", sourceryVersion: String = "") {
+    public init(path: String?, module: String?, types: [Type], typealiases: [Typealias] = [], inlineRanges: [String: NSRange] = [:], inlineIndentations: [String: String] = [:], modifiedDate: Date = Date(), sourceryVersion: String = "") {
         self.path = path
         self.module = module
         self.types = types
         self.typealiases = typealiases
         self.inlineRanges = inlineRanges
         self.inlineIndentations = inlineIndentations
-        self.contentSha = contentSha
+        self.modifiedDate = modifiedDate
         self.sourceryVersion = sourceryVersion
 
         types.forEach { type in type.module = module }
@@ -2044,7 +2044,8 @@ import Foundation
             guard let typealiases: [Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             guard let inlineRanges: [String: NSRange] = aDecoder.decode(forKey: "inlineRanges") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineRanges"])); fatalError() }; self.inlineRanges = inlineRanges
             guard let inlineIndentations: [String: String] = aDecoder.decode(forKey: "inlineIndentations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inlineIndentations"])); fatalError() }; self.inlineIndentations = inlineIndentations
-            self.contentSha = aDecoder.decode(forKey: "contentSha")
+            guard let modifiedDate: Date = aDecoder.decode(forKey: "modifiedDate") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["modifiedDate"])); fatalError()  }
+            self.modifiedDate = modifiedDate
             guard let sourceryVersion: String = aDecoder.decode(forKey: "sourceryVersion") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["sourceryVersion"])); fatalError() }; self.sourceryVersion = sourceryVersion
         }
 
@@ -2056,7 +2057,7 @@ import Foundation
             aCoder.encode(self.typealiases, forKey: "typealiases")
             aCoder.encode(self.inlineRanges, forKey: "inlineRanges")
             aCoder.encode(self.inlineIndentations, forKey: "inlineIndentations")
-            aCoder.encode(self.contentSha, forKey: "contentSha")
+            aCoder.encode(self.modifiedDate, forKey: "modifiedDate")
             aCoder.encode(self.sourceryVersion, forKey: "sourceryVersion")
         }
 // sourcery:end

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -81,7 +81,7 @@ class GeneratorSpec: QuickSpec {
 
             func generate(_ template: String) -> String {
                 beforeEachGenerate()
-                let uniqueTypes = Composer().uniqueTypes(FileParserResult(path: nil, module: nil, types: types, typealiases: []))
+                let uniqueTypes = Composer.uniqueTypes(FileParserResult(path: nil, module: nil, types: types, typealiases: []))
 
                 return (try? Generator.generate(Types(types: uniqueTypes),
                         template: StencilTemplate(templateString: template),

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -23,7 +23,7 @@ class ParserComposerSpec: QuickSpec {
             describe("uniqueType") {
                 func parse(_ code: String) -> [Type] {
                     guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
-                    return Composer().uniqueTypes(parserResult)
+                    return Composer.uniqueTypes(parserResult)
                 }
 
                 context("given class hierarchy") {
@@ -927,7 +927,7 @@ class ParserComposerSpec: QuickSpec {
                             return acc
                         }
 
-                        return Composer().uniqueTypes(parserResult)
+                        return Composer.uniqueTypes(parserResult)
                     }
 
                     it("extends type with extension") {

--- a/SourceryTests/Parsing/FileParser + AttributesSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AttributesSpec.swift
@@ -13,7 +13,7 @@ class FileParserAttributesSpec: QuickSpec {
 
             func parse(_ code: String) -> [Type] {
                 guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
-                return Composer().uniqueTypes(parserResult)
+                return Composer.uniqueTypes(parserResult)
             }
 
             it("extracts type attributes") {

--- a/SourceryTests/Parsing/FileParser + MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser + MethodsSpec.swift
@@ -17,7 +17,7 @@ class FileParserMethodsSpec: QuickSpec {
             describe("parseMethod") {
                 func parse(_ code: String) -> [Type] {
                     guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
-                    return Composer().uniqueTypes(parserResult)
+                    return Composer.uniqueTypes(parserResult)
                 }
 
                 it("extracts methods properly") {

--- a/SourceryTests/Parsing/FileParser+SubscriptsSpec.swift
+++ b/SourceryTests/Parsing/FileParser+SubscriptsSpec.swift
@@ -13,7 +13,7 @@ class FileParserSubscriptsSpec: QuickSpec {
             describe("parseSubscript") {
                 func parse(_ code: String) -> [Type] {
                     guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
-                    return Composer().uniqueTypes(parserResult)
+                    return Composer.uniqueTypes(parserResult)
                 }
 
                 it("extracts subscripts properly") {

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -17,7 +17,7 @@ class FileParserSpec: QuickSpec {
             describe("parse") {
                 func parse(_ code: String) -> [Type] {
                     guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
-                    return Composer().uniqueTypes(parserResult)
+                    return Composer.uniqueTypes(parserResult)
                 }
 
                 describe("regression files") {


### PR DESCRIPTION
1. Switches cache to rely on modified date instead of sha256
2. Parallelizes combine phase

Does 2. step seem safe? looking at the code I think it is as we only mutate unique table before I run multi-threaded logic and it only mutates a single type per thread so no locks are required

For NYT project this branch yields 5-10x speed improvement for codebase which is huge.