### PR TITLE
Fixed missing SourceryRuntime dependency of SourceryFramework (SPM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed a bug in inferring extensions of Dictionary and Array types
 - Fixed a bug that was including default values as part of AssociatedValues type names
 - Fixed an issue with AutoMockable.stencil template when mocked function's return type was closure
+- Fixed missing SourceryRuntime dependency of SourceryFramework (SPM)
 
 ## 0.17.0
 

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,8 @@ let package = Package(
         .target(name: "SourceryFramework", dependencies: [
           "PathKit",
           "SourceKittenFramework",
-          "SourceryUtils"
+          "SourceryUtils",
+          "SourceryRuntime"
         ]),
         .target(name: "SourceryJS", dependencies: [
           "PathKit"


### PR DESCRIPTION
I was not able to use SourceryFramework 0.17.0 in my custom tool, because XCode was complaining about missing SourceryRuntime module in some of the SourceryFramework source file. Changes in this PR fixed the issue.