### PR TITLE
Filtered config for missing env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Sourcery CHANGELOG
 
 ---
+## Master
+
+### Bug fixes
+
+- Fixed expansion of undefined environment variables (now consistent with command line behaviour, where such args are empty strings)
+
 ## 0.17.0
 
 ### Internal Changes

--- a/Sourcery/Configuration.swift
+++ b/Sourcery/Configuration.swift
@@ -294,24 +294,21 @@ private extension String {
         }
     }
 
-    func expandingEnvVars(env: [String: String]) -> String {
-        let entries = self.components(separatedBy: "\n").compactMap { entry -> String? in
-            guard let match = entry.range(of: #"\$\{(.)\w+\}"#, options: .regularExpression) else {
-                return entry
-            }
-
-            // get the env variable as "${ENV_VAR}"
-            let key = String(entry[match])
-
-            // get the env variable as "ENV_VAR" - note missing $ and brackets
-            let keyString = String(key[2..<key.count-1])
-
-            guard let value = env[keyString] else { return nil }
-
-            return entry.replacingOccurrences(of: key, with: value)
+    func expandingEnvVars(env: [String: String]) -> String? {
+        // check if entry has an env variable
+        guard let match = self.range(of: #"\$\{(.)\w+\}"#, options: .regularExpression) else {
+            return self
         }
 
-        return entries.joined(separator: "\n")
+        // get the env variable as "${ENV_VAR}"
+        let key = String(self[match])
+
+        // get the env variable as "ENV_VAR" - note missing $ and brackets
+        let keyString = String(key[2..<key.count-1])
+
+        guard let value = env[keyString] else { return "" }
+
+        return self.replacingOccurrences(of: key, with: value)
     }
 }
 

--- a/SourceryTests/ConfigurationSpec.swift
+++ b/SourceryTests/ConfigurationSpec.swift
@@ -47,7 +47,7 @@ class ConfigurationSpec: QuickSpec {
 
                         let serverPort = config.args["serverPort"]
 
-                        expect(serverPort).to(equal(nil))
+                        expect(serverPort).to(beNil())
                     } catch {
                         expect("\(error)").to(equal("Invalid config file format. Expected dictionary."))
                     }

--- a/SourceryTests/ConfigurationSpec.swift
+++ b/SourceryTests/ConfigurationSpec.swift
@@ -45,9 +45,9 @@ class ConfigurationSpec: QuickSpec {
                                                        env: ["SOURCE_PATH": "Sources",
                                                              "serverUrl": "www.example.com"])
 
-                        let serverPort = config.args["serverPort"]
+                        let serverPort = config.args["serverPort"] as? String
 
-                        expect(serverPort).to(beNil())
+                        expect(serverPort).to(equal(""))
                     } catch {
                         expect("\(error)").to(equal("Invalid config file format. Expected dictionary."))
                     }

--- a/SourceryTests/ConfigurationSpec.swift
+++ b/SourceryTests/ConfigurationSpec.swift
@@ -14,10 +14,14 @@ class ConfigurationSpec: QuickSpec {
 
                 it("replaces the env placeholder") {
                     do {
+                        let serverUrlArg = "serverUrl"
+                        let serverUrl: String = "www.example.com"
+
                         let config = try Configuration(
                             path: Stubs.configs + ".valid.yml",
                             relativePath: relativePath,
-                            env: ["SOURCE_PATH": "Sources"]
+                            env: ["SOURCE_PATH": "Sources",
+                                  serverUrlArg: serverUrl]
                         )
                         guard case let Source.sources(paths) = config.source,
                             let path = paths.include.first else {
@@ -25,7 +29,25 @@ class ConfigurationSpec: QuickSpec {
                             return
                         }
 
+                        let configServerUrl = config.args[serverUrlArg] as? String
+
+                        expect(configServerUrl).to(equal(serverUrl))
                         expect(path).to(equal("/some/path/Sources"))
+                    } catch {
+                        expect("\(error)").to(equal("Invalid config file format. Expected dictionary."))
+                    }
+                }
+
+                it("removes args entries with missing env variables") {
+                    do {
+                        let config = try Configuration(path: Stubs.configs + ".valid.yml",
+                                                       relativePath: relativePath,
+                                                       env: ["SOURCE_PATH": "Sources",
+                                                             "serverUrl": "www.example.com"])
+
+                        let serverPort = config.args["serverPort"]
+
+                        expect(serverPort).to(equal(nil))
                     } catch {
                         expect("\(error)").to(equal("Invalid config file format. Expected dictionary."))
                     }

--- a/SourceryTests/Stub/Configs/.valid.yml
+++ b/SourceryTests/Stub/Configs/.valid.yml
@@ -3,3 +3,6 @@ sources:
 templates:
 - "Templates"
 output: "Output"
+args:
+    serverUrl: ${serverUrl}
+    serverPort: ${serverPort}


### PR DESCRIPTION
Added a more complex mechanism to expand env variables, removing entries with missing variables. This will allow configuration files to behave like the command line `--args` version.