### PR TITLE
Fix error at build time when using SwiftTemplate & Xcode 11.4 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add missing documentation for the `ProtocolComposition` type.
 - Fix incorrectly taking closure optional return value as sign that whole variable is optional (#823) 
 - Fix incorrectly taking return values with closure as generic type as sign that whole variable is a closure (#845)
+- Fix empty error at build time when using SwiftTemplate on Xcode 11.4 and higher (#817)
 
 ## 0.18.0
 

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -229,6 +229,7 @@ open class SwiftTemplate {
 
         let arguments = [
             "xcrun",
+            "--sdk", "macosx",
             "swift",
             "build",
             "-Xswiftc", "-Onone",
@@ -240,7 +241,7 @@ open class SwiftTemplate {
                                                        currentDirectoryPath: buildDir)
 
         if compilationResult.exitCode != 0 || !compilationResult.error.isEmpty {
-            throw compilationResult.output
+            throw compilationResult.error
         }
 
         return binaryFile

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -241,7 +241,9 @@ open class SwiftTemplate {
                                                        currentDirectoryPath: buildDir)
 
         if compilationResult.exitCode != 0 || !compilationResult.error.isEmpty {
-            throw compilationResult.error
+            throw [compilationResult.output, compilationResult.error]
+                .filter { !$0.isEmpty }
+                .joined(separator: "\n")
         }
 
         return binaryFile


### PR DESCRIPTION
Fix for the issues #817 / #835

**Problem**

We obtain a weird empty error during the build when the following criteria are met
- using Xcode 11.4 and higher
- using a SwiftTemplate
- using a build phase to run Sourcery

<img width="637" alt="image" src="https://user-images.githubusercontent.com/11665957/90110772-994f3700-dd02-11ea-9aa9-1c0d3da6f005.png">

**It works when we run the exact same command from a terminal**

**Solution**

As we can see, the latest command to run is "xcrun swift ..."
This command is used at only one place in Sourcery, in SwiftTemplate.swift!

By looking at that code, if an error occurred during this command execution, we throw the `output` instead of the `error`. 
```
if compilationResult.exitCode != 0 || !compilationResult.error.isEmpty {
    throw compilationResult.output
}
```

That's why we have an empty error in Xcode. by printing the error instead, we have more information

<img width="628" alt="image" src="https://user-images.githubusercontent.com/11665957/90111549-a7ea1e00-dd03-11ea-84ec-50b3f9bdf64e.png">

It looks like it is trying to generate the template by using the SDK the project is using instead of MacOSX

A quick print of the SDK path using `xcrun --show-sdk-path` confirms it isn't using the correct one
`/Applications/Xcode/.../Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.6.sdk`
The same command in a terminal shows it is using MacOSX. **That explains why it works in the terminal**
`/Applications/Xcode/.../Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk`

By forcing the SDK to MacOSX using the option `-sdk macosx`, it works perfectly 🎉