### PR TITLE
Adds support for associated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ---
 ## Master
 
+### New Features
+
+- Added support for associated types (#539)
+
 ### Bug fixes
 
 - Disallow protocol compositions from being considered as the `rawType` of an `enum` (#830)

--- a/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery.xcodeproj/project.pbxproj
@@ -128,6 +128,8 @@
 		E291DE1CB3B72BAA22DEDEDA /* StencilTemplateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291D0D4A5AF091CD15550FD /* StencilTemplateSpec.swift */; };
 		E291DF22F03C87C646576942 /* AnnotationsParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291DCF0A8E779EC67C9A37E /* AnnotationsParserSpec.swift */; };
 		E43A7434D25A759BA0658051 /* Pods_SourceryUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC54F603FD22AD275A3E7B3F /* Pods_SourceryUtils.framework */; };
+		F63E56CE24BCB13700715CD1 /* AssociatedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63E56CD24BCB13700715CD1 /* AssociatedType.swift */; };
+		F63E602824BCF57E00715CD1 /* FileParser + AssociatedTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63E602724BCF57E00715CD1 /* FileParser + AssociatedTypeSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -356,6 +358,8 @@
 		E291DFE1A3D6905537EE86D9 /* ComposerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposerSpec.swift; sourceTree = "<group>"; };
 		F1A3DAD7FDF3830E52EF0509 /* Pods-SourceryFramework.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SourceryFramework.release.xcconfig"; path = "Target Support Files/Pods-SourceryFramework/Pods-SourceryFramework.release.xcconfig"; sourceTree = "<group>"; };
 		F3C3A7B6CE0BCA036E0835CE /* Pods-Sourcery.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sourcery.release.xcconfig"; path = "Target Support Files/Pods-Sourcery/Pods-Sourcery.release.xcconfig"; sourceTree = "<group>"; };
+		F63E56CD24BCB13700715CD1 /* AssociatedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssociatedType.swift; path = SourceryRuntime/Sources/AssociatedType.swift; sourceTree = SOURCE_ROOT; };
+		F63E602724BCF57E00715CD1 /* FileParser + AssociatedTypeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileParser + AssociatedTypeSpec.swift"; sourceTree = "<group>"; };
 		F81A4FAFF66C386F53742B5F /* Pods_SourcerySwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SourcerySwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF69E64877680ED87A0520E5 /* Pods-SourceryJS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SourceryJS.release.xcconfig"; path = "Target Support Files/Pods-SourceryJS/Pods-SourceryJS.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -496,6 +500,7 @@
 			children = (
 				09334E621EB916040092806F /* AccessLevel.swift */,
 				09334E631EB916040092806F /* Annotations.swift */,
+				F63E56CD24BCB13700715CD1 /* AssociatedType.swift */,
 				524A2EA61FFD3C40001CD8F9 /* BytesRange.swift */,
 				6D31FC5E1F0C2DE4000E77E3 /* Definition.swift */,
 				09334E641EB916040092806F /* Attribute.swift */,
@@ -793,6 +798,7 @@
 				E291DD46F8BC3AA0E7E5FB4D /* FileParserSpec.swift */,
 				E291DCF0A8E779EC67C9A37E /* AnnotationsParserSpec.swift */,
 				E291D37EF6AA39833209828F /* FileParser + VariableSpec.swift */,
+				F63E602724BCF57E00715CD1 /* FileParser + AssociatedTypeSpec.swift */,
 				098442721E21BF850051E1A1 /* FileParser + AttributesSpec.swift */,
 				E291DC650271984B35942FE4 /* TemplateAnnotationsParserSpec.swift */,
 				0906124C1E2BC43500BA0937 /* FileParser + MethodsSpec.swift */,
@@ -1575,6 +1581,7 @@
 				09334E7B1EB916040092806F /* Protocol.swift in Sources */,
 				09334E5D1EB915E00092806F /* Diffable.generated.swift in Sources */,
 				A65B189D23F3F05D0023F4A9 /* ProtocolComposition.swift in Sources */,
+				F63E56CE24BCB13700715CD1 /* AssociatedType.swift in Sources */,
 				09334E5F1EB915E00092806F /* JSExport.generated.swift in Sources */,
 				09334E601EB915E00092806F /* Typed.generated.swift in Sources */,
 				09334E7E1EB916040092806F /* Type.swift in Sources */,
@@ -1625,6 +1632,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09B1DD3F1E21ADD8009228EE /* GeneratorSpec.swift in Sources */,
+				F63E602824BCF57E00715CD1 /* FileParser + AssociatedTypeSpec.swift in Sources */,
 				0967DA611E0341400084F702 /* ProtocolSpec.swift in Sources */,
 				CDF5E71D1E671B8500664763 /* TypedSpec.generated.swift in Sources */,
 				CDE812ED1E1127FF00F1FF97 /* Sourcery+PerformanceSpec.swift in Sources */,

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -101,6 +101,10 @@ public struct Composer {
             if let composition = type as? ProtocolComposition {
                 resolveProtocolCompositionTypes(composition, resolve: resolveType)
             }
+
+            if let sourceryProtocol = type as? SourceryProtocol {
+                resolveAssociatedTypes(sourceryProtocol, resolve: resolveType)
+            }
         }
 
         DispatchQueue.concurrentPerform(iterations: functions.count) { (counter) in
@@ -263,6 +267,15 @@ public struct Composer {
         }
 
         protocolComposition.composedTypes = composedTypes
+    }
+
+    private static func resolveAssociatedTypes(_ sourceryProtocol: SourceryProtocol, resolve: TypeResolver) {
+        sourceryProtocol.associatedTypes.forEach { (_, value) in
+            guard let typeName = value.typeName,
+                let type = resolve(typeName, sourceryProtocol)
+                else { return }
+            value.type = type
+        }
     }
 
     /// returns typealiases map to their full names, with `resolved` removing intermediate

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -744,7 +744,8 @@ extension FileParser {
                 .trimmingCharacters(in: CharacterSet.init(charactersIn: "=").union(.whitespacesAndNewlines))
             else { return nil }
 
-        if let composedTypeNames = extractComposedTypeNames(from: nameSuffix), composedTypeNames.count > 1 {
+        let trimmingCharacterSet = CharacterSet(charactersIn: "=")
+        if let composedTypeNames = extractComposedTypeNames(from: nameSuffix, trimmingCharacterSet: trimmingCharacterSet), composedTypeNames.count > 1 {
             let inheritedTypes = composedTypeNames.map { $0.name }
             return .protocolComposition(ProtocolComposition(name: name, parent: containingType, inheritedTypes: inheritedTypes, composedTypeNames: composedTypeNames))
         }
@@ -914,12 +915,17 @@ extension FileParser {
         }
     }
 
-    private func extractComposedTypeNames(from value: String) -> [TypeName]? {
+    private func extractComposedTypeNames(from value: String, trimmingCharacterSet: CharacterSet? = nil) -> [TypeName]? {
         guard case let components = value.components(separatedBy: CharacterSet(charactersIn: "&")),
             components.count > 1 else { return nil }
 
+        var characterSet: CharacterSet = .whitespacesAndNewlines
+        if let trimmingCharacterSet = trimmingCharacterSet {
+            characterSet = characterSet.union(trimmingCharacterSet)
+        }
+
         let suffixes = components.map { source in
-            source.trimmingCharacters(in: CharacterSet(charactersIn: "=").union(.whitespacesAndNewlines))
+            source.trimmingCharacters(in: characterSet)
         }
         return suffixes.map(TypeName.init(_:))
     }

--- a/SourceryRuntime/Sources/AssociatedType.swift
+++ b/SourceryRuntime/Sources/AssociatedType.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Describes Swift AssociatedType
+@objcMembers public final class AssociatedType: NSObject, SourceryModel {
+    /// associatedType name
+    public let name: String
+
+    /// associatedType type constraint name, if specified
+    public let typeName: TypeName?
+
+    // sourcery: skipEquality, skipDescription
+    /// associatedType constrained type, if known, i.e. if the type is declared in the scanned sources.
+    public var type: Type?
+
+    public init(name: String, typeName: TypeName? = nil, type: Type? = nil) {
+        self.name = name
+        self.typeName = typeName
+        self.type = type
+    }
+
+// sourcery:inline:AssociatedType.AutoCoding
+        /// :nodoc:
+        required public init?(coder aDecoder: NSCoder) {
+            guard let name: String = aDecoder.decode(forKey: "name") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["name"])); fatalError() }; self.name = name
+            self.typeName = aDecoder.decode(forKey: "typeName")
+            self.type = aDecoder.decode(forKey: "type")
+        }
+
+        /// :nodoc:
+        public func encode(with aCoder: NSCoder) {
+            aCoder.encode(self.name, forKey: "name")
+            aCoder.encode(self.typeName, forKey: "typeName")
+            aCoder.encode(self.type, forKey: "type")
+        }
+// sourcery:end
+}

--- a/SourceryRuntime/Sources/AssociatedType.swift
+++ b/SourceryRuntime/Sources/AssociatedType.swift
@@ -12,6 +12,7 @@ import Foundation
     /// associatedType constrained type, if known, i.e. if the type is declared in the scanned sources.
     public var type: Type?
 
+    /// :nodoc:
     public init(name: String, typeName: TypeName? = nil, type: Type? = nil) {
         self.name = name
         self.typeName = typeName

--- a/SourceryRuntime/Sources/AssociatedType.swift
+++ b/SourceryRuntime/Sources/AssociatedType.swift
@@ -2,14 +2,14 @@ import Foundation
 
 /// Describes Swift AssociatedType
 @objcMembers public final class AssociatedType: NSObject, SourceryModel {
-    /// associatedType name
+    /// Associated type name
     public let name: String
 
-    /// associatedType type constraint name, if specified
+    /// Associated type type constraint name, if specified
     public let typeName: TypeName?
 
     // sourcery: skipEquality, skipDescription
-    /// associatedType constrained type, if known, i.e. if the type is declared in the scanned sources.
+    /// Associated type constrained type, if known, i.e. if the type is declared in the scanned sources.
     public var type: Type?
 
     /// :nodoc:

--- a/SourceryRuntime/Sources/Coding.generated.swift
+++ b/SourceryRuntime/Sources/Coding.generated.swift
@@ -44,6 +44,8 @@ extension NSCoder {
 
 extension ArrayType: NSCoding {}
 
+extension AssociatedType: NSCoding {}
+
 extension AssociatedValue: NSCoding {}
 
 extension Attribute: NSCoding {}

--- a/SourceryRuntime/Sources/Description.generated.swift
+++ b/SourceryRuntime/Sources/Description.generated.swift
@@ -13,6 +13,15 @@ extension ArrayType {
         return string
     }
 }
+extension AssociatedType {
+    /// :nodoc:
+    override public var description: String {
+        var string = "\(Swift.type(of: self)): "
+        string += "name = \(String(describing: self.name)), "
+        string += "typeName = \(String(describing: self.typeName))"
+        return string
+    }
+}
 extension AssociatedValue {
     /// :nodoc:
     override public var description: String {
@@ -162,7 +171,8 @@ extension Protocol {
     override public var description: String {
         var string = super.description
         string += ", "
-        string += "kind = \(String(describing: self.kind))"
+        string += "kind = \(String(describing: self.kind)), "
+        string += "associatedTypes = \(String(describing: self.associatedTypes))"
         return string
     }
 }
@@ -237,6 +247,7 @@ extension Type {
     override public var description: String {
         var string = "\(Swift.type(of: self)): "
         string += "module = \(String(describing: self.module)), "
+        string += "imports = \(String(describing: self.imports)), "
         string += "typealiases = \(String(describing: self.typealiases)), "
         string += "isExtension = \(String(describing: self.isExtension)), "
         string += "kind = \(String(describing: self.kind)), "

--- a/SourceryRuntime/Sources/Diffable.generated.swift
+++ b/SourceryRuntime/Sources/Diffable.generated.swift
@@ -15,6 +15,18 @@ extension ArrayType: Diffable {
         return results
     }
 }
+extension AssociatedType: Diffable {
+    @objc func diffAgainst(_ object: Any?) -> DiffableResult {
+        let results = DiffableResult()
+        guard let castObject = object as? AssociatedType else {
+            results.append("Incorrect type <expected: AssociatedType, received: \(Swift.type(of: object))>")
+            return results
+        }
+        results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: castObject.name))
+        results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
+        return results
+    }
+}
 extension AssociatedValue: Diffable {
     @objc func diffAgainst(_ object: Any?) -> DiffableResult {
         let results = DiffableResult()
@@ -209,6 +221,7 @@ extension Protocol {
             results.append("Incorrect type <expected: Protocol, received: \(Swift.type(of: object))>")
             return results
         }
+        results.append(contentsOf: DiffableResult(identifier: "associatedTypes").trackDifference(actual: self.associatedTypes, expected: castObject.associatedTypes))
         results.append(contentsOf: super.diffAgainst(castObject))
         return results
     }
@@ -298,6 +311,7 @@ extension Type: Diffable {
             return results
         }
         results.append(contentsOf: DiffableResult(identifier: "module").trackDifference(actual: self.module, expected: castObject.module))
+        results.append(contentsOf: DiffableResult(identifier: "imports").trackDifference(actual: self.imports, expected: castObject.imports))
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "isExtension").trackDifference(actual: self.isExtension, expected: castObject.isExtension))
         results.append(contentsOf: DiffableResult(identifier: "accessLevel").trackDifference(actual: self.accessLevel, expected: castObject.accessLevel))

--- a/SourceryRuntime/Sources/Equality.generated.swift
+++ b/SourceryRuntime/Sources/Equality.generated.swift
@@ -13,6 +13,15 @@ extension ArrayType {
         return true
     }
 }
+extension AssociatedType {
+    /// :nodoc:
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? AssociatedType else { return false }
+        if self.name != rhs.name { return false }
+        if self.typeName != rhs.typeName { return false }
+        return true
+    }
+}
 extension AssociatedValue {
     /// :nodoc:
     override public func isEqual(_ object: Any?) -> Bool {
@@ -171,6 +180,7 @@ extension Protocol {
     /// :nodoc:
     override public func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Protocol else { return false }
+        if self.associatedTypes != rhs.associatedTypes { return false }
         return super.isEqual(rhs)
     }
 }
@@ -236,6 +246,7 @@ extension Type {
     override public func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Type else { return false }
         if self.module != rhs.module { return false }
+        if self.imports != rhs.imports { return false }
         if self.typealiases != rhs.typealiases { return false }
         if self.isExtension != rhs.isExtension { return false }
         if self.accessLevel != rhs.accessLevel { return false }

--- a/SourceryRuntime/Sources/JSExport.generated.swift
+++ b/SourceryRuntime/Sources/JSExport.generated.swift
@@ -13,6 +13,14 @@ import JavaScriptCore
 
 extension ArrayType: ArrayTypeAutoJSExport {}
 
+@objc protocol AssociatedTypeAutoJSExport: JSExport {
+    var name: String { get }
+    var typeName: TypeName? { get }
+    var type: Type? { get }
+}
+
+extension AssociatedType: AssociatedTypeAutoJSExport {}
+
 @objc protocol AssociatedValueAutoJSExport: JSExport {
     var localName: String? { get }
     var externalName: String? { get }
@@ -46,6 +54,7 @@ extension BytesRange: BytesRangeAutoJSExport {}
     var kind: String { get }
     var isFinal: Bool { get }
     var module: String? { get }
+    var imports: [String] { get }
     var accessLevel: String { get }
     var name: String { get }
     var globalName: String { get }
@@ -113,6 +122,7 @@ extension DictionaryType: DictionaryTypeAutoJSExport {}
     var based: [String: String] { get }
     var hasAssociatedValues: Bool { get }
     var module: String? { get }
+    var imports: [String] { get }
     var accessLevel: String { get }
     var name: String { get }
     var globalName: String { get }
@@ -225,7 +235,9 @@ extension MethodParameter: MethodParameterAutoJSExport {}
 
 @objc protocol ProtocolAutoJSExport: JSExport {
     var kind: String { get }
+    var associatedTypes: [String: AssociatedType] { get }
     var module: String? { get }
+    var imports: [String] { get }
     var accessLevel: String { get }
     var name: String { get }
     var globalName: String { get }
@@ -265,6 +277,7 @@ extension Protocol: ProtocolAutoJSExport {}
 @objc protocol StructAutoJSExport: JSExport {
     var kind: String { get }
     var module: String? { get }
+    var imports: [String] { get }
     var accessLevel: String { get }
     var name: String { get }
     var globalName: String { get }
@@ -351,6 +364,7 @@ extension TupleType: TupleTypeAutoJSExport {}
 
 @objc protocol TypeAutoJSExport: JSExport {
     var module: String? { get }
+    var imports: [String] { get }
     var kind: String { get }
     var accessLevel: String { get }
     var name: String { get }

--- a/SourceryRuntime/Sources/Protocol.swift
+++ b/SourceryRuntime/Sources/Protocol.swift
@@ -17,6 +17,9 @@ public typealias SourceryProtocol = Protocol
     /// Returns "protocol"
     public override var kind: String { return "protocol" }
 
+    /// list of all declared associated types with their names as keys
+    public var associatedTypes: [String: AssociatedType]
+
     /// :nodoc:
     public override init(name: String = "",
                          parent: Type? = nil,
@@ -31,6 +34,7 @@ public typealias SourceryProtocol = Protocol
                          attributes: [String: Attribute] = [:],
                          annotations: [String: NSObject] = [:],
                          isGeneric: Bool = false) {
+        self.associatedTypes = [:]
         super.init(
             name: name,
             parent: parent,
@@ -57,12 +61,14 @@ public typealias SourceryProtocol = Protocol
 // sourcery:inline:Protocol.AutoCoding
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
+            guard let associatedTypes: [String: AssociatedType] = aDecoder.decode(forKey: "associatedTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["associatedTypes"])); fatalError() }; self.associatedTypes = associatedTypes
             super.init(coder: aDecoder)
         }
 
         /// :nodoc:
         override public func encode(with aCoder: NSCoder) {
             super.encode(with: aCoder)
+            aCoder.encode(self.associatedTypes, forKey: "associatedTypes")
         }
 // sourcery:end
 }

--- a/SourceryRuntime/Sources/Type.swift
+++ b/SourceryRuntime/Sources/Type.swift
@@ -292,6 +292,7 @@ import Foundation
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
             self.module = aDecoder.decode(forKey: "module")
+            guard let imports: [String] = aDecoder.decode(forKey: "imports") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["imports"])); fatalError() }; self.imports = imports
             guard let typealiases: [String: Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             self.isExtension = aDecoder.decode(forKey: "isExtension")
             guard let accessLevel: String = aDecoder.decode(forKey: "accessLevel") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["accessLevel"])); fatalError() }; self.accessLevel = accessLevel
@@ -318,6 +319,7 @@ import Foundation
         /// :nodoc:
         public func encode(with aCoder: NSCoder) {
             aCoder.encode(self.module, forKey: "module")
+            aCoder.encode(self.imports, forKey: "imports")
             aCoder.encode(self.typealiases, forKey: "typealiases")
             aCoder.encode(self.isExtension, forKey: "isExtension")
             aCoder.encode(self.accessLevel, forKey: "accessLevel")

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -53,16 +53,17 @@ import Foundation
 
 /// Describes Swift AssociatedType
 @objcMembers public final class AssociatedType: NSObject, SourceryModel {
-    /// associatedType name
+    /// Associated type name
     public let name: String
 
-    /// associatedType type constraint name, if specified
+    /// Associated type type constraint name, if specified
     public let typeName: TypeName?
 
     // sourcery: skipEquality, skipDescription
-    /// associatedType constrained type, if known, i.e. if the type is declared in the scanned sources.
+    /// Associated type constrained type, if known, i.e. if the type is declared in the scanned sources.
     public var type: Type?
 
+    /// :nodoc:
     public init(name: String, typeName: TypeName? = nil, type: Type? = nil) {
         self.name = name
         self.typeName = typeName

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -47,6 +47,46 @@ public protocol Annotated {
 }
 
 """),
+    .init(name: "AssociatedType.swift", content:
+"""
+import Foundation
+
+/// Describes Swift AssociatedType
+@objcMembers public final class AssociatedType: NSObject, SourceryModel {
+    /// associatedType name
+    public let name: String
+
+    /// associatedType type constraint name, if specified
+    public let typeName: TypeName?
+
+    // sourcery: skipEquality, skipDescription
+    /// associatedType constrained type, if known, i.e. if the type is declared in the scanned sources.
+    public var type: Type?
+
+    public init(name: String, typeName: TypeName? = nil, type: Type? = nil) {
+        self.name = name
+        self.typeName = typeName
+        self.type = type
+    }
+
+// sourcery:inline:AssociatedType.AutoCoding
+        /// :nodoc:
+        required public init?(coder aDecoder: NSCoder) {
+            guard let name: String = aDecoder.decode(forKey: "name") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["name"])); fatalError() }; self.name = name
+            self.typeName = aDecoder.decode(forKey: "typeName")
+            self.type = aDecoder.decode(forKey: "type")
+        }
+
+        /// :nodoc:
+        public func encode(with aCoder: NSCoder) {
+            aCoder.encode(self.name, forKey: "name")
+            aCoder.encode(self.typeName, forKey: "typeName")
+            aCoder.encode(self.type, forKey: "type")
+        }
+// sourcery:end
+}
+
+"""),
     .init(name: "Attribute.swift", content:
 """
 import Foundation
@@ -359,6 +399,8 @@ extension NSCoder {
 
 extension ArrayType: NSCoding {}
 
+extension AssociatedType: NSCoding {}
+
 extension AssociatedValue: NSCoding {}
 
 extension Attribute: NSCoding {}
@@ -440,6 +482,15 @@ extension ArrayType {
         var string = "\\(Swift.type(of: self)): "
         string += "name = \\(String(describing: self.name)), "
         string += "elementTypeName = \\(String(describing: self.elementTypeName))"
+        return string
+    }
+}
+extension AssociatedType {
+    /// :nodoc:
+    override public var description: String {
+        var string = "\\(Swift.type(of: self)): "
+        string += "name = \\(String(describing: self.name)), "
+        string += "typeName = \\(String(describing: self.typeName))"
         return string
     }
 }
@@ -592,7 +643,8 @@ extension Protocol {
     override public var description: String {
         var string = super.description
         string += ", "
-        string += "kind = \\(String(describing: self.kind))"
+        string += "kind = \\(String(describing: self.kind)), "
+        string += "associatedTypes = \\(String(describing: self.associatedTypes))"
         return string
     }
 }
@@ -667,6 +719,7 @@ extension Type {
     override public var description: String {
         var string = "\\(Swift.type(of: self)): "
         string += "module = \\(String(describing: self.module)), "
+        string += "imports = \\(String(describing: self.imports)), "
         string += "typealiases = \\(String(describing: self.typealiases)), "
         string += "isExtension = \\(String(describing: self.isExtension)), "
         string += "kind = \\(String(describing: self.kind)), "
@@ -753,6 +806,18 @@ extension ArrayType: Diffable {
         }
         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: castObject.name))
         results.append(contentsOf: DiffableResult(identifier: "elementTypeName").trackDifference(actual: self.elementTypeName, expected: castObject.elementTypeName))
+        return results
+    }
+}
+extension AssociatedType: Diffable {
+    @objc func diffAgainst(_ object: Any?) -> DiffableResult {
+        let results = DiffableResult()
+        guard let castObject = object as? AssociatedType else {
+            results.append("Incorrect type <expected: AssociatedType, received: \\(Swift.type(of: object))>")
+            return results
+        }
+        results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: castObject.name))
+        results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
         return results
     }
 }
@@ -950,6 +1015,7 @@ extension Protocol {
             results.append("Incorrect type <expected: Protocol, received: \\(Swift.type(of: object))>")
             return results
         }
+        results.append(contentsOf: DiffableResult(identifier: "associatedTypes").trackDifference(actual: self.associatedTypes, expected: castObject.associatedTypes))
         results.append(contentsOf: super.diffAgainst(castObject))
         return results
     }
@@ -1039,6 +1105,7 @@ extension Type: Diffable {
             return results
         }
         results.append(contentsOf: DiffableResult(identifier: "module").trackDifference(actual: self.module, expected: castObject.module))
+        results.append(contentsOf: DiffableResult(identifier: "imports").trackDifference(actual: self.imports, expected: castObject.imports))
         results.append(contentsOf: DiffableResult(identifier: "typealiases").trackDifference(actual: self.typealiases, expected: castObject.typealiases))
         results.append(contentsOf: DiffableResult(identifier: "isExtension").trackDifference(actual: self.isExtension, expected: castObject.isExtension))
         results.append(contentsOf: DiffableResult(identifier: "accessLevel").trackDifference(actual: self.accessLevel, expected: castObject.accessLevel))
@@ -1574,6 +1641,15 @@ extension ArrayType {
         return true
     }
 }
+extension AssociatedType {
+    /// :nodoc:
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? AssociatedType else { return false }
+        if self.name != rhs.name { return false }
+        if self.typeName != rhs.typeName { return false }
+        return true
+    }
+}
 extension AssociatedValue {
     /// :nodoc:
     override public func isEqual(_ object: Any?) -> Bool {
@@ -1732,6 +1808,7 @@ extension Protocol {
     /// :nodoc:
     override public func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Protocol else { return false }
+        if self.associatedTypes != rhs.associatedTypes { return false }
         return super.isEqual(rhs)
     }
 }
@@ -1797,6 +1874,7 @@ extension Type {
     override public func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Type else { return false }
         if self.module != rhs.module { return false }
+        if self.imports != rhs.imports { return false }
         if self.typealiases != rhs.typealiases { return false }
         if self.isExtension != rhs.isExtension { return false }
         if self.accessLevel != rhs.accessLevel { return false }
@@ -2149,6 +2227,14 @@ import JavaScriptCore
 
 extension ArrayType: ArrayTypeAutoJSExport {}
 
+@objc protocol AssociatedTypeAutoJSExport: JSExport {
+    var name: String { get }
+    var typeName: TypeName? { get }
+    var type: Type? { get }
+}
+
+extension AssociatedType: AssociatedTypeAutoJSExport {}
+
 @objc protocol AssociatedValueAutoJSExport: JSExport {
     var localName: String? { get }
     var externalName: String? { get }
@@ -2182,6 +2268,7 @@ extension BytesRange: BytesRangeAutoJSExport {}
     var kind: String { get }
     var isFinal: Bool { get }
     var module: String? { get }
+    var imports: [String] { get }
     var accessLevel: String { get }
     var name: String { get }
     var globalName: String { get }
@@ -2249,6 +2336,7 @@ extension DictionaryType: DictionaryTypeAutoJSExport {}
     var based: [String: String] { get }
     var hasAssociatedValues: Bool { get }
     var module: String? { get }
+    var imports: [String] { get }
     var accessLevel: String { get }
     var name: String { get }
     var globalName: String { get }
@@ -2361,7 +2449,9 @@ extension MethodParameter: MethodParameterAutoJSExport {}
 
 @objc protocol ProtocolAutoJSExport: JSExport {
     var kind: String { get }
+    var associatedTypes: [String: AssociatedType] { get }
     var module: String? { get }
+    var imports: [String] { get }
     var accessLevel: String { get }
     var name: String { get }
     var globalName: String { get }
@@ -2401,6 +2491,7 @@ extension Protocol: ProtocolAutoJSExport {}
 @objc protocol StructAutoJSExport: JSExport {
     var kind: String { get }
     var module: String? { get }
+    var imports: [String] { get }
     var accessLevel: String { get }
     var name: String { get }
     var globalName: String { get }
@@ -2487,6 +2578,7 @@ extension TupleType: TupleTypeAutoJSExport {}
 
 @objc protocol TypeAutoJSExport: JSExport {
     var module: String? { get }
+    var imports: [String] { get }
     var kind: String { get }
     var accessLevel: String { get }
     var name: String { get }
@@ -2994,6 +3086,9 @@ public typealias SourceryProtocol = Protocol
     /// Returns "protocol"
     public override var kind: String { return "protocol" }
 
+    /// list of all declared associated types with their names as keys
+    public var associatedTypes: [String: AssociatedType]
+
     /// :nodoc:
     public override init(name: String = "",
                          parent: Type? = nil,
@@ -3008,6 +3103,7 @@ public typealias SourceryProtocol = Protocol
                          attributes: [String: Attribute] = [:],
                          annotations: [String: NSObject] = [:],
                          isGeneric: Bool = false) {
+        self.associatedTypes = [:]
         super.init(
             name: name,
             parent: parent,
@@ -3034,12 +3130,14 @@ public typealias SourceryProtocol = Protocol
 // sourcery:inline:Protocol.AutoCoding
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
+            guard let associatedTypes: [String: AssociatedType] = aDecoder.decode(forKey: "associatedTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["associatedTypes"])); fatalError() }; self.associatedTypes = associatedTypes
             super.init(coder: aDecoder)
         }
 
         /// :nodoc:
         override public func encode(with aCoder: NSCoder) {
             super.encode(with: aCoder)
+            aCoder.encode(self.associatedTypes, forKey: "associatedTypes")
         }
 // sourcery:end
 }
@@ -3874,6 +3972,7 @@ import Foundation
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
             self.module = aDecoder.decode(forKey: "module")
+            guard let imports: [String] = aDecoder.decode(forKey: "imports") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["imports"])); fatalError() }; self.imports = imports
             guard let typealiases: [String: Typealias] = aDecoder.decode(forKey: "typealiases") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["typealiases"])); fatalError() }; self.typealiases = typealiases
             self.isExtension = aDecoder.decode(forKey: "isExtension")
             guard let accessLevel: String = aDecoder.decode(forKey: "accessLevel") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["accessLevel"])); fatalError() }; self.accessLevel = accessLevel
@@ -3900,6 +3999,7 @@ import Foundation
         /// :nodoc:
         public func encode(with aCoder: NSCoder) {
             aCoder.encode(self.module, forKey: "module")
+            aCoder.encode(self.imports, forKey: "imports")
             aCoder.encode(self.typealiases, forKey: "typealiases")
             aCoder.encode(self.isExtension, forKey: "isExtension")
             aCoder.encode(self.accessLevel, forKey: "accessLevel")

--- a/SourceryTests/Parsing/FileParser + AssociatedTypeSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AssociatedTypeSpec.swift
@@ -13,15 +13,15 @@ private func build(_ source: String) -> [String: SourceKitRepresentable]? {
 final class FileParserAssociatedTypeSpec: QuickSpec {
     override func spec() {
         describe("Parser") {
-            describe("parseAssociatedType") {
+            describe("parse associated type") {
                 func parse(_ code: String) -> [Type] {
                     guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
                     return Composer.uniqueTypesAndFunctions(parserResult).types
                 }
 
                 context("given protocol") {
-                    context("with an associatedType") {
-                        it("extracts associatedType properly") {
+                    context("with an associated type") {
+                        it("extracts associated type properly") {
                             let code = """
                                 protocol Foo {
                                     associatedtype Bar
@@ -33,8 +33,8 @@ final class FileParserAssociatedTypeSpec: QuickSpec {
                         }
                     }
 
-                    context("with multiple associatedTypes") {
-                        it("extracts associatedTypes properly") {
+                    context("with multiple associated types") {
+                        it("extracts associated types properly") {
                             let code = """
                                 protocol Foo {
                                     associatedtype Bar
@@ -48,8 +48,8 @@ final class FileParserAssociatedTypeSpec: QuickSpec {
                         }
                     }
 
-                    context("with associatedType constrained to an unknown type") {
-                        it("extracts associatedType properly") {
+                    context("with associated type constrained to an unknown type") {
+                        it("extracts associated type properly") {
                             let code = """
                                 protocol Foo {
                                     associatedtype Bar: Codable
@@ -64,8 +64,8 @@ final class FileParserAssociatedTypeSpec: QuickSpec {
                         }
                     }
 
-                    context("with associatedType constrained to a known type") {
-                        it("extracts associatedType properly") {
+                    context("with associated type constrained to a known type") {
+                        it("extracts associated type properly") {
                             let code = """
                                 protocol A {}
                                 protocol Foo {
@@ -83,8 +83,8 @@ final class FileParserAssociatedTypeSpec: QuickSpec {
                         }
                     }
 
-                    context("with associatedType constrained to a composite type") {
-                        it("extracts associatedType properly") {
+                    context("with associated type constrained to a composite type") {
+                        it("extracts associated type properly") {
                             let code = """
                                 protocol Foo {
                                     associatedtype Bar: Encodable & Decodable

--- a/SourceryTests/Parsing/FileParser + AssociatedTypeSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AssociatedTypeSpec.swift
@@ -1,0 +1,114 @@
+import Quick
+import Nimble
+import PathKit
+import SourceKittenFramework
+@testable import Sourcery
+@testable import SourceryFramework
+@testable import SourceryRuntime
+
+private func build(_ source: String) -> [String: SourceKitRepresentable]? {
+    return try? Structure(file: File(contents: source)).dictionary
+}
+
+final class FileParserAssociatedTypeSpec: QuickSpec {
+    override func spec() {
+        describe("Parser") {
+            describe("parseAssociatedType") {
+                func parse(_ code: String) -> [Type] {
+                    guard let parserResult = try? FileParser(contents: code).parse() else { fail(); return [] }
+                    return Composer.uniqueTypesAndFunctions(parserResult).types
+                }
+
+                context("given protocol") {
+                    context("with an associatedType") {
+                        it("extracts associatedType properly") {
+                            let code = """
+                                protocol Foo {
+                                    associatedtype Bar
+                                }
+                            """
+                            let expectedProtocol = Protocol(name: "Foo")
+                            expectedProtocol.associatedTypes["Bar"] = AssociatedType(name: "Bar")
+                            expect(parse(code)).to(equal([expectedProtocol]))
+                        }
+                    }
+
+                    context("with multiple associatedTypes") {
+                        it("extracts associatedTypes properly") {
+                            let code = """
+                                protocol Foo {
+                                    associatedtype Bar
+                                    associatedtype Baz
+                                }
+                            """
+                            let expectedProtocol = Protocol(name: "Foo")
+                            expectedProtocol.associatedTypes["Bar"] = AssociatedType(name: "Bar")
+                            expectedProtocol.associatedTypes["Baz"] = AssociatedType(name: "Baz")
+                            expect(parse(code)).to(equal([expectedProtocol]))
+                        }
+                    }
+
+                    context("with associatedType constrained to an unknown type") {
+                        it("extracts associatedType properly") {
+                            let code = """
+                                protocol Foo {
+                                    associatedtype Bar: Codable
+                                }
+                            """
+                            let expectedProtocol = Protocol(name: "Foo")
+                            expectedProtocol.associatedTypes["Bar"] = AssociatedType(
+                                name: "Bar",
+                                typeName: TypeName("Codable")
+                            )
+                            expect(parse(code)).to(equal([expectedProtocol]))
+                        }
+                    }
+
+                    context("with associatedType constrained to a known type") {
+                        it("extracts associatedType properly") {
+                            let code = """
+                                protocol A {}
+                                protocol Foo {
+                                    associatedtype Bar: A
+                                }
+                            """
+                            let protocolA = Protocol(name: "A")
+                            let protocolFoo = Protocol(name: "Foo")
+                            protocolFoo.associatedTypes["Bar"] = AssociatedType(
+                                name: "Bar",
+                                typeName: TypeName("A"),
+                                type: protocolA
+                            )
+                            expect(parse(code)).to(equal([protocolA, protocolFoo]))
+                        }
+                    }
+
+                    context("with associatedType constrained to a composite type") {
+                        it("extracts associatedType properly") {
+                            let code = """
+                                protocol Foo {
+                                    associatedtype Bar: Encodable & Decodable
+                                }
+                            """
+                            let expectedType = ProtocolComposition(
+                                inheritedTypes: ["Encodable", "Decodable"],
+                                composedTypeNames: [TypeName("Encodable"), TypeName("Decodable")]
+                            )
+                            let expectedProtocol = Protocol(name: "Foo")
+                            expectedType.parent = expectedProtocol
+                            expectedProtocol.associatedTypes["Bar"] = AssociatedType(
+                                name: "Bar",
+                                typeName: TypeName("Encodable & Decodable"),
+                                type: expectedType
+                            )
+                            let actualProtocol = parse(code).first
+                            expect(actualProtocol).to(equal(expectedProtocol))
+                            let actualType = (actualProtocol as? SourceryProtocol)?.associatedTypes.first?.value.type
+                            expect(actualType).to(equal(expectedType))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SourceryTests/Parsing/FileParser + AssociatedTypeSpec.swift
+++ b/SourceryTests/Parsing/FileParser + AssociatedTypeSpec.swift
@@ -107,6 +107,31 @@ final class FileParserAssociatedTypeSpec: QuickSpec {
                             expect(actualType).to(equal(expectedType))
                         }
                     }
+
+                    context("with associated type constrained to a typealias") {
+                        it("extracts associated type properly") {
+                            let code = """
+                                protocol Foo {
+                                    typealias AEncodable = Encodable
+                                    associatedtype Bar: AEncodable
+                                }
+                            """
+                            let givenTypealias = Typealias(aliasName: "AEncodable", typeName: TypeName("Encodable"))
+                            let expectedProtocol = Protocol(name: "Foo", typealiases: [givenTypealias])
+                            givenTypealias.parent = expectedProtocol
+                            expectedProtocol.associatedTypes["Bar"] = AssociatedType(
+                                name: "Bar",
+                                typeName: TypeName(
+                                    givenTypealias.aliasName,
+                                    actualTypeName: givenTypealias.typeName
+                                )
+                            )
+                            let actualProtocol = parse(code).first
+                            expect(actualProtocol).to(equal(expectedProtocol))
+                            let actualTypeName = (actualProtocol as? SourceryProtocol)?.associatedTypes.first?.value.typeName?.actualTypeName
+                            expect(actualTypeName).to(equal(givenTypealias.actualTypeName))
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds support for accessing all associated types declared in a protocol including their type constraints.

Fixes krzysztofzablocki/Sourcery#539