### PR TITLE
Fixes isValidClosureName to handle generic types correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Disallow protocol compositions from being considered as the `rawType` of an `enum` (#830)
 - Add missing documentation for the `ProtocolComposition` type.
 - Fix incorrectly taking closure optional return value as sign that whole variable is optional (#823) 
+- Fix incorrectly taking return values with closure as generic type as sign that whole variable is a closure (#845)
 
 ## 0.18.0
 

--- a/SourceryRuntime/Sources/Extensions.swift
+++ b/SourceryRuntime/Sources/Extensions.swift
@@ -96,7 +96,7 @@ public extension String {
 
     /// :nodoc:
     func isValidClosureName() -> Bool {
-        return components(separatedBy: "->", excludingDelimiterBetween: ("(", ")")).count > 1
+        return components(separatedBy: "->", excludingDelimiterBetween: (["(", "<"], [")", ">"])).count > 1
     }
 
     /// :nodoc:

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -1967,7 +1967,7 @@ public extension String {
 
     /// :nodoc:
     func isValidClosureName() -> Bool {
-        return components(separatedBy: "->", excludingDelimiterBetween: ("(", ")")).count > 1
+        return components(separatedBy: "->", excludingDelimiterBetween: (["(", "<"], [")", ">"])).count > 1
     }
 
     /// :nodoc:

--- a/SourceryTests/Models/TypeNameSpec.swift
+++ b/SourceryTests/Models/TypeNameSpec.swift
@@ -113,7 +113,7 @@ class TypeNameSpec: QuickSpec {
                     expect(TypeName("((Int) -> (Int)) -> ()").isClosure).to(beTrue())
                     expect(TypeName("(Foo<String>) -> Bool)").isClosure).to(beTrue())
                     expect(TypeName("(Int) -> Foo<Bool>").isClosure).to(beTrue())
-                    expect(TypeName("(Foo<String>) -> Foo<Bool>)").isClosure).to(beTrue())
+                    expect(TypeName("(Foo<String>) -> Foo<Bool>").isClosure).to(beTrue())
                     expect(TypeName("((Int, Int) -> (), Int)").isClosure).to(beFalse())
                 }
 
@@ -138,8 +138,8 @@ class TypeNameSpec: QuickSpec {
                     expect(TypeName("Foo<() -> ()>").isClosure).to(beFalse())
                     expect(TypeName("Foo<(String) -> Bool>").isClosure).to(beFalse())
                     expect(TypeName("Foo<(String) -> Bool?>").isClosure).to(beFalse())
-                    expect(TypeName("Foo<(Bar<String>) -> Bool)>").isClosure).to(beFalse())
-                    expect(TypeName("Foo<(Bar<String>) -> Bar<Bool>)>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(Bar<String>) -> Bool>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(Bar<String>) -> Bar<Bool>>").isClosure).to(beFalse())
                 }
             }
 

--- a/SourceryTests/Models/TypeNameSpec.swift
+++ b/SourceryTests/Models/TypeNameSpec.swift
@@ -111,6 +111,9 @@ class TypeNameSpec: QuickSpec {
                     expect(TypeName("() -> (Int, Int)").isClosure).to(beTrue())
                     expect(TypeName("() -> (Int) -> (Int)").isClosure).to(beTrue())
                     expect(TypeName("((Int) -> (Int)) -> ()").isClosure).to(beTrue())
+                    expect(TypeName("(Foo<String>) -> Bool)").isClosure).to(beTrue())
+                    expect(TypeName("(Int) -> Foo<Bool>").isClosure).to(beTrue())
+                    expect(TypeName("(Foo<String>) -> Foo<Bool>)").isClosure).to(beTrue())
                     expect(TypeName("((Int, Int) -> (), Int)").isClosure).to(beFalse())
                 }
 
@@ -127,6 +130,16 @@ class TypeNameSpec: QuickSpec {
                     expect(TypeName("(() -> ())!").isImplicitlyUnwrappedOptional).to(beTrue())
                     expect(TypeName("Optional<() -> ()>").isOptional).to(beTrue())
                     expect(TypeName("ImplicitlyUnwrappedOptional<() -> ()>").isImplicitlyUnwrappedOptional).to(beTrue())
+                }
+            }
+
+            context("given closure type inside generic type") {
+                it("reports closure correctly") {
+                    expect(TypeName("Foo<() -> ()>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(String) -> Bool>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(String) -> Bool?>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(Bar<String>) -> Bool)>").isClosure).to(beFalse())
+                    expect(TypeName("Foo<(Bar<String>) -> Bar<Bool>)>").isClosure).to(beFalse())
                 }
             }
 


### PR DESCRIPTION
Fixes krzysztofzablocki/Sourcery#844