### PR TITLE
Log errors when running with `--watch` option Re #785

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ---
 ## Master
 
+### Internal Changes
+
+- Improved error logging when running with `--watch` option
+
 ### Bug fixes
 
 - Fixed expansion of undefined environment variables (now consistent with command line behaviour, where such args are empty strings)

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -466,8 +466,12 @@ extension Sourcery {
 
         var result: String = ""
         SwiftTryCatch.try({
-                              result = (try? Generator.generate(parsingResult.types, template: template, arguments: self.arguments)) ?? ""
-                          }, catch: { error in
+            do {
+                result = try Generator.generate(parsingResult.types, template: template, arguments: self.arguments)
+            } catch {
+                Log.error(error)
+            }
+        }, catch: { error in
             result = error?.description ?? ""
         }, finallyBlock: {})
 


### PR DESCRIPTION
This is an improvement for better logging when running with `--watch` option. https://github.com/krzysztofzablocki/Sourcery/issues/785