### PR TITLE
Add podspecs for macOS frameworks

### DIFF
--- a/SourceryFramework.podspec
+++ b/SourceryFramework.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+
+  s.name         = "SourceryFramework"
+  s.version      = "1.0.0"
+  s.summary      = "A tool that brings meta-programming to Swift, allowing you to code generate Swift code."
+
+  s.description  = <<-DESC
+                 A tool that brings meta-programming to Swift, allowing you to code generate Swift code.
+                   * Featuring daemon mode that allows you to write templates side-by-side with generated code.
+                   * Using SourceKit so you can scan your regular code.
+                   DESC
+
+  s.homepage     = "https://github.com/krzysztofzablocki/Sourcery"
+  s.license      = 'MIT'
+  s.author       = { "Krzysztof Zabłocki" => "krzysztof.zablocki@pixle.pl" }
+  s.social_media_url = "https://twitter.com/merowing_"
+  s.source       = { :http => "https://github.com/krzysztofzablocki/Sourcery/releases/download/#{s.version}/sourcery-#{s.version}.zip" }
+
+  s.source_files = "SourceryFramework/Sources/**/*.swift"
+  
+  s.osx.deployment_target  = '10.11'
+  
+  s.dependency 'SourceryUtils'
+  s.dependency 'SourceryRuntime'
+  s.dependency 'SourceKittenFramework', '~> 0.23.1'
+end

--- a/SourceryRuntime.podspec
+++ b/SourceryRuntime.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+
+  s.name         = "SourceryRuntime"
+  s.version      = "1.0.0"
+  s.summary      = "A tool that brings meta-programming to Swift, allowing you to code generate Swift code."
+
+  s.description  = <<-DESC
+                 A tool that brings meta-programming to Swift, allowing you to code generate Swift code.
+                   * Featuring daemon mode that allows you to write templates side-by-side with generated code.
+                   * Using SourceKit so you can scan your regular code.
+                   DESC
+
+  s.homepage     = "https://github.com/krzysztofzablocki/Sourcery"
+  s.license      = 'MIT'
+  s.author       = { "Krzysztof Zabłocki" => "krzysztof.zablocki@pixle.pl" }
+  s.social_media_url = "https://twitter.com/merowing_"
+  s.source       = { :http => "https://github.com/krzysztofzablocki/Sourcery/releases/download/#{s.version}/sourcery-#{s.version}.zip" }
+
+  s.source_files = "SourceryRuntime/Sources/**/*.swift"
+  
+  s.osx.deployment_target  = '10.11'
+  
+  s.dependency 'SourceryUtils'
+end

--- a/SourceryUtils.podspec
+++ b/SourceryUtils.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+
+  s.name         = "SourceryUtils"
+  s.version      = "1.0.0"
+  s.summary      = "A tool that brings meta-programming to Swift, allowing you to code generate Swift code."
+
+  s.description  = <<-DESC
+                 A tool that brings meta-programming to Swift, allowing you to code generate Swift code.
+                   * Featuring daemon mode that allows you to write templates side-by-side with generated code.
+                   * Using SourceKit so you can scan your regular code.
+                   DESC
+
+  s.homepage     = "https://github.com/krzysztofzablocki/Sourcery"
+  s.license      = 'MIT'
+  s.author       = { "Krzysztof Zabłocki" => "krzysztof.zablocki@pixle.pl" }
+  s.social_media_url = "https://twitter.com/merowing_"
+  s.source       = { :http => "https://github.com/krzysztofzablocki/Sourcery/releases/download/#{s.version}/sourcery-#{s.version}.zip" }
+
+  s.source_files = "SourceryUtils/Sources/**/*.swift"
+  
+  s.osx.deployment_target  = '10.11'
+  
+  s.dependency 'PathKit'
+end


### PR DESCRIPTION
**What this pull request adds:**

- Ability to use SourceryFramework and other macOS frameworks with Cocoapods (it also works without need to release it to global Spec repo)

**Use case:**

We have project that uses Cocoapods, we use Sourcery directly from Swift, and it is very convenient for our case to use Sourcery from Swift code, we are migrating from ton of independent templates and entry points to code generation to a single nice Swift project.

We don't really need to have podspecs to be able to use Sourcery, since our project for code generation uses SPM. But our iOS which works with that code generation uses Cocoapods, and it's very nice to be able to work in a single project, also cocoapods have nice features that is missing in SPM, such as development pods (also SPM can't work with mixed Obj-C, Swift code, so there is no way to migrate everything to SPM). So SPM is used only to build binaries.

**Drawbacks**

If you want to support this, you will have to update versions of podspecs, so, additional work. Note that the use case seems to be rare, at least for now, so releasing those frameworks to global spec repo seems unnecessary, they can be used without it just fine, by specifying url to git repo.

**P.S.**

I don't know if the descriptions of podspecs suits, I just copypasted them. We also don't expect this to be released to global spec repo, but podspecs are nice to have. If you want me to improve something in this PR, I'm willing to do so.