### PR TITLE
Tuple for associated values in enum case is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Fix multiline method declarations parsing
 - Fix an issue, where "types.implementing.<protocolName>" did not work due to an additional module name.
+- Using tuple for associated values in enum case is deprecated since Swift 5.2. Fix AutoEquatable and AutoHashable templates to avoid the warning (#842)
 
 ## 1.0.0
 

--- a/Templates/Templates/AutoEquatable.stencil
+++ b/Templates/Templates/AutoEquatable.stencil
@@ -46,12 +46,22 @@ extension {{ type.name }}: Equatable {}
 public func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
     switch (lhs, rhs) {
     {% for case in type.cases %}
-    {% if case.hasAssociatedValue %}case (.{{ case.name }}(let lhs), .{{ case.name }}(let rhs)):{% else %}case (.{{ case.name }}, .{{ case.name }}):{% endif %}
+    {% if case.hasAssociatedValue %}
+    {% if case.associatedValues.count == 1 %}
+    case let (.{{ case.name }}(lhs), .{{ case.name }}(rhs)):
+    {% else %}
+    {% map case.associatedValues into lhsValues using associated %}lhs{{ associated.externalName|upperFirstLetter }}{% endmap %}
+    {% map case.associatedValues into rhsValues using associated %}rhs{{ associated.externalName|upperFirstLetter }}{% endmap %}
+    case let (.{{ case.name }}({{ lhsValues|join: ", " }}), .{{ case.name }}({{ rhsValues|join: ", " }})):
+    {% endif %}
+    {% else %}
+    case (.{{ case.name }}, .{{ case.name }}):
+    {% endif %}
         {% if not case.hasAssociatedValue %}return true{% else %}
         {% if case.associatedValues.count == 1 %}
         return lhs == rhs
         {% else %}
-        {% for associated in case.associatedValues %}if lhs.{{ associated.externalName }} != rhs.{{ associated.externalName }} { return false }
+        {% for associated in case.associatedValues %}if lhs{{ associated.externalName|upperFirstLetter }} != rhs{{ associated.externalName|upperFirstLetter }} { return false }
         {% endfor %}return true
         {% endif %}
         {% endif %}

--- a/Templates/Templates/AutoHashable.stencil
+++ b/Templates/Templates/AutoHashable.stencil
@@ -33,7 +33,16 @@ extension {{ type.name }}: Hashable {
     {{ type.accessLevel }} func hash(into hasher: inout Hasher) {
         switch self {
         {% for case in type.cases %}
-        {% if case.hasAssociatedValue %}case .{{ case.name }}(let data):{% else %}case .{{ case.name }}:{% endif %}
+        {% if case.hasAssociatedValue %}
+        {% if case.associatedValues.count == 1 %}
+        case let .{{ case.name }}(data):
+        {% else %}
+        {% map case.associatedValues into associatedValues using associated %}{{ associated.externalName }}{% endmap %}
+        case let .{{ case.name }}({{ associatedValues|join: ", " }}):
+        {% endif %}
+        {% else %}
+        case .{{ case.name }}:
+        {% endif %}
             {{ forloop.counter }}.hash(into: &hasher)
             {% if type.computedVariables.count > 0 %}
             {% for variable in type.computedVariables %}
@@ -45,7 +54,7 @@ extension {{ type.name }}: Hashable {
             {% if case.associatedValues.count == 1 %}
             data.hash(into: &hasher)
             {% else %}
-            {% for associated in case.associatedValues %}data.{{ associated.externalName }}.hash(into: &hasher)
+            {% for associated in case.associatedValues %}{{ associated.externalName }}.hash(into: &hasher)
             {% endfor %}
             {% endif %}
             {% endif %}

--- a/Templates/Tests/Expected/AutoEquatable.expected
+++ b/Templates/Tests/Expected/AutoEquatable.expected
@@ -83,11 +83,11 @@ public func == (lhs: AutoEquatableEnum, rhs: AutoEquatableEnum) -> Bool {
     switch (lhs, rhs) {
     case (.one, .one):
         return true
-    case (.two(let lhs), .two(let rhs)):
-        if lhs.first != rhs.first { return false }
-        if lhs.second != rhs.second { return false }
+    case let (.two(lhsFirst, lhsSecond), .two(rhsFirst, rhsSecond)):
+        if lhsFirst != rhsFirst { return false }
+        if lhsSecond != rhsSecond { return false }
         return true
-    case (.three(let lhs), .three(let rhs)):
+    case let (.three(lhs), .three(rhs)):
         return lhs == rhs
     default: return false
     }

--- a/Templates/Tests/Expected/AutoHashable.expected
+++ b/Templates/Tests/Expected/AutoHashable.expected
@@ -91,11 +91,11 @@ extension AutoHashableEnum: Hashable {
         switch self {
         case .one:
             1.hash(into: &hasher)
-        case .two(let data):
+        case let .two(first, second):
             2.hash(into: &hasher)
-            data.first.hash(into: &hasher)
-            data.second.hash(into: &hasher)
-        case .three(let data):
+            first.hash(into: &hasher)
+            second.hash(into: &hasher)
+        case let .three(data):
             3.hash(into: &hasher)
             data.hash(into: &hasher)
         }

--- a/Templates/Tests/Generated/AutoEquatable.generated.swift
+++ b/Templates/Tests/Generated/AutoEquatable.generated.swift
@@ -86,11 +86,11 @@ public func == (lhs: AutoEquatableEnum, rhs: AutoEquatableEnum) -> Bool {
     switch (lhs, rhs) {
     case (.one, .one):
         return true
-    case (.two(let lhs), .two(let rhs)):
-        if lhs.first != rhs.first { return false }
-        if lhs.second != rhs.second { return false }
+    case let (.two(lhsFirst, lhsSecond), .two(rhsFirst, rhsSecond)):
+        if lhsFirst != rhsFirst { return false }
+        if lhsSecond != rhsSecond { return false }
         return true
-    case (.three(let lhs), .three(let rhs)):
+    case let (.three(lhs), .three(rhs)):
         return lhs == rhs
     default: return false
     }

--- a/Templates/Tests/Generated/AutoHashable.generated.swift
+++ b/Templates/Tests/Generated/AutoHashable.generated.swift
@@ -94,11 +94,11 @@ extension AutoHashableEnum: Hashable {
         switch self {
         case .one:
             1.hash(into: &hasher)
-        case .two(let data):
+        case let .two(first, second):
             2.hash(into: &hasher)
-            data.first.hash(into: &hasher)
-            data.second.hash(into: &hasher)
-        case .three(let data):
+            first.hash(into: &hasher)
+            second.hash(into: &hasher)
+        case let .three(data):
             3.hash(into: &hasher)
             data.hash(into: &hasher)
         }


### PR DESCRIPTION
Code generated with AutoEquatable and AutoHashable templates is raising a deprecation warning

Using a tuple to access associated values in the enum case is now deprecated since Swift 5.2

Update the 2 templates accordingly to put the exhaustive list of associated values, and avoid the warning

#842