### PR TITLE
HUGE performance boost to 'parse' when have a large complex 'excludes' list.

### DIFF
--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -243,15 +243,16 @@ extension Sourcery {
         var inlineRanges = [(file: String, ranges: [String: NSRange], indentations: [String: String])]()
         var allResults = [FileParserResult]()
 
+        let excludeSet = Set(exclude
+            .map { $0.isDirectory ? try? $0.recursiveChildren() : [$0] }
+            .compactMap({ $0 }).flatMap({ $0 }))
+
         try from.enumerated().forEach { index, from in
             let fileList = from.isDirectory ? try from.recursiveChildren() : [from]
             let sources = try fileList
                 .filter { $0.isSwiftSourceFile }
                 .filter {
-                    let exclude = exclude
-                        .map { $0.isDirectory ? try? $0.recursiveChildren() : [$0] }
-                        .compactMap({ $0 }).flatMap({ $0 })
-                    return !exclude.contains($0)
+                    return !excludeSet.contains($0)
                 }
                 .compactMap { (path: Path) -> (path: Path, contents: String)? in
                     do {


### PR DESCRIPTION
Removed the recursive computation of the excludeList from the outside the enumeration().

The old logic would recompute the entire exclusion path list for every file being checked in the path.
Now the exclusion list is computed first, and then it's reused for the enumeration.

Also found a definite improvement in using a 'Set' over a simple 'array'.

This results in a HUGE runtime performance for repos with large number of excluded files (we saw 95 seconds runtime -> 3.5 seconds).