### PR TITLE
fix inferring dictionary and array variables types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - Fixed expansion of undefined environment variables (now consistent with command line behaviour, where such args are empty strings)
+- Fixed a bug in inferring extensions of Dictionary and Array types
 
 ## 0.17.0
 

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -123,14 +123,14 @@ public struct Composer {
         if let array = parseArrayType(lookupName) {
             lookupName.array = array
             array.elementType = resolveTypeWithName(array.elementTypeName)
-            lookupName.generic = GenericType(name: lookupName.name, typeParameters: [
+            lookupName.generic = GenericType(name: "Array", typeParameters: [
                 GenericTypeParameter(typeName: array.elementTypeName, type: array.elementType)
                 ])
         } else if let dictionary = parseDictionaryType(lookupName) {
             lookupName.dictionary = dictionary
             dictionary.valueType = resolveTypeWithName(dictionary.valueTypeName)
             dictionary.keyType = resolveTypeWithName(dictionary.keyTypeName)
-            lookupName.generic = GenericType(name: lookupName.name, typeParameters: [
+            lookupName.generic = GenericType(name: "Dictionary", typeParameters: [
                 GenericTypeParameter(typeName: dictionary.keyTypeName, type: dictionary.keyType),
                 GenericTypeParameter(typeName: dictionary.valueTypeName, type: dictionary.valueType)
                 ])

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -262,8 +262,8 @@ class ParserComposerSpec: QuickSpec {
                         let variable = types.first?.variables.first
                         let tuple = variable?.typeName.tuple
 
-                        let stringToFloatDictGeneric = GenericType(name: "Dictionary<String, Float>", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
-                        let stringToFloatDictGenericLiteral = GenericType(name: "[String: Float]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
+                        let stringToFloatDictGeneric = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
+                        let stringToFloatDictGenericLiteral = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Float"))])
 
                         let stringToFloatDict = DictionaryType(name: "Dictionary<String, Float>", valueTypeName: TypeName("Float"), keyTypeName: TypeName("String"))
                         let stringToFloatDictLiteral = DictionaryType(name: "[String: Float]", valueTypeName: TypeName("Float"), keyTypeName: TypeName("String"))
@@ -273,10 +273,10 @@ class ParserComposerSpec: QuickSpec {
                         expect(tuple?.elements[2]).to(equal(TupleElement(name: "2", typeName: TypeName("String"))))
                         expect(tuple?.elements[3]).to(equal(TupleElement(name: "3", typeName: TypeName("Float"))))
                         expect(tuple?.elements[4]).to(equal(
-                            TupleElement(name: "literal", typeName: TypeName("[String: [String: Float]]", dictionary: DictionaryType(name: "[String: [String: Float]]", valueTypeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral), keyTypeName: TypeName("String")), generic: GenericType(name: "[String: [String: Float]]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral))])))
+                            TupleElement(name: "literal", typeName: TypeName("[String: [String: Float]]", dictionary: DictionaryType(name: "[String: [String: Float]]", valueTypeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("[String: Float]", dictionary: stringToFloatDictLiteral, generic: stringToFloatDictGenericLiteral))])))
                         ))
                         expect(tuple?.elements[5]).to(equal(
-                            TupleElement(name: "generic", typeName: TypeName("Dictionary<String, Dictionary<String, Float>>", dictionary: DictionaryType(name: "Dictionary<String, Dictionary<String, Float>>", valueTypeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary<String, Dictionary<String, Float>>", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric))])))
+                            TupleElement(name: "generic", typeName: TypeName("Dictionary<String, Dictionary<String, Float>>", dictionary: DictionaryType(name: "Dictionary<String, Dictionary<String, Float>>", valueTypeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("Dictionary<String, Float>", dictionary: stringToFloatDict, generic: stringToFloatDictGeneric))])))
                         ))
                         expect(tuple?.elements[6]).to(equal(
                             TupleElement(name: "closure", typeName: TypeName("(Int) -> (Int -> Int)", closure: ClosureType(name: "(Int) -> (Int -> Int)", parameters: [
@@ -308,7 +308,7 @@ class ParserComposerSpec: QuickSpec {
                                     ])))
                         ))
                         expect(variables?[2].typeName.array).to(equal(
-                            ArrayType(name: "[[Int]]", elementTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                            ArrayType(name: "[[Int]]", elementTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[3].typeName.array).to(equal(
                             ArrayType(name: "[()->()]", elementTypeName: TypeName("()->()", closure: ClosureType(name: "() -> ()", parameters: [], returnTypeName: TypeName("()"))))
@@ -331,7 +331,7 @@ class ParserComposerSpec: QuickSpec {
                                     ])))
                         ))
                         expect(variables?[2].typeName.array).to(equal(
-                            ArrayType(name: "Array<Array<Int>>", elementTypeName: TypeName("Array<Int>", array: ArrayType(name: "Array<Int>", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array<Int>", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                            ArrayType(name: "Array<Array<Int>>", elementTypeName: TypeName("Array<Int>", array: ArrayType(name: "Array<Int>", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[3].typeName.array).to(equal(
                             ArrayType(name: "Array<()->()>", elementTypeName: TypeName("()->()", closure: ClosureType(name: "() -> ()", parameters: [], returnTypeName: TypeName("()"))))
@@ -348,11 +348,11 @@ class ParserComposerSpec: QuickSpec {
                             DictionaryType(name: "Dictionary<Int, String>", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int"))
                         ))
                         expect(variables?[1].typeName.dictionary).to(equal(
-                            DictionaryType(name: "Dictionary<[Int], [String]>", valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "[String]", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])), keyTypeName: TypeName("[Int]", array:
-                                ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
+                            DictionaryType(name: "Dictionary<[Int], [String]>", valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])), keyTypeName: TypeName("[Int]", array:
+                                ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))])))
                         ))
                         expect(variables?[2].typeName.dictionary).to(equal(
-                            DictionaryType(name: "Dictionary<Int, [Int: String]>", valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "[Int: String]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])), keyTypeName: TypeName("Int"))
+                            DictionaryType(name: "Dictionary<Int, [Int: String]>", valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])), keyTypeName: TypeName("Int"))
                         ))
                         expect(variables?[3].typeName.dictionary).to(equal(
                             DictionaryType(name: "Dictionary<Int, (String, String)>",
@@ -365,6 +365,30 @@ class ParserComposerSpec: QuickSpec {
                     }
                 }
 
+                context("given generic types extensions") {
+                    it("detects protocol conformance in extension of generic types") {
+                        let types = parse("""
+                            protocol Bar {}
+                            extension Array: Bar {}
+                            extension Dictionary: Bar {}
+                            extension Set: Bar {}
+                            struct Foo {
+                                var array: Array<Int>
+                                var arrayLiteral: [Int]
+                                var dictionary: Dictionary<String, Int>
+                                var dictionaryLiteral: [String: Int]
+                                var set: Set<String>
+                            }
+                            """)
+                        let bar = SourceryProtocol.init(name: "Bar")
+                        let variables = types[3].variables
+                        expect(variables[0].type?.implements["Bar"]).to(equal(bar))
+                        expect(variables[1].type?.implements["Bar"]).to(equal(bar))
+                        expect(variables[2].type?.implements["Bar"]).to(equal(bar))
+                        expect(variables[3].type?.implements["Bar"]).to(equal(bar))
+                        expect(variables[4].type?.implements["Bar"]).to(equal(bar))
+                    }
+                }
                 context("given literal dictionary type") {
                     it("extracts key type properly") {
                         let types = parse("struct Foo { var dictionary: [Int: String]; var dictionaryOfArrays: [[Int]: [String]]; var dicitonaryOfDictionaries: [Int: [Int: String]]; var dictionaryOfTuples: [Int: (String, String)]; var dictionaryOfClojures: [Int: ()->()] }")
@@ -375,13 +399,13 @@ class ParserComposerSpec: QuickSpec {
                         ))
                         expect(variables?[1].typeName.dictionary).to(equal(
                             DictionaryType(name: "[[Int]: [String]]",
-                                           valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "[String]", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])),
-                                           keyTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "[Int]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))]))
+                                           valueTypeName: TypeName("[String]", array: ArrayType(name: "[String]", elementTypeName: TypeName("String")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("String"))])),
+                                           keyTypeName: TypeName("[Int]", array: ArrayType(name: "[Int]", elementTypeName: TypeName("Int")), generic: GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Int"))]))
                             )
                         ))
                         expect(variables?[2].typeName.dictionary).to(equal(
                             DictionaryType(name: "[Int: [Int: String]]",
-                                           valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "[Int: String]", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])),
+                                           valueTypeName: TypeName("[Int: String]", dictionary: DictionaryType(name: "[Int: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("Int")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("Int")), GenericTypeParameter(typeName: TypeName("String"))])),
                                            keyTypeName: TypeName("Int")
                             )
                         ))
@@ -704,7 +728,7 @@ class ParserComposerSpec: QuickSpec {
                         it("replaces associated value alias type with actual dictionary type name") {
                             var expectedTypeName = TypeName("[String: Any]")
                             expectedTypeName.dictionary = DictionaryType(name: "[String: Any]", valueTypeName: TypeName("Any"), valueType: nil, keyTypeName: TypeName("String"), keyType: nil)
-                            expectedTypeName.generic = GenericType(name: "[String: Any]", typeParameters: [GenericTypeParameter(typeName: TypeName("String"), type: nil), GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
+                            expectedTypeName.generic = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String"), type: nil), GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
 
                             let expectedAssociatedValue = AssociatedValue(typeName: TypeName("JSON", actualTypeName: expectedTypeName, dictionary: expectedTypeName.dictionary, generic: expectedTypeName.generic), type: nil)
 
@@ -718,7 +742,7 @@ class ParserComposerSpec: QuickSpec {
                         it("replaces associated value alias type with actual array type name") {
                             let expectedTypeName = TypeName("[Any]")
                             expectedTypeName.array = ArrayType(name: "[Any]", elementTypeName: TypeName("Any"), elementType: nil)
-                            expectedTypeName.generic = GenericType(name: "[Any]", typeParameters: [GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
+                            expectedTypeName.generic = GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Any"), type: nil)])
 
                             let expectedAssociatedValue = AssociatedValue(typeName: TypeName("JSON", actualTypeName: expectedTypeName, array: expectedTypeName.array, generic: expectedTypeName.generic), type: nil)
 
@@ -866,7 +890,7 @@ class ParserComposerSpec: QuickSpec {
                         let expectedBlah = Struct(name: "Blah", containedTypes: [Struct(name: "Foo"), Struct(name: "Bar", variables: [expectedVariable])])
                         expectedActualTypeName.array = ArrayType(name: "[Blah.Foo]?", elementTypeName: TypeName("Blah.Foo"), elementType: Struct(name: "Foo", parent: expectedBlah))
                         expectedVariable.typeName.array = expectedActualTypeName.array
-                        expectedActualTypeName.generic = GenericType(name: "[Blah.Foo]?", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
+                        expectedActualTypeName.generic = GenericType(name: "Array", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
                         expectedVariable.typeName.generic = expectedActualTypeName.generic
 
                         let types = parse("struct Blah { struct Foo {}; struct Bar { let foo: [Foo]? }}")
@@ -884,7 +908,7 @@ class ParserComposerSpec: QuickSpec {
                         let expectedBlah = Struct(name: "Blah", containedTypes: [Struct(name: "Foo"), Struct(name: "Bar", variables: [expectedVariable])])
                         expectedActualTypeName.dictionary = DictionaryType(name: "[Blah.Foo: Blah.Foo]?", valueTypeName: TypeName("Blah.Foo"), valueType: Struct(name: "Foo", parent: expectedBlah), keyTypeName: TypeName("Blah.Foo"), keyType: Struct(name: "Foo", parent: expectedBlah))
                         expectedVariable.typeName.dictionary = expectedActualTypeName.dictionary
-                        expectedActualTypeName.generic = GenericType(name: "[Blah.Foo: Blah.Foo]?", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah)), GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
+                        expectedActualTypeName.generic = GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah)), GenericTypeParameter(typeName: TypeName("Blah.Foo"), type: Struct(name: "Foo", parent: expectedBlah))])
                         expectedVariable.typeName.generic = expectedActualTypeName.generic
 
                         let types = parse("struct Blah { struct Foo {}; struct Bar { let foo: [Foo: Foo]? }}")

--- a/SourceryTests/Parsing/FileParser + MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser + MethodsSpec.swift
@@ -137,7 +137,7 @@ class FileParserMethodsSpec: QuickSpec {
                             .to(equal([
                                 Class(name: "Foo", methods: [
                                     Method(name: "foo( bar: [String: String],   foo : ((String, String) -> Void), other: Optional<String>)", selectorName: "foo(bar:foo:other:)", parameters: [
-                                        MethodParameter(name: "bar", typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "[String: String]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))]))),
+                                        MethodParameter(name: "bar", typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))]))),
                                         MethodParameter(name: "foo", typeName: TypeName("((String, String) -> Void)", closure: ClosureType(name: "(String, String) -> Void", parameters: [
                                             MethodParameter(argumentLabel: nil, typeName: TypeName("String")),
                                             MethodParameter(argumentLabel: nil, typeName: TypeName("String"))

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -467,7 +467,7 @@ class FileParserSpec: QuickSpec {
                                                 AssociatedValue(localName: nil, externalName: "2", typeName: TypeName("Int"))
                                                 ]),
                                             EnumCase(name: "optionC", associatedValues: [
-                                                AssociatedValue(localName: "dict", externalName: nil, typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "[String: String]", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))])))
+                                                AssociatedValue(localName: "dict", externalName: nil, typeName: TypeName("[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName("String"), keyTypeName: TypeName("String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName("String")), GenericTypeParameter(typeName: TypeName("String"))])))
                                                 ])
                                         ])
                                 ]))


### PR DESCRIPTION
Resolves #788 

The issue was that for arrays and dictionaries we are using custom parsing to parse literal syntax and for these types `typeName.generic.name` that is used for inferring types in composer was using the same name as `typeName.dictionary.name` or `typeName.array.name`, i.e. `[String: Int]` or `Dictionary<String, Int>`. For other types, i.e. `Set`, we set `typeName.generic.name` to just `Set` and then we infer extensions of `Set` type properly. So the fix is to align `typeName.generic.name` for dictionaries and array to follow the same behaviour as for other generic types, meaning they will be now `Dictionary` or `Array`. At the same time `typeName.array.name` and `typeName.dictionary.name` behaviour stays the same and they will contain the type name that was used in declaration.