### PR TITLE
Strip out default values from type names in AssociatedValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Added `optional` filter for variables
 - Added `json` filter to output raw JSON objects 
+- Added `.defaultValue` to `AssociatedValue`
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fixed expansion of undefined environment variables (now consistent with command line behaviour, where such args are empty strings)
 - Fixed a bug in inferring extensions of Dictionary and Array types
+- Fixed a bug that was including default values as part of AssociatedValues type names
 
 ## 0.17.0
 

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -667,7 +667,9 @@ extension FileParser {
             .enumerated()
             .map { index, body in
                 let annotations = AnnotationsParser(contents: body).all
-                let body = body.strippingComments()
+                let body = body
+                    .strippingComments()
+                    .strippingDefaultValues()
                 let nameAndType = body.colonSeparated().map({ $0.trimmingCharacters(in: .whitespaces) })
                 let defaultName: String? = index == 0 && items.count == 1 ? nil : "\(index)"
 
@@ -854,6 +856,14 @@ extension String {
         } while !finished
 
         return stripped
+    }
+
+    func strippingDefaultValues() -> String {
+        if let defaultValueRange = self.range(of: "=") {
+            return String(self[self.startIndex ..< defaultValueRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+        } else {
+            return self
+        }
     }
 
 }

--- a/SourceryRuntime/Sources/Description.generated.swift
+++ b/SourceryRuntime/Sources/Description.generated.swift
@@ -20,6 +20,7 @@ extension AssociatedValue {
         string += "localName = \(String(describing: self.localName)), "
         string += "externalName = \(String(describing: self.externalName)), "
         string += "typeName = \(String(describing: self.typeName)), "
+        string += "defaultValue = \(String(describing: self.defaultValue)), "
         string += "annotations = \(String(describing: self.annotations))"
         return string
     }

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -25,6 +25,7 @@ extension AssociatedValue: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "localName").trackDifference(actual: self.localName, expected: castObject.localName))
         results.append(contentsOf: DiffableResult(identifier: "externalName").trackDifference(actual: self.externalName, expected: castObject.externalName))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "defaultValue").trackDifference(actual: self.defaultValue, expected: castObject.defaultValue))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         return results
     }

--- a/SourceryRuntime/Sources/Enum.swift
+++ b/SourceryRuntime/Sources/Enum.swift
@@ -23,20 +23,24 @@ import Foundation
     /// Associated value type, if known
     public var type: Type?
 
+    /// Associated value default value
+    public let defaultValue: String?
+
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
     public var annotations: [String: NSObject] = [:]
 
     /// :nodoc:
-    public init(localName: String?, externalName: String?, typeName: TypeName, type: Type? = nil, annotations: [String: NSObject] = [:]) {
+    public init(localName: String?, externalName: String?, typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:]) {
         self.localName = localName
         self.externalName = externalName
         self.typeName = typeName
         self.type = type
+        self.defaultValue = defaultValue
         self.annotations = annotations
     }
 
-    convenience init(name: String? = nil, typeName: TypeName, type: Type? = nil, annotations: [String: NSObject] = [:]) {
-        self.init(localName: name, externalName: name, typeName: typeName, type: type, annotations: annotations)
+    convenience init(name: String? = nil, typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:]) {
+        self.init(localName: name, externalName: name, typeName: typeName, type: type, defaultValue: defaultValue, annotations: annotations)
     }
 
 // sourcery:inline:AssociatedValue.AutoCoding
@@ -46,6 +50,7 @@ import Foundation
             self.externalName = aDecoder.decode(forKey: "externalName")
             guard let typeName: TypeName = aDecoder.decode(forKey: "typeName") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typeName"])); fatalError() }; self.typeName = typeName
             self.type = aDecoder.decode(forKey: "type")
+            self.defaultValue = aDecoder.decode(forKey: "defaultValue")
             guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
         }
 
@@ -55,6 +60,7 @@ import Foundation
             aCoder.encode(self.externalName, forKey: "externalName")
             aCoder.encode(self.typeName, forKey: "typeName")
             aCoder.encode(self.type, forKey: "type")
+            aCoder.encode(self.defaultValue, forKey: "defaultValue")
             aCoder.encode(self.annotations, forKey: "annotations")
         }
 // sourcery:end

--- a/SourceryRuntime/Sources/Equality.generated.swift
+++ b/SourceryRuntime/Sources/Equality.generated.swift
@@ -20,6 +20,7 @@ extension AssociatedValue {
         if self.localName != rhs.localName { return false }
         if self.externalName != rhs.externalName { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.defaultValue != rhs.defaultValue { return false }
         if self.annotations != rhs.annotations { return false }
         return true
     }

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -449,6 +449,7 @@ extension AssociatedValue {
         string += "localName = \\(String(describing: self.localName)), "
         string += "externalName = \\(String(describing: self.externalName)), "
         string += "typeName = \\(String(describing: self.typeName)), "
+        string += "defaultValue = \\(String(describing: self.defaultValue)), "
         string += "annotations = \\(String(describing: self.annotations))"
         return string
     }
@@ -750,6 +751,7 @@ extension AssociatedValue: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "localName").trackDifference(actual: self.localName, expected: castObject.localName))
         results.append(contentsOf: DiffableResult(identifier: "externalName").trackDifference(actual: self.externalName, expected: castObject.externalName))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "defaultValue").trackDifference(actual: self.defaultValue, expected: castObject.defaultValue))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         return results
     }
@@ -1318,20 +1320,24 @@ import Foundation
     /// Associated value type, if known
     public var type: Type?
 
+    /// Associated value default value
+    public let defaultValue: String?
+
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
     public var annotations: [String: NSObject] = [:]
 
     /// :nodoc:
-    public init(localName: String?, externalName: String?, typeName: TypeName, type: Type? = nil, annotations: [String: NSObject] = [:]) {
+    public init(localName: String?, externalName: String?, typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:]) {
         self.localName = localName
         self.externalName = externalName
         self.typeName = typeName
         self.type = type
+        self.defaultValue = defaultValue
         self.annotations = annotations
     }
 
-    convenience init(name: String? = nil, typeName: TypeName, type: Type? = nil, annotations: [String: NSObject] = [:]) {
-        self.init(localName: name, externalName: name, typeName: typeName, type: type, annotations: annotations)
+    convenience init(name: String? = nil, typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:]) {
+        self.init(localName: name, externalName: name, typeName: typeName, type: type, defaultValue: defaultValue, annotations: annotations)
     }
 
 // sourcery:inline:AssociatedValue.AutoCoding
@@ -1341,6 +1347,7 @@ import Foundation
             self.externalName = aDecoder.decode(forKey: "externalName")
             guard let typeName: TypeName = aDecoder.decode(forKey: "typeName") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typeName"])); fatalError() }; self.typeName = typeName
             self.type = aDecoder.decode(forKey: "type")
+            self.defaultValue = aDecoder.decode(forKey: "defaultValue")
             guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
         }
 
@@ -1350,6 +1357,7 @@ import Foundation
             aCoder.encode(self.externalName, forKey: "externalName")
             aCoder.encode(self.typeName, forKey: "typeName")
             aCoder.encode(self.type, forKey: "type")
+            aCoder.encode(self.defaultValue, forKey: "defaultValue")
             aCoder.encode(self.annotations, forKey: "annotations")
         }
 // sourcery:end
@@ -1529,6 +1537,7 @@ extension AssociatedValue {
         if self.localName != rhs.localName { return false }
         if self.externalName != rhs.externalName { return false }
         if self.typeName != rhs.typeName { return false }
+        if self.defaultValue != rhs.defaultValue { return false }
         if self.annotations != rhs.annotations { return false }
         return true
     }

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -484,6 +484,23 @@ class FileParserSpec: QuickSpec {
                                           ]))
                     }
 
+                    it("does not include default values for asssociated types as part of its name") {
+                        expect(parse("enum Foo { case optionA(Int = 1, named: Float = 42.0, _: Bool = false); case optionB(Bool = true) }"))
+                        .to(equal([
+                            Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases:
+                                [
+                                    EnumCase(name: "optionA", associatedValues: [
+                                        AssociatedValue(localName: nil, externalName: "0", typeName: TypeName("Int")),
+                                        AssociatedValue(localName: "named", externalName: "named", typeName: TypeName("Float")),
+                                        AssociatedValue(localName: nil, externalName: "2", typeName: TypeName("Bool"))
+                                        ]),
+                                    EnumCase(name: "optionB", associatedValues: [
+                                    AssociatedValue(localName: nil, externalName: nil, typeName: TypeName("Bool"))
+                                    ])
+                                ])
+                        ]))
+                    }
+
                     context("given associated value with its type existing") {
 
                         it("extracts associated value's type") {

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -484,18 +484,18 @@ class FileParserSpec: QuickSpec {
                                           ]))
                     }
 
-                    it("does not include default values for asssociated types as part of its name") {
+                    it("extracts default values for asssociated values") {
                         expect(parse("enum Foo { case optionA(Int = 1, named: Float = 42.0, _: Bool = false); case optionB(Bool = true) }"))
                         .to(equal([
                             Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases:
                                 [
                                     EnumCase(name: "optionA", associatedValues: [
-                                        AssociatedValue(localName: nil, externalName: "0", typeName: TypeName("Int")),
-                                        AssociatedValue(localName: "named", externalName: "named", typeName: TypeName("Float")),
-                                        AssociatedValue(localName: nil, externalName: "2", typeName: TypeName("Bool"))
+                                        AssociatedValue(localName: nil, externalName: "0", typeName: TypeName("Int"), defaultValue: "1"),
+                                        AssociatedValue(localName: "named", externalName: "named", typeName: TypeName("Float"), defaultValue: "42.0"),
+                                        AssociatedValue(localName: nil, externalName: "2", typeName: TypeName("Bool"), defaultValue: "false")
                                         ]),
                                     EnumCase(name: "optionB", associatedValues: [
-                                    AssociatedValue(localName: nil, externalName: nil, typeName: TypeName("Bool"))
+                                    AssociatedValue(localName: nil, externalName: nil, typeName: TypeName("Bool"), defaultValue: "true")
                                     ])
                                 ])
                         ]))


### PR DESCRIPTION
When parsing the following Enum:
```swift
enum Foo {
    case bar(Int = 1)
}
```
`typeName.name` in the `AssociatedValue` is set to `Int = 1`, which I'm assuming is semantically incorrect as the default value has nothing to do with a type name.

We can store the default value somewhere else (maybe another property of `AssociatedValue`?) in another PR if needs be.