### PR TITLE
Fix multiline method declarations parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug fixes
 
+- Fix multiline method declarations parsing
 - Fix an issue, where "types.implementing.<protocolName>" did not work due to an additional module name.
 
 ## 1.0.0

--- a/Sourcery.xcodeproj/xcshareddata/xcschemes/SourceryFramework.xcscheme
+++ b/Sourcery.xcodeproj/xcshareddata/xcschemes/SourceryFramework.xcscheme
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:Sourcery.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sourcery.xcworkspace/xcshareddata/xcschemes/Sourcery.xcscheme
+++ b/Sourcery.xcworkspace/xcshareddata/xcschemes/Sourcery.xcscheme
@@ -54,8 +54,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD754C8A1D853F000082B512"
+            BuildableName = "Sourcery.app"
+            BlueprintName = "Sourcery"
+            ReferencedContainer = "container:Sourcery.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -68,17 +77,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CD754C8A1D853F000082B512"
-            BuildableName = "Sourcery.app"
-            BlueprintName = "Sourcery"
-            ReferencedContainer = "container:Sourcery.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -130,8 +128,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SourceryFramework/Sources/Parsing/FileParser.swift
+++ b/SourceryFramework/Sources/Parsing/FileParser.swift
@@ -125,7 +125,6 @@ public final class FileParser {
         var typealiases = [Typealias]()
         try walkDeclarations(source: source) { kind, name, access, inheritedTypes, source, definedIn, next in
             let type: Type
-
             switch kind {
             case .protocol:
                 type = Protocol(name: name, accessLevel: access, isExtension: false, inheritedTypes: inheritedTypes)
@@ -940,8 +939,10 @@ extension String {
             finished = true
             let lines = stripped.lines()
             if lines.count > 1 {
-                stripped = lines.filter({ line in !line.content.hasPrefix("//") }).map({ $0.content }).joined(separator: "")
-                finished = false
+                stripped = lines.lazy
+                    .filter({ line in !line.content.hasPrefix("//") })
+                    .map(\.content)
+                    .joined(separator: "\n")
             }
             if let annotationStart = stripped.range(of: "/*")?.lowerBound, let annotationEnd = stripped.range(of: "*/")?.upperBound {
                 stripped = stripped.replacingCharacters(in: annotationStart ..< annotationEnd, with: "")

--- a/SourceryRuntime/Sources/TemplateContext.swift
+++ b/SourceryRuntime/Sources/TemplateContext.swift
@@ -234,14 +234,14 @@ extension ProcessInfo {
             guard let type = all.first(where: { $0.name == key }) else {
                 throw "Unknown type \(key), should be used with `based`"
             }
-            
+
             try validate(type)
-            
+
             if let module = type.module {
                 longKey = [module, type.name].joined(separator: ".")
             }
         }
-        
+
         // If we find the types directly, return them
         if let types = types[key] {
             return types

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -84,3 +84,8 @@ protocol FunctionWithClosureReturnType: AutoMockable {
     func get() -> () -> Void
     func getOptional() -> (() -> Void)?
 }
+
+protocol FunctionWithMultilineDeclaration: AutoMockable {
+    func start(car: String,
+               of model: String)
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -156,6 +156,27 @@ class FunctionWithClosureReturnTypeMock: FunctionWithClosureReturnType {
     }
 
 }
+class FunctionWithMultilineDeclarationMock: FunctionWithMultilineDeclaration {
+
+    //MARK: - start
+
+    var startCarOfCallsCount = 0
+    var startCarOfCalled: Bool {
+        return startCarOfCallsCount > 0
+    }
+    var startCarOfReceivedArguments: (car: String, model: String)?
+    var startCarOfReceivedInvocations: [(car: String, model: String)] = []
+    var startCarOfClosure: ((String, String) -> Void)?
+
+    func start(car: String,
+               of model: String) {
+        startCarOfCallsCount += 1
+        startCarOfReceivedArguments = (car: car, model: model)
+        startCarOfReceivedInvocations.append((car: car, model: model))
+        startCarOfClosure?(car, model)
+    }
+
+}
 class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOptionalReturnValueProtocol {
 
     //MARK: - implicitReturn

--- a/Templates/Tests/Generated/AutoCases.generated.swift
+++ b/Templates/Tests/Generated/AutoCases.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoCodable.generated.swift
+++ b/Templates/Tests/Generated/AutoCodable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all

--- a/Templates/Tests/Generated/AutoLenses.generated.swift
+++ b/Templates/Tests/Generated/AutoLenses.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable variable_name

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length
@@ -171,6 +171,27 @@ class FunctionWithClosureReturnTypeMock: FunctionWithClosureReturnType {
     func getOptional() -> (() -> Void)? {
         getOptionalCallsCount += 1
         return getOptionalClosure.map({ $0() }) ?? getOptionalReturnValue
+    }
+
+}
+class FunctionWithMultilineDeclarationMock: FunctionWithMultilineDeclaration {
+
+    //MARK: - start
+
+    var startCarOfCallsCount = 0
+    var startCarOfCalled: Bool {
+        return startCarOfCallsCount > 0
+    }
+    var startCarOfReceivedArguments: (car: String, model: String)?
+    var startCarOfReceivedInvocations: [(car: String, model: String)] = []
+    var startCarOfClosure: ((String, String) -> Void)?
+
+    func start(car: String,
+               of model: String) {
+        startCarOfCallsCount += 1
+        startCarOfReceivedArguments = (car: car, model: model)
+        startCarOfReceivedInvocations.append((car: car, model: model))
+        startCarOfClosure?(car, model)
     }
 
 }

--- a/Templates/Tests/Generated/LinuxMain.generated.swift
+++ b/Templates/Tests/Generated/LinuxMain.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest


### PR DESCRIPTION
Fixes #862.

### Backround
The actual proposal is described in #862.
I used `Xcode 11.7` to make these changes. Seems like the project does not compile with `Xcode 12` and I didn't have time to look into why.

### What has been done
1. Fix multiline method parsing in `FileParser.swift:943`
2. Added tests for it in `FileParser + MethodsSpec.swift` and `TemplatesTests`
3. Regenerated `Templates` generated classes to include latest version `1.0.0`
4. Seems like `SourceryRuntime.content.generated.swift` was automatically adjusted. Maybe some leftovers from previous PRs