### PR TITLE
add .swiftpm/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ playground.xcworkspace
 Packages/
 Package.pins
 .build/
+.swiftpm/
 
 # CocoaPods
 #


### PR DESCRIPTION
When opening Package.swift with Xcode, it will create a .swiftpm directory, this should be in the gitignore