### PR TITLE
Improve AutoMockable.stencil for functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - Fixed expansion of undefined environment variables (now consistent with command line behaviour, where such args are empty strings)
 - Fixed a bug in inferring extensions of Dictionary and Array types
 - Fixed a bug that was including default values as part of AssociatedValues type names
-
+- Fixed an issue with AutoMockable.stencil template when mocked function's return type was closure
+  
 ## 0.17.0
 
 ### Internal Changes

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -62,7 +62,7 @@ import AppKit
     var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
-    var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure }}{{ method.returnTypeName }}{{ ')' if method.returnTypeName.isClosure }}{{ '!' if not method.isOptionalReturnType }}
+    var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ method.returnTypeName }}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ '!' if not method.isOptionalReturnType }}
     {% endif %}
     {% call methodClosureDeclaration method %}
 

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -62,7 +62,7 @@ import AppKit
     var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
-    var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ method.returnTypeName }}{{ '!' if not method.isOptionalReturnType }}
+    var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure }}{{ method.returnTypeName }}{{ ')' if method.returnTypeName.isClosure }}{{ '!' if not method.isOptionalReturnType }}
     {% endif %}
     {% call methodClosureDeclaration method %}
 

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -79,3 +79,8 @@ protocol AnnotatedProtocol {
 protocol SingleOptionalParameterFunction: AutoMockable {
     func send(message: String?)
 }
+
+protocol FunctionWithClosureReturnType: AutoMockable {
+    func get() -> () -> Void
+    func getOptional() -> (() -> Void)?
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -125,6 +125,37 @@ class ExtendableProtocolMock: ExtendableProtocol {
     }
 
 }
+class FunctionWithClosureReturnTypeMock: FunctionWithClosureReturnType {
+
+    //MARK: - get
+
+    var getCallsCount = 0
+    var getCalled: Bool {
+        return getCallsCount > 0
+    }
+    var getReturnValue: (() -> Void)!
+    var getClosure: (() -> () -> Void)?
+
+    func get() -> () -> Void {
+        getCallsCount += 1
+        return getClosure.map({ $0() }) ?? getReturnValue
+    }
+
+    //MARK: - getOptional
+
+    var getOptionalCallsCount = 0
+    var getOptionalCalled: Bool {
+        return getOptionalCallsCount > 0
+    }
+    var getOptionalReturnValue: (() -> Void)?
+    var getOptionalClosure: (() -> () -> Void?)?
+
+    func getOptional() -> (() -> Void)? {
+        getOptionalCallsCount += 1
+        return getOptionalClosure.map({ $0() }) ?? getOptionalReturnValue
+    }
+
+}
 class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOptionalReturnValueProtocol {
 
     //MARK: - implicitReturn

--- a/Templates/Tests/Generated/AutoCases.generated.swift
+++ b/Templates/Tests/Generated/AutoCases.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoCodable.generated.swift
+++ b/Templates/Tests/Generated/AutoCodable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all

--- a/Templates/Tests/Generated/AutoLenses.generated.swift
+++ b/Templates/Tests/Generated/AutoLenses.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable variable_name

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length
@@ -140,6 +140,37 @@ class ExtendableProtocolMock: ExtendableProtocol {
         reportMessageReceivedMessage = message
         reportMessageReceivedInvocations.append(message)
         reportMessageClosure?(message)
+    }
+
+}
+class FunctionWithClosureReturnTypeMock: FunctionWithClosureReturnType {
+
+    //MARK: - get
+
+    var getCallsCount = 0
+    var getCalled: Bool {
+        return getCallsCount > 0
+    }
+    var getReturnValue: (() -> Void)!
+    var getClosure: (() -> () -> Void)?
+
+    func get() -> () -> Void {
+        getCallsCount += 1
+        return getClosure.map({ $0() }) ?? getReturnValue
+    }
+
+    //MARK: - getOptional
+
+    var getOptionalCallsCount = 0
+    var getOptionalCalled: Bool {
+        return getOptionalCallsCount > 0
+    }
+    var getOptionalReturnValue: (() -> Void)?
+    var getOptionalClosure: (() -> () -> Void?)?
+
+    func getOptional() -> (() -> Void)? {
+        getOptionalCallsCount += 1
+        return getOptionalClosure.map({ $0() }) ?? getOptionalReturnValue
     }
 
 }

--- a/Templates/Tests/Generated/LinuxMain.generated.swift
+++ b/Templates/Tests/Generated/LinuxMain.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest


### PR DESCRIPTION
Improve AutoMockable.stencil when function's return type is closure, then wrap it with `()` brackets 