### PR TITLE
Fix an issue, where "types.implementing.<protocolName>" did not work …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Sourcery CHANGELOG
 
 ---
+## 1.0.1
+
+### Bug fixes
+
+- Fix an issue, where "types.implementing.<protocolName>" did not work due to an additional module name.
+
 ## 1.0.0
 
 ### New Features

--- a/SourceryRuntime/Sources/TemplateContext.swift
+++ b/SourceryRuntime/Sources/TemplateContext.swift
@@ -227,13 +227,32 @@ extension ProcessInfo {
     }
 
     public func types(forKey key: String) throws -> [Type] {
+        // In some configurations, the types are keyed by "ModuleName.TypeName"
+        var longKey: String?
+
         if let validate = validate {
             guard let type = all.first(where: { $0.name == key }) else {
                 throw "Unknown type \(key), should be used with `based`"
             }
+            
             try validate(type)
+            
+            if let module = type.module {
+                longKey = [module, type.name].joined(separator: ".")
+            }
         }
-        return types[key] ?? []
+        
+        // If we find the types directly, return them
+        if let types = types[key] {
+            return types
+        }
+
+        // if we find a types for the longKey, return them
+        if let longKey = longKey, let types = types[longKey] {
+            return types
+        }
+
+        return []
     }
 
     /// :nodoc:


### PR DESCRIPTION
…due to an additional module name.

Version 1.0.0 broke Codegeneration using “implementing” when using multiple modules for us (e.g. Framework and App) for us.

Calls like

```
{% for type in types.implementing.SimpleFactory %}
```

no longer work for us. (`SimpleFactory` is a protocol we use to mark types for Codegeneration)

Debugging the sourcery code I found that for our config, the types dictionary inside

```
 public func types(forKey key: String) throws -> [Type]
```

is keyed by "ModuleName.TypeName" rather than the expected "TypeName".

Doing a fallback lookup for  "ModuleName.TypeName" when the lookup for "TypeName" fails fixes this for us.

Is this a valid approach? Are there better options? Is it likely other places in the code are also affected?

Our Config.yml:

```
project:
  file: ../../<ProjectName>.xcodeproj
  target:
    name: <InternalFrameworkName>
templates:
  - SourceryTemplates/
output: ../../Sources/<InternalFrameworkName>/Base/Sourcery
args:
additionalImports: |
  import <InternalFrameworkName>

```
