### PR TITLE
Add support for accessing all typealiases, parse global typealiases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Added support for parsing [Protocol Compositions](https://docs.swift.org/swift-book/ReferenceManual/Types.html#ID454)
 - Added support for parsing free functions
 - Added support for indirect enum cases
+- Added support for accessing all typealiases via `typealiases` and `typesaliasesByName`
+- Added support for parsing global typealiases
 
 ### Internal Changes
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -308,11 +308,11 @@ extension Sourcery {
         let uniqueTypeStart = currentTimestamp()
 
         //! All files have been scanned, time to join extensions with base class
-        let (types, functions) = Composer.uniqueTypesAndFunctions(parserResult)
+        let (types, functions, typealiases) = Composer.uniqueTypesAndFunctions(parserResult)
 
         Log.benchmark("\tcombiningTypes: \(currentTimestamp() - uniqueTypeStart)\n\ttotal: \(currentTimestamp() - startScan)")
         Log.info("Found \(types.count) types.")
-        return (Types(types: types), functions, inlineRanges)
+        return (Types(types: types, typealiases: typealiases), functions, inlineRanges)
     }
 
     private func loadOrParse(parser: FileParser, cachesPath: @autoclosure () -> Path?) throws -> FileParserResult {

--- a/SourceryRuntime/Sources/Description.generated.swift
+++ b/SourceryRuntime/Sources/Description.generated.swift
@@ -85,6 +85,7 @@ extension EnumCase {
         string += "rawValue = \(String(describing: self.rawValue)), "
         string += "associatedValues = \(String(describing: self.associatedValues)), "
         string += "annotations = \(String(describing: self.annotations)), "
+        string += "indirect = \(String(describing: self.indirect)), "
         string += "hasAssociatedValue = \(String(describing: self.hasAssociatedValue))"
         return string
     }
@@ -96,6 +97,7 @@ extension FileParserResult {
         string += "path = \(String(describing: self.path)), "
         string += "module = \(String(describing: self.module)), "
         string += "types = \(String(describing: self.types)), "
+        string += "functions = \(String(describing: self.functions)), "
         string += "typealiases = \(String(describing: self.typealiases)), "
         string += "inlineRanges = \(String(describing: self.inlineRanges)), "
         string += "inlineIndentations = \(String(describing: self.inlineIndentations)), "
@@ -205,6 +207,7 @@ extension TemplateContext {
     /// :nodoc:
     override public var description: String {
         var string = "\(Swift.type(of: self)): "
+        string += "functions = \(String(describing: self.functions)), "
         string += "types = \(String(describing: self.types)), "
         string += "argument = \(String(describing: self.argument)), "
         string += "stencilContext = \(String(describing: self.stencilContext))"
@@ -276,7 +279,8 @@ extension Types {
     /// :nodoc:
     override public var description: String {
         var string = "\(Swift.type(of: self)): "
-        string += "types = \(String(describing: self.types))"
+        string += "types = \(String(describing: self.types)), "
+        string += "typealiases = \(String(describing: self.typealiases))"
         return string
     }
 }

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -350,6 +350,7 @@ extension Types: Diffable {
             return results
         }
         results.append(contentsOf: DiffableResult(identifier: "types").trackDifference(actual: self.types, expected: castObject.types))
+        results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         return results
     }
 }

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -117,6 +117,7 @@ extension EnumCase: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "rawValue").trackDifference(actual: self.rawValue, expected: castObject.rawValue))
         results.append(contentsOf: DiffableResult(identifier: "associatedValues").trackDifference(actual: self.associatedValues, expected: castObject.associatedValues))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
+        results.append(contentsOf: DiffableResult(identifier: "indirect").trackDifference(actual: self.indirect, expected: castObject.indirect))
         return results
     }
 }
@@ -130,6 +131,7 @@ extension FileParserResult: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "path").trackDifference(actual: self.path, expected: castObject.path))
         results.append(contentsOf: DiffableResult(identifier: "module").trackDifference(actual: self.module, expected: castObject.module))
         results.append(contentsOf: DiffableResult(identifier: "types").trackDifference(actual: self.types, expected: castObject.types))
+        results.append(contentsOf: DiffableResult(identifier: "functions").trackDifference(actual: self.functions, expected: castObject.functions))
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "inlineRanges").trackDifference(actual: self.inlineRanges, expected: castObject.inlineRanges))
         results.append(contentsOf: DiffableResult(identifier: "inlineIndentations").trackDifference(actual: self.inlineIndentations, expected: castObject.inlineIndentations))
@@ -258,6 +260,7 @@ extension TemplateContext: Diffable {
             results.append("Incorrect type <expected: TemplateContext, received: \(Swift.type(of: object))>")
             return results
         }
+        results.append(contentsOf: DiffableResult(identifier: "functions").trackDifference(actual: self.functions, expected: castObject.functions))
         results.append(contentsOf: DiffableResult(identifier: "types").trackDifference(actual: self.types, expected: castObject.types))
         results.append(contentsOf: DiffableResult(identifier: "argument").trackDifference(actual: self.argument, expected: castObject.argument))
         return results

--- a/SourceryRuntime/Sources/Enum.swift
+++ b/SourceryRuntime/Sources/Enum.swift
@@ -111,7 +111,7 @@ import Foundation
             self.rawValue = aDecoder.decode(forKey: "rawValue")
             guard let associatedValues: [AssociatedValue] = aDecoder.decode(forKey: "associatedValues") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["associatedValues"])); fatalError() }; self.associatedValues = associatedValues
             guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
-            guard let indirect: Bool = aDecoder.decode(forKey: "indirect") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["indirect"])); fatalError() }; self.indirect = indirect
+            self.indirect = aDecoder.decode(forKey: "indirect")
         }
 
         /// :nodoc:

--- a/SourceryRuntime/Sources/Equality.generated.swift
+++ b/SourceryRuntime/Sources/Equality.generated.swift
@@ -108,6 +108,7 @@ extension FileParserResult {
         if self.path != rhs.path { return false }
         if self.module != rhs.module { return false }
         if self.types != rhs.types { return false }
+        if self.functions != rhs.functions { return false }
         if self.typealiases != rhs.typealiases { return false }
         if self.inlineRanges != rhs.inlineRanges { return false }
         if self.inlineIndentations != rhs.inlineIndentations { return false }
@@ -206,6 +207,7 @@ extension TemplateContext {
     /// :nodoc:
     override public func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? TemplateContext else { return false }
+        if self.functions != rhs.functions { return false }
         if self.types != rhs.types { return false }
         if self.argument != rhs.argument { return false }
         return true

--- a/SourceryRuntime/Sources/Equality.generated.swift
+++ b/SourceryRuntime/Sources/Equality.generated.swift
@@ -281,6 +281,7 @@ extension Types {
     override public func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Types else { return false }
         if self.types != rhs.types { return false }
+        if self.typealiases != rhs.typealiases { return false }
         return true
     }
 }

--- a/SourceryRuntime/Sources/JSExport.generated.swift
+++ b/SourceryRuntime/Sources/JSExport.generated.swift
@@ -151,6 +151,7 @@ extension Enum: EnumAutoJSExport {}
     var rawValue: String? { get }
     var associatedValues: [AssociatedValue] { get }
     var annotations: [String: NSObject] { get }
+    var indirect: Bool { get }
     var hasAssociatedValue: Bool { get }
 }
 
@@ -320,6 +321,7 @@ extension Struct: StructAutoJSExport {}
 extension Subscript: SubscriptAutoJSExport {}
 
 @objc protocol TemplateContextAutoJSExport: JSExport {
+    var functions: [SourceryMethod] { get }
     var types: Types { get }
     var argument: [String: NSObject] { get }
     var type: [String: Type] { get }

--- a/SourceryRuntime/Sources/TemplateContext.swift
+++ b/SourceryRuntime/Sources/TemplateContext.swift
@@ -25,15 +25,15 @@ import Foundation
 // sourcery:inline:TemplateContext.AutoCoding
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
-            guard let types: Types = aDecoder.decode(forKey: "types") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["types"])); fatalError() }; self.types = types
             guard let functions: [SourceryMethod] = aDecoder.decode(forKey: "functions") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["functions"])); fatalError() }; self.functions = functions
+            guard let types: Types = aDecoder.decode(forKey: "types") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["types"])); fatalError() }; self.types = types
             guard let argument: [String: NSObject] = aDecoder.decode(forKey: "argument") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["argument"])); fatalError() }; self.argument = argument
         }
 
         /// :nodoc:
         public func encode(with aCoder: NSCoder) {
-            aCoder.encode(self.types, forKey: "types")
             aCoder.encode(self.functions, forKey: "functions")
+            aCoder.encode(self.types, forKey: "types")
             aCoder.encode(self.argument, forKey: "argument")
         }
 // sourcery:end
@@ -84,19 +84,25 @@ extension ProcessInfo {
     public let types: [Type]
 
     /// :nodoc:
-    public init(types: [Type]) {
+    public let typealiases: [Typealias]
+
+    /// :nodoc:
+    public init(types: [Type], typealiases: [Typealias] = []) {
         self.types = types
+        self.typealiases = typealiases
     }
 
 // sourcery:inline:Types.AutoCoding
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
             guard let types: [Type] = aDecoder.decode(forKey: "types") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["types"])); fatalError() }; self.types = types
+            guard let typealiases: [Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
         }
 
         /// :nodoc:
         public func encode(with aCoder: NSCoder) {
             aCoder.encode(self.types, forKey: "types")
+            aCoder.encode(self.typealiases, forKey: "typealiases")
         }
 // sourcery:end
 
@@ -106,6 +112,14 @@ extension ProcessInfo {
         var typesByName = [String: Type]()
         self.types.forEach { typesByName[$0.name] = $0 }
         return typesByName
+    }()
+
+    // sourcery: skipDescription, skipEquality, skipCoding
+    /// :nodoc:
+    public lazy internal(set) var typesaliasesByName: [String: Typealias] = {
+        var typesaliasesByName = [String: Typealias]()
+        self.typealiases.forEach { typesaliasesByName[$0.name] = $0 }
+        return typesaliasesByName
     }()
 
     // sourcery: skipDescription, skipEquality, skipCoding

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -1087,6 +1087,7 @@ extension Types: Diffable {
             return results
         }
         results.append(contentsOf: DiffableResult(identifier: "types").trackDifference(actual: self.types, expected: castObject.types))
+        results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         return results
     }
 }
@@ -1431,7 +1432,7 @@ import Foundation
             self.rawValue = aDecoder.decode(forKey: "rawValue")
             guard let associatedValues: [AssociatedValue] = aDecoder.decode(forKey: "associatedValues") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["associatedValues"])); fatalError() }; self.associatedValues = associatedValues
             guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
-            guard let indirect: Bool = aDecoder.decode(forKey: "indirect") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["indirect"])); fatalError() }; self.indirect = indirect
+            self.indirect = aDecoder.decode(forKey: "indirect")
         }
 
         /// :nodoc:
@@ -1827,6 +1828,7 @@ extension Types {
     override public func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Types else { return false }
         if self.types != rhs.types { return false }
+        if self.typealiases != rhs.typealiases { return false }
         return true
     }
 }
@@ -3320,15 +3322,15 @@ import Foundation
 // sourcery:inline:TemplateContext.AutoCoding
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
-            guard let types: Types = aDecoder.decode(forKey: "types") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["types"])); fatalError() }; self.types = types
             guard let functions: [SourceryMethod] = aDecoder.decode(forKey: "functions") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["functions"])); fatalError() }; self.functions = functions
+            guard let types: Types = aDecoder.decode(forKey: "types") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["types"])); fatalError() }; self.types = types
             guard let argument: [String: NSObject] = aDecoder.decode(forKey: "argument") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["argument"])); fatalError() }; self.argument = argument
         }
 
         /// :nodoc:
         public func encode(with aCoder: NSCoder) {
-            aCoder.encode(self.types, forKey: "types")
             aCoder.encode(self.functions, forKey: "functions")
+            aCoder.encode(self.types, forKey: "types")
             aCoder.encode(self.argument, forKey: "argument")
         }
 // sourcery:end
@@ -3379,19 +3381,25 @@ extension ProcessInfo {
     public let types: [Type]
 
     /// :nodoc:
-    public init(types: [Type]) {
+    public let typealiases: [Typealias]
+
+    /// :nodoc:
+    public init(types: [Type], typealiases: [Typealias] = []) {
         self.types = types
+        self.typealiases = typealiases
     }
 
 // sourcery:inline:Types.AutoCoding
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
             guard let types: [Type] = aDecoder.decode(forKey: "types") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["types"])); fatalError() }; self.types = types
+            guard let typealiases: [Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
         }
 
         /// :nodoc:
         public func encode(with aCoder: NSCoder) {
             aCoder.encode(self.types, forKey: "types")
+            aCoder.encode(self.typealiases, forKey: "typealiases")
         }
 // sourcery:end
 
@@ -3401,6 +3409,14 @@ extension ProcessInfo {
         var typesByName = [String: Type]()
         self.types.forEach { typesByName[$0.name] = $0 }
         return typesByName
+    }()
+
+    // sourcery: skipDescription, skipEquality, skipCoding
+    /// :nodoc:
+    public lazy internal(set) var typesaliasesByName: [String: Typealias] = {
+        var typesaliasesByName = [String: Typealias]()
+        self.typealiases.forEach { typesaliasesByName[$0.name] = $0 }
+        return typesaliasesByName
     }()
 
     // sourcery: skipDescription, skipEquality, skipCoding

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -515,6 +515,7 @@ extension EnumCase {
         string += "rawValue = \\(String(describing: self.rawValue)), "
         string += "associatedValues = \\(String(describing: self.associatedValues)), "
         string += "annotations = \\(String(describing: self.annotations)), "
+        string += "indirect = \\(String(describing: self.indirect)), "
         string += "hasAssociatedValue = \\(String(describing: self.hasAssociatedValue))"
         return string
     }
@@ -526,6 +527,7 @@ extension FileParserResult {
         string += "path = \\(String(describing: self.path)), "
         string += "module = \\(String(describing: self.module)), "
         string += "types = \\(String(describing: self.types)), "
+        string += "functions = \\(String(describing: self.functions)), "
         string += "typealiases = \\(String(describing: self.typealiases)), "
         string += "inlineRanges = \\(String(describing: self.inlineRanges)), "
         string += "inlineIndentations = \\(String(describing: self.inlineIndentations)), "
@@ -635,6 +637,7 @@ extension TemplateContext {
     /// :nodoc:
     override public var description: String {
         var string = "\\(Swift.type(of: self)): "
+        string += "functions = \\(String(describing: self.functions)), "
         string += "types = \\(String(describing: self.types)), "
         string += "argument = \\(String(describing: self.argument)), "
         string += "stencilContext = \\(String(describing: self.stencilContext))"
@@ -706,7 +709,8 @@ extension Types {
     /// :nodoc:
     override public var description: String {
         var string = "\\(Swift.type(of: self)): "
-        string += "types = \\(String(describing: self.types))"
+        string += "types = \\(String(describing: self.types)), "
+        string += "typealiases = \\(String(describing: self.typealiases))"
         return string
     }
 }
@@ -854,6 +858,7 @@ extension EnumCase: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "rawValue").trackDifference(actual: self.rawValue, expected: castObject.rawValue))
         results.append(contentsOf: DiffableResult(identifier: "associatedValues").trackDifference(actual: self.associatedValues, expected: castObject.associatedValues))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
+        results.append(contentsOf: DiffableResult(identifier: "indirect").trackDifference(actual: self.indirect, expected: castObject.indirect))
         return results
     }
 }
@@ -867,6 +872,7 @@ extension FileParserResult: Diffable {
         results.append(contentsOf: DiffableResult(identifier: "path").trackDifference(actual: self.path, expected: castObject.path))
         results.append(contentsOf: DiffableResult(identifier: "module").trackDifference(actual: self.module, expected: castObject.module))
         results.append(contentsOf: DiffableResult(identifier: "types").trackDifference(actual: self.types, expected: castObject.types))
+        results.append(contentsOf: DiffableResult(identifier: "functions").trackDifference(actual: self.functions, expected: castObject.functions))
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "inlineRanges").trackDifference(actual: self.inlineRanges, expected: castObject.inlineRanges))
         results.append(contentsOf: DiffableResult(identifier: "inlineIndentations").trackDifference(actual: self.inlineIndentations, expected: castObject.inlineIndentations))
@@ -995,6 +1001,7 @@ extension TemplateContext: Diffable {
             results.append("Incorrect type <expected: TemplateContext, received: \\(Swift.type(of: object))>")
             return results
         }
+        results.append(contentsOf: DiffableResult(identifier: "functions").trackDifference(actual: self.functions, expected: castObject.functions))
         results.append(contentsOf: DiffableResult(identifier: "types").trackDifference(actual: self.types, expected: castObject.types))
         results.append(contentsOf: DiffableResult(identifier: "argument").trackDifference(actual: self.argument, expected: castObject.argument))
         return results
@@ -1655,6 +1662,7 @@ extension FileParserResult {
         if self.path != rhs.path { return false }
         if self.module != rhs.module { return false }
         if self.types != rhs.types { return false }
+        if self.functions != rhs.functions { return false }
         if self.typealiases != rhs.typealiases { return false }
         if self.inlineRanges != rhs.inlineRanges { return false }
         if self.inlineIndentations != rhs.inlineIndentations { return false }
@@ -1753,6 +1761,7 @@ extension TemplateContext {
     /// :nodoc:
     override public func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? TemplateContext else { return false }
+        if self.functions != rhs.functions { return false }
         if self.types != rhs.types { return false }
         if self.argument != rhs.argument { return false }
         return true
@@ -2271,6 +2280,7 @@ extension Enum: EnumAutoJSExport {}
     var rawValue: String? { get }
     var associatedValues: [AssociatedValue] { get }
     var annotations: [String: NSObject] { get }
+    var indirect: Bool { get }
     var hasAssociatedValue: Bool { get }
 }
 
@@ -2440,6 +2450,7 @@ extension Struct: StructAutoJSExport {}
 extension Subscript: SubscriptAutoJSExport {}
 
 @objc protocol TemplateContextAutoJSExport: JSExport {
+    var functions: [SourceryMethod] { get }
     var types: Types { get }
     var argument: [String: NSObject] { get }
     var type: [String: Type] { get }

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -153,7 +153,7 @@ class SwiftTemplateTests: QuickSpec {
                     try Generator.generate(Types(types: []), functions: [], template: SwiftTemplate(path: templatePath))
                     }
                     .to(throwError(closure: { (error) in
-                        expect("\(error)").to(contain("\(templatePath): Fatal error: Index out of range\n"))
+                        expect("\(error)").to(contain("\(templatePath): Fatal error: Index out of range"))
                     }))
             }
 

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -81,7 +81,7 @@ class GeneratorSpec: QuickSpec {
 
             func generate(_ template: String) -> String {
                 beforeEachGenerate()
-                let (uniqueTypes, _) = Composer.uniqueTypesAndFunctions(FileParserResult(path: nil, module: nil, types: types, functions: [], typealiases: []))
+                let (uniqueTypes, _, _) = Composer.uniqueTypesAndFunctions(FileParserResult(path: nil, module: nil, types: types, functions: [], typealiases: []))
 
                 return (try? Generator.generate(Types(types: uniqueTypes), functions: [],
                         template: StencilTemplate(templateString: template),

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -871,8 +871,6 @@ class ParserComposerSpec: QuickSpec {
                             let type = parse("class Bar { typealias FooAlias = Foo; var foo: FooAlias }; class Foo {}").first
                             let variable = type?.variables.first
 
-                            let typealiases = parseTypealiases("class Bar { typealias FooAlias = Foo; var foo: FooAlias }; class Foo {}")
-
                             expect(variable).to(equal(expectedVariable))
                             expect(variable?.actualTypeName).to(equal(expectedVariable.actualTypeName))
                             expect(variable?.type).to(equal(expectedVariable.type))
@@ -900,12 +898,25 @@ class ParserComposerSpec: QuickSpec {
                             expect(variable?.type).to(equal(expectedVariable.type))
                         }
 
-                        it("extracts typealiases") {
+                        it("populates the local collection of typealiases") {
+                            let expectedType = Class(name: "Foo")
                             let expectedParent = Class(name: "Bar")
-                            expect(parseTypealiases("class Bar { typealias FooAlias = Foo; var foo: FooAlias }; class Foo {}"))
-                                .to(contain([
-                                    Typealias(aliasName: "FooAlias", typeName: TypeName("Foo"), parent: expectedParent)
-                                ]))
+                            let type = parse("class Bar { typealias FooAlias = Foo }; class Foo {}").first
+                            let aliases = type?.typealiases
+
+                            expect(aliases).to(haveCount(1))
+                            expect(aliases?["FooAlias"]).to(equal(Typealias(aliasName: "FooAlias", typeName: TypeName("Foo"), parent: expectedParent)))
+                            expect(aliases?["FooAlias"]?.type).to(equal(expectedType))
+                        }
+
+                        it("populates the global collection of typealiases") {
+                            let expectedType = Class(name: "Foo")
+                            let expectedParent = Class(name: "Bar")
+                            let aliases = parseTypealiases("class Bar { typealias FooAlias = Foo }; class Foo {}")
+
+                            expect(aliases).to(haveCount(1))
+                            expect(aliases.first).to(equal(Typealias(aliasName: "FooAlias", typeName: TypeName("Foo"), parent: expectedParent)))
+                            expect(aliases.first?.type).to(equal(expectedType))
                         }
                     }
 

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -20,7 +20,7 @@ class ParserComposerSpec: QuickSpec {
     // swiftlint:disable function_body_length
     override func spec() {
         describe("ParserComposer") {
-            describe("uniqueType") {
+            describe("uniqueTypesAndFunctions") {
                 func parse(_ code: String) -> [Type] {
                     guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
                     return Composer.uniqueTypesAndFunctions(parserResult).types
@@ -509,6 +509,10 @@ class ParserComposerSpec: QuickSpec {
                 }
 
                 context("given typealiases") {
+                    func parseTypealiases(_ code: String) -> [Typealias] {
+                        guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
+                        return Composer.uniqueTypesAndFunctions(parserResult).typealiases
+                    }
 
                     it("resolves definedInType for methods") {
                         let input = "class Foo { func bar() {} }; typealias FooAlias = Foo; extension FooAlias { func baz() {} }"
@@ -867,6 +871,8 @@ class ParserComposerSpec: QuickSpec {
                             let type = parse("class Bar { typealias FooAlias = Foo; var foo: FooAlias }; class Foo {}").first
                             let variable = type?.variables.first
 
+                            let typealiases = parseTypealiases("class Bar { typealias FooAlias = Foo; var foo: FooAlias }; class Foo {}")
+
                             expect(variable).to(equal(expectedVariable))
                             expect(variable?.actualTypeName).to(equal(expectedVariable.actualTypeName))
                             expect(variable?.type).to(equal(expectedVariable.type))
@@ -892,6 +898,42 @@ class ParserComposerSpec: QuickSpec {
                             expect(variable).to(equal(expectedVariable))
                             expect(variable?.actualTypeName).to(equal(expectedVariable.actualTypeName))
                             expect(variable?.type).to(equal(expectedVariable.type))
+                        }
+
+                        it("extracts typealiases") {
+                            let expectedParent = Class(name: "Bar")
+                            expect(parseTypealiases("class Bar { typealias FooAlias = Foo; var foo: FooAlias }; class Foo {}"))
+                                .to(contain([
+                                    Typealias(aliasName: "FooAlias", typeName: TypeName("Foo"), parent: expectedParent)
+                                ]))
+                        }
+                    }
+
+                    context("given global typealias") {
+                        it("extracts typealiases of other typealiases") {
+                            expect(parseTypealiases("typealias Foo = Int; typealias Bar = Foo"))
+                                .to(contain([
+                                    Typealias(aliasName: "Foo", typeName: TypeName("Int")),
+                                    Typealias(aliasName: "Bar", typeName: TypeName("Foo"))
+                                ]))
+                        }
+
+                        it("extracts typealiases of other typealiases of a type") {
+                            expect(parseTypealiases("typealias Foo = Baz; typealias Bar = Foo; class Baz {}"))
+                                .to(contain([
+                                    Typealias(aliasName: "Foo", typeName: TypeName("Baz")),
+                                    Typealias(aliasName: "Bar", typeName: TypeName("Foo"))
+                                ]))
+                        }
+
+                        it("resolves types transitively") {
+                            let expectedType = Class(name: "Baz")
+
+                            let typealiases = parseTypealiases("typealias Foo = Bar; typealias Bar = Baz; class Baz {}")
+
+                            expect(typealiases).to(haveCount(2))
+                            expect(typealiases.first?.type).to(equal(expectedType))
+                            expect(typealiases.last?.type).to(equal(expectedType))
                         }
                     }
                 }

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -215,7 +215,6 @@ class FileParserSpec: QuickSpec {
                                     Typealias(aliasName: "GlobalAlias", typeName: TypeName("() -> ()"))
                                     ]))
                         }
-
                     }
 
                     context("given local typealias") {


### PR DESCRIPTION
Supports accessing all typealiases from `TemplateContext`, including both global and local typealiases as well as typealiases that point at other typealiases.

Added to `TemplateContext` as both `typesaliasesByName` and `typealiases`.

Fixes #765
Fixes #235