### PR TITLE
Eliminate extra blank lines after header

### DIFF
--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -17,7 +17,7 @@ class Sourcery {
     public static let version: String = SourceryVersion.current.value
     public static let generationMarker: String = "// Generated using Sourcery"
     public static let generationHeader = "\(Sourcery.generationMarker) \(Sourcery.version) — https://github.com/krzysztofzablocki/Sourcery\n"
-        + "// DO NOT EDIT\n\n"
+        + "// DO NOT EDIT\n"
 
     enum Error: Swift.Error {
         case containsMergeConflictMarkers


### PR DESCRIPTION
Fix #829

As in the issue, there are extra blank lines after header that warn me when using swiftlint.
I don't think it's necessary to invalidate `vertical_whitespace` rule using the `swiftlint:disable` notation.