### PR TITLE
public extension Decodable

### DIFF
--- a/Pods/xcproj/Sources/xcproj/Decodable+Dictionary.swift
+++ b/Pods/xcproj/Sources/xcproj/Decodable+Dictionary.swift
@@ -2,13 +2,13 @@ import Foundation
 
 // MARK: - Decodable Extension
 
-extension Decodable {
+public extension Decodable {
 
     /// Initialies the Decodable object with a JSON dictionary.
     ///
     /// - Parameter jsonDictionary: json dictionary.
     /// - Throws: throws an error if the initialization fails.
-    init(jsonDictionary: [String: Any]) throws {
+    init(jsonDictionary: [AnyHashable: Any]) throws {
         let decoder = JSONDecoder()
         let data = try JSONSerialization.data(withJSONObject: jsonDictionary, options: [])
         self = try decoder.decode(Self.self, from: data)


### PR DESCRIPTION
Hello.
Thank you for Sourcery.
In this pull request I made `Decodable.init(jsonDictionary:)` `public` and changed the first argument's type from `[String:Any]` to `[AnyHashable:Any]` to make it more flexible.