### PR TITLE
Type inference and resolution improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Sourcery CHANGELOG
 
 ---
+## Master
+
+### New Features
+- `Self` reference is resolved to correct type. [Enchancement Request](https://github.com/krzysztofzablocki/Sourcery/issues/900)
+- Sourcery will now attempt to resolve local type names across modules when it can be done without ambiguity. Previously we only supported fully qualified names. [Enchancement Request](https://github.com/krzysztofzablocki/Sourcery/issues/899)
+
 ## 1.1.1
 
 - Updates StencilSwiftKit to 2.8.0

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -317,8 +317,12 @@ public struct Composer {
         }
 
         if let containingType = containingType {
-            //check if typealias is for one of contained types
-            if let possibleTypeName = typealiases["\(containingType.globalName).\(unwrappedTypeName)"]?.typeName.name {
+            // check if self
+            if typeName.unwrappedTypeName == "Self" {
+                actualTypeName = containingType.globalName
+            }
+            // check if typealias is for one of contained types
+            else if let possibleTypeName = typealiases["\(containingType.globalName).\(unwrappedTypeName)"]?.typeName.name {
                 let containedType = containingType.containedTypes.first(where: {
                     $0.name == "\(containingType.name).\(possibleTypeName)" || $0.name == possibleTypeName
                 })

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -50,23 +50,23 @@ public struct Composer {
         parsedTypes
             .filter { $0.isExtension == true }
             .forEach {
-                $0.localName = actualTypeName(for: TypeName($0.name), typealiases: resolvedTypealiases) ?? $0.localName
+                $0.localName = actualTypeName(for: TypeName($0.name), modules: modules, typealiases: resolvedTypealiases) ?? $0.localName
             }
 
         //extend all types with their extensions
         parsedTypes.forEach { type in
-            type.inheritedTypes = type.inheritedTypes.map { actualTypeName(for: TypeName($0), typealiases: resolvedTypealiases) ?? $0 }
+            type.inheritedTypes = type.inheritedTypes.map { actualTypeName(for: TypeName($0), modules: modules, typealiases: resolvedTypealiases) ?? $0 }
 
             let uniqueType = unique[type.globalName] ?? typeFromModule(type.name, modules: modules) ?? type.imports.lazy.compactMap { modules[$0]?[type.name] }.first
 
             guard let current = uniqueType else {
-                //for unknown types we still store their extensions
+                // for unknown types we still store their extensions
                 unique[type.globalName] = type
 
                 let inheritanceClause = type.inheritedTypes.isEmpty ? "" :
                         ": \(type.inheritedTypes.joined(separator: ", "))"
 
-                Log.verbose("Found \"extension \(type.name)\(inheritanceClause)\" of type for which there is no original type declaration information.")
+                Log.warning("Found \"extension \(type.name)\(inheritanceClause)\" of type for which there is no original type declaration information.")
                 return
             }
 
@@ -120,14 +120,14 @@ public struct Composer {
 
         updateTypeRelationships(types: types)
         return (
-            types: types.sorted { $0.name < $1.name },
+            types: types.sorted { $0.globalName < $1.globalName },
             functions: functions.sorted { $0.name < $1.name },
             typealiases: typealiases.sorted(by: { $0.name < $1.name })
         )
     }
 
     private static func resolveType(typeName: TypeName, containingType: Type?, unique: [String: Type], modules: [String: [String: Type]], typealiases: [String: Typealias]) -> Type? {
-        let actualTypeName = self.actualTypeName(for: typeName, containingType: containingType, unique: unique, typealiases: typealiases)
+        let actualTypeName = self.actualTypeName(for: typeName, containingType: containingType, unique: unique, modules: modules, typealiases: typealiases)
         if let actualTypeName = actualTypeName, actualTypeName != typeName.unwrappedTypeName {
             typeName.actualTypeName = TypeName(actualTypeName)
         }
@@ -306,7 +306,7 @@ public struct Composer {
     }
 
     /// returns actual type name for type alias
-    private static func actualTypeName(for typeName: TypeName, containingType: Type? = nil, unique: [String: Type]? = nil, typealiases: [String: Typealias]) -> String? {
+    private static func actualTypeName(for typeName: TypeName, containingType: Type? = nil, unique: [String: Type]? = nil, modules: [String: [String: Type]], typealiases: [String: Typealias]) -> String? {
         let optionalPrefix = typeName.isOptional ? "?" : typeName.isImplicitlyUnwrappedOptional ? "!" : ""
         let unwrappedTypeName = typeName.unwrappedTypeName
         var actualTypeName: String?
@@ -339,10 +339,7 @@ public struct Composer {
                     }
 
                     if actualTypeName == nil {
-                        //check with module name
-                        if let module = containingType.module, let name = unique?["\(module).\(unwrappedTypeName)"]?.globalName {
-                            actualTypeName = name
-                        }
+                        actualTypeName = inferActualTypename(from: typeName, containedInType: containingType, uniqueTypes: unique ?? [:], modules: modules)
                     }
                     actualTypeName = actualTypeName ?? unwrappedTypeName
                 }
@@ -356,10 +353,10 @@ public struct Composer {
                 for element in elements {
                     let nameAndValue = element.colonSeparated().map({ $0.trimmingCharacters(in: .whitespaces) })
                     if nameAndValue.count == 1 {
-                        let valueName = self.actualTypeName(for: TypeName(nameAndValue[0]), containingType: containingType, unique: unique, typealiases: typealiases)
+                        let valueName = self.actualTypeName(for: TypeName(nameAndValue[0]), containingType: containingType, unique: unique, modules: modules, typealiases: typealiases)
                         actualElements.append(valueName ?? nameAndValue[0])
                     } else {
-                        let valueName = self.actualTypeName(for: TypeName(nameAndValue[1]), containingType: containingType, unique: unique, typealiases: typealiases)
+                        let valueName = self.actualTypeName(for: TypeName(nameAndValue[1]), containingType: containingType, unique: unique, modules: modules, typealiases: typealiases)
                         actualElements.append("\(nameAndValue[0]): \(valueName ?? nameAndValue[1])")
                     }
                 }
@@ -370,23 +367,23 @@ public struct Composer {
                     .map({ $0.trimmingCharacters(in: .whitespaces) })
                 if types.count == 1 {
                     //array literal
-                    let name = self.actualTypeName(for: TypeName(types[0]), containingType: containingType, unique: unique, typealiases: typealiases)
+                    let name = self.actualTypeName(for: TypeName(types[0]), containingType: containingType, unique: unique, modules: modules, typealiases: typealiases)
                     actualTypeName = "[\(name ?? types[0])]"
                 } else {
                     //dictionary literal
-                    let keyName = self.actualTypeName(for: TypeName(types[0]), containingType: containingType, unique: unique, typealiases: typealiases)
-                    let valueName = self.actualTypeName(for: TypeName(types[1]), containingType: containingType, unique: unique, typealiases: typealiases)
+                    let keyName = self.actualTypeName(for: TypeName(types[0]), containingType: containingType, unique: unique, modules: modules, typealiases: typealiases)
+                    let valueName = self.actualTypeName(for: TypeName(types[1]), containingType: containingType, unique: unique, modules: modules, typealiases: typealiases)
                     actualTypeName = "[\(keyName ?? types[0]): \(valueName ?? types[1])]"
                 }
             } else if let genericStartIndex = unwrappedTypeName.firstIndex(of: "<"), unwrappedTypeName.last == ">" {
                 let genericTypeNameString = String(unwrappedTypeName.prefix(upTo: genericStartIndex))
-                let genericTypeName = self.actualTypeName(for: TypeName(genericTypeNameString), containingType: containingType, unique: unique, typealiases: typealiases)
+                let genericTypeName = self.actualTypeName(for: TypeName(genericTypeNameString), containingType: containingType, unique: unique, modules: modules, typealiases: typealiases)
 
                 let typeParametersString = unwrappedTypeName.suffix(from: genericStartIndex).dropFirst().dropLast()
                 let typeParameters = String(typeParametersString).commaSeparated()
                 var actualTypeParameters = [String]()
                 for typeParameter in typeParameters {
-                    if let typeName = self.actualTypeName(for: TypeName(typeParameter), containingType: containingType, unique: unique, typealiases: typealiases) {
+                    if let typeName = self.actualTypeName(for: TypeName(typeParameter), containingType: containingType, unique: unique, modules: modules, typealiases: typealiases) {
                         actualTypeParameters.append(typeName)
                     } else {
                         actualTypeParameters.append(typeParameter)
@@ -398,6 +395,61 @@ public struct Composer {
         } else {
             return nil
         }
+    }
+
+    private static func inferActualTypename(from typename: TypeName, containedInType: Type?, uniqueTypes: [String: Type], modules: [String: [String: Type]]) -> String? {
+        let unwrappedTypeName = typename.unwrappedTypeName
+
+        func fullName(for module: String) -> String {
+            "\(module).\(unwrappedTypeName)"
+        }
+
+        func type(for module: String) -> Type? {
+            return modules[module]?[unwrappedTypeName]
+        }
+
+        func ambigiousErrorMessage(from types: [Type]) -> String? {
+            Log.warning("Ambigious type \(typename), found \(types.map { $0.globalName }.joined(separator: ", ")). Specify module name at declaration site to disambigutate.")
+            return nil
+        }
+
+        let explicitModulesAtDeclarationSite: [String] = [
+            containedInType?.module.map { [$0] } ?? [],    // main module for this typename
+            containedInType?.imports ?? []    // imported modules
+        ]
+        .flatMap { $0 }
+
+        let remainingModules = Set(modules.keys).subtracting(explicitModulesAtDeclarationSite)
+
+        /// We need to check whether we can find type in one of the modules but we need to be careful to avoid amibiguity
+        /// First checking explicit modules available at declaration site (so source module + all imported ones)
+        /// If there is no ambigiuity there we can assume that module will be resolved by the compiler
+        /// If that's not the case we look after remaining modules in the application and if the typename has no ambigiuity we use that
+        /// But if there is more than 1 typename duplication across modules we have no way to resolve what is the compiler going to use so we fail
+        let moduleSetsToCheck: [Array<String>] = [
+            explicitModulesAtDeclarationSite,
+            Array(remainingModules)
+        ]
+
+        for modules in moduleSetsToCheck {
+            let possibleTypes = modules
+                .compactMap { type(for: $0) }
+
+            if possibleTypes.count > 1 {
+                return ambigiousErrorMessage(from: possibleTypes)
+            }
+
+            if let type = possibleTypes.first {
+                return type.globalName
+            }
+        }
+
+        // as last result for unknown types / extensions
+        // try extracting type from unique array
+        if let module = containedInType?.module {
+            return uniqueTypes[fullName(for: module)]?.globalName
+        }
+        return nil
     }
 
     private static func typeFromModule(_ name: String, modules: [String: [String: Type]]) -> Type? {

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -1118,7 +1118,7 @@ class ParserComposerSpec: QuickSpec {
                     }
                 }
 
-                context("given type name with module name") {
+                context("given types within modules") {
                     func parseModules(_ modules: (name: String?, contents: String)...) -> [Type] {
                         let moduleResults = modules.compactMap {
                             try? FileParser(contents: $0.contents, module: $0.name).parse()
@@ -1133,144 +1133,202 @@ class ParserComposerSpec: QuickSpec {
                         return Composer.uniqueTypesAndFunctions(parserResult).types
                     }
 
-                    it("extends type with extension") {
-                        let expectedBar = Struct(name: "Bar", variables: [Variable(name: "foo", typeName: TypeName("Int"), accessLevel: (read: .none, write: .none), isComputed: true, definedInTypeName: TypeName("MyModule.Bar"))])
-                        expectedBar.module = "MyModule"
+                    context("when using global names") {
 
-                        let types = parseModules(
-                            (name: "MyModule", contents: "struct Bar {}"),
-                            (name: nil, contents: "extension MyModule.Bar { var foo: Int { return 0 } }")
-                        )
+                        it("extends type with extension") {
+                            let expectedBar = Struct(name: "Bar", variables: [Variable(name: "foo", typeName: TypeName("Int"), accessLevel: (read: .none, write: .none), isComputed: true, definedInTypeName: TypeName("MyModule.Bar"))])
+                            expectedBar.module = "MyModule"
 
-                        expect(types).to(equal([expectedBar]))
-                    }
+                            let types = parseModules(
+                                (name: "MyModule", contents: "struct Bar {}"),
+                                (name: nil, contents: "extension MyModule.Bar { var foo: Int { return 0 } }")
+                            )
 
-                    it("resolves variable type") {
-                        let expectedBar = Struct(name: "Bar")
-                        expectedBar.module = "MyModule"
-                        let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName("MyModule.Bar"), type: expectedBar, definedInTypeName: TypeName("Foo"))])
-
-                        let types = parseModules(
-                            (name: "MyModule", contents: "struct Bar {}"),
-                            (name: nil, contents: "struct Foo { var bar: MyModule.Bar }")
-                        )
-
-                        expect(types).to(equal([expectedBar, expectedFoo]))
-                        expect(types.last?.variables.first?.type).to(equal(expectedBar))
-                    }
-
-                    it("resolves variable defined in type") {
-                        let expectedBar = Struct(name: "Bar")
-                        expectedBar.module = "MyModule"
-                        let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName("MyModule.Bar"), type: expectedBar, definedInTypeName: TypeName("Foo"))])
-
-                        let types = parseModules(
-                            (name: "MyModule", contents: "struct Bar {}"),
-                            (name: nil, contents: "struct Foo { var bar: MyModule.Bar }")
-                        )
-
-                        expect(types).to(equal([expectedBar, expectedFoo]))
-                        expect(types.last?.variables.first?.type).to(equal(expectedBar))
-                        expect(types.last?.variables.first?.definedInType).to(equal(expectedFoo))
-                    }
-
-                    it("resolves variable type correctly") {
-                        let expectedBar = Struct(name: "Bar", variables: [
-                                                    Variable(name: "bat", typeName: TypeName("Int"), type: nil, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo.Bar"))
-                        ])
-                        expectedBar.module = "Foo"
-
-                        let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName("Bar"), type: expectedBar, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo"))], containedTypes: [expectedBar])
-                        expectedFoo.module = "Foo"
-
-                        let types = parseModules(
-                            (name: "Foo", contents:
-                                """
-                                struct Foo {
-                                    struct Bar {
-                                        let bat: Int
-                                    }
-                                    let bar: Bar
-                                }
-                                """
-                            ))
-
-                        expect(types).to(equal([expectedFoo, expectedBar]))
-
-                        let parsedFoo = types.first(where: { $0.globalName == "Foo.Foo" })
-                        expect(parsedFoo).to(equal(expectedFoo))
-                        expect(parsedFoo?.variables.first?.type).to(equal(expectedBar))
-                    }
-
-                    it("resolves variable type correctly when generics are used") {
-                        let expectedBar = Struct(name: "Bar", variables: [
-                            Variable(name: "batDouble", typeName: TypeName("Double"), type: nil, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo.Bar")),
-                            Variable(name: "batInt", typeName: TypeName("Int"), type: nil, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo.Bar"))
-                        ])
-                        expectedBar.module = "Foo"
-
-                        let expectedBaz = Struct(name: "Baz", isGeneric: true)
-                        expectedBaz.module = "Foo"
-
-                        let expectedFoo = Struct(name: "Foo", variables: [
-                            Variable(name: "bar", typeName: TypeName("Bar"), type: expectedBar, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo")),
-                            Variable(name: "bazbars", typeName: TypeName("Baz<Bar>", generic: .init(name: "Foo.Foo.Baz", typeParameters: [.init(typeName: .init("Foo.Foo.Bar"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo")),
-                            Variable(name: "bazDoubles", typeName: TypeName("Baz<Double>", generic: .init(name: "Foo.Foo.Baz", typeParameters: [.init(typeName: .init("Foo.Double"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo")),
-                            Variable(name: "bazInts", typeName: TypeName("Baz<Int>", generic: .init(name: "Foo.Foo.Baz", typeParameters: [.init(typeName: .init("Int"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo"))
-                        ], containedTypes: [expectedBar, expectedBaz])
-                        expectedFoo.module = "Foo"
-
-                        let expectedDouble = Type(name: "Double", accessLevel: .none, isExtension: true)
-                        expectedDouble.module = "Foo"
-
-                        let types = parseModules(
-                            (name: "Foo", contents:
-                                """
-                                extension Double {}
-                                struct Foo {
-                                        struct Bar {
-                                            let batDouble: Double
-                                            let batInt: Int
-                                        }
-
-                                        struct Baz<T> {
-                                        }
-
-                                        let bar: Bar
-                                        let bazbars: Baz<Bar>
-                                        let bazDoubles: Baz<Double>
-                                        let bazInts: Baz<Int>
-                                }
-                                """
-                            ))
-
-                        expect(types).to(equal([expectedDouble, expectedFoo, expectedBar, expectedBaz]))
-
-                        func check(variable: String, typeName: String?, type: String?, onType globalName: String) {
-                            let entity = types.first(where: { $0.globalName == globalName })
-                            expect(entity).toNot(beNil())
-
-                            let variable = entity?.allVariables.first(where: { $0.name == variable })
-                            expect(variable).toNot(beNil())
-                            if let typeName = typeName {
-                                expect(variable?.typeName.description).to(equal(typeName))
-                            } else {
-                                expect(variable?.typeName.description).to(beNil())
-                            }
-
-                            if let type = type {
-                                expect(variable?.type?.name).to(equal(type))
-                            } else {
-                                expect(variable?.type?.name).to(beNil())
-                            }
+                            expect(types).to(equal([expectedBar]))
                         }
 
-                        check(variable: "bar", typeName: "Bar", type: "Foo.Bar", onType: "Foo.Foo")
-                        check(variable: "bazbars", typeName: "Baz<Bar>", type: "Foo.Baz", onType: "Foo.Foo")
-                        check(variable: "bazDoubles", typeName: "Baz<Double>", type: "Foo.Baz", onType: "Foo.Foo")
-                        check(variable: "bazInts", typeName: "Baz<Int>", type: "Foo.Baz", onType: "Foo.Foo")
-                        check(variable: "batDouble", typeName: "Double", type: "Double", onType: "Foo.Foo.Bar")
-                        check(variable: "batInt", typeName: "Int", type: nil, onType: "Foo.Foo.Bar")
+                        it("resolves variable type") {
+                            let expectedBar = Struct(name: "Bar")
+                            expectedBar.module = "MyModule"
+                            let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName("MyModule.Bar"), type: expectedBar, definedInTypeName: TypeName("Foo"))])
+
+                            let types = parseModules(
+                                (name: "MyModule", contents: "struct Bar {}"),
+                                (name: nil, contents: "struct Foo { var bar: MyModule.Bar }")
+                            )
+
+                            expect(types).to(equal([expectedFoo, expectedBar]))
+                            expect(types.first?.variables.first?.type).to(equal(expectedBar))
+                        }
+
+                        it("resolves variable defined in type") {
+                            let expectedBar = Struct(name: "Bar")
+                            expectedBar.module = "MyModule"
+                            let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName("MyModule.Bar"), type: expectedBar, definedInTypeName: TypeName("Foo"))])
+
+                            let types = parseModules(
+                                (name: "MyModule", contents: "struct Bar {}"),
+                                (name: nil, contents: "struct Foo { var bar: MyModule.Bar }")
+                            )
+
+                            expect(types).to(equal([expectedFoo, expectedBar]))
+                            expect(types.first?.variables.first?.type).to(equal(expectedBar))
+                            expect(types.first?.variables.first?.definedInType).to(equal(expectedFoo))
+                        }
+                    }
+
+                    context("when using local names") {
+                        it("resolves variable type properly") {
+                            let expectedBarA = Struct(name: "Bar")
+                            expectedBarA.module = "ModuleA"
+
+                            let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName("Bar"), type: expectedBarA, definedInTypeName: TypeName("Foo"))])
+                            expectedFoo.module = "ModuleB"
+                            expectedFoo.imports = ["ModuleA"]
+
+                            let expectedBarC = Struct(name: "Bar")
+                            expectedBarC.module = "ModuleC"
+
+                            let types = parseModules(
+                                (name: "ModuleA", contents: "struct Bar {}"),
+                                (name: "ModuleB", contents:
+                                    """
+                                    import ModuleA
+                                    struct Foo { var bar: Bar }
+                                    """
+                                ),
+                                (name: "ModuleC", contents: "struct Bar {}")
+                            )
+
+                            expect(types).to(equal([expectedBarA, expectedFoo, expectedBarC]))
+                            expect(types.first(where: { $0.name == "Foo" })?.variables.first?.type).to(equal(expectedBarA))
+                        }
+
+                        it("throws error when variable type is ambigious") {
+                            let expectedBarA = Struct(name: "Bar")
+                            expectedBarA.module = "ModuleA"
+
+                            let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName("Bar"), type: expectedBarA, definedInTypeName: TypeName("Foo"))])
+                            expectedFoo.module = "ModuleB"
+
+                            let expectedBarC = Struct(name: "Bar")
+                            expectedBarC.module = "ModuleC"
+
+                            let types = parseModules(
+                                (name: "ModuleA", contents: "struct Bar {}"),
+                                (name: "ModuleB", contents:
+                                    """
+                                    struct Foo { var bar: Bar }
+                                    """
+                                ),
+                                (name: "ModuleC", contents: "struct Bar {}")
+                            )
+
+                            let barVariable = types.last?.variables.first
+
+                            expect(types).to(equal([expectedBarA, expectedFoo, expectedBarC]))
+                            expect(barVariable?.typeName).to(beNil())
+                            expect(barVariable?.type).to(beNil())
+                        }
+
+                        it("resolves variable type correctly") {
+                            let expectedBar = Struct(name: "Bar", variables: [
+                                                        Variable(name: "bat", typeName: TypeName("Int"), type: nil, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo.Bar"))
+                            ])
+                            expectedBar.module = "Foo"
+
+                            let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName("Bar"), type: expectedBar, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo"))], containedTypes: [expectedBar])
+                            expectedFoo.module = "Foo"
+
+                            let types = parseModules(
+                                (name: "Foo", contents:
+                                    """
+                                    struct Foo {
+                                        struct Bar {
+                                            let bat: Int
+                                        }
+                                        let bar: Bar
+                                    }
+                                    """
+                                ))
+
+                            expect(types).to(equal([expectedFoo, expectedBar]))
+
+                            let parsedFoo = types.first(where: { $0.globalName == "Foo.Foo" })
+                            expect(parsedFoo).to(equal(expectedFoo))
+                            expect(parsedFoo?.variables.first?.type).to(equal(expectedBar))
+                        }
+
+                        it("resolves variable type correctly when generics are used") {
+                            let expectedBar = Struct(name: "Bar", variables: [
+                                Variable(name: "batDouble", typeName: TypeName("Double"), type: nil, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo.Bar")),
+                                Variable(name: "batInt", typeName: TypeName("Int"), type: nil, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo.Bar"))
+                            ])
+                            expectedBar.module = "ModuleA"
+
+                            let expectedBaz = Struct(name: "Baz", isGeneric: true)
+                            expectedBaz.module = "ModuleA"
+
+                            let expectedFoo = Struct(name: "Foo", variables: [
+                                Variable(name: "bar", typeName: TypeName("Bar"), type: expectedBar, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo")),
+                                Variable(name: "bazbars", typeName: TypeName("Baz<Bar>", generic: .init(name: "ModuleA.Foo.Baz", typeParameters: [.init(typeName: .init("ModuleA.Foo.Bar"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo")),
+                                Variable(name: "bazDoubles", typeName: TypeName("Baz<Double>", generic: .init(name: "ModuleA.Foo.Baz", typeParameters: [.init(typeName: .init("ModuleA.Double"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo")),
+                                Variable(name: "bazInts", typeName: TypeName("Baz<Int>", generic: .init(name: "ModuleA.Foo.Baz", typeParameters: [.init(typeName: .init("Int"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName("Foo"))
+                            ], containedTypes: [expectedBar, expectedBaz])
+                            expectedFoo.module = "ModuleA"
+
+                            let expectedDouble = Type(name: "Double", accessLevel: .none, isExtension: true)
+                            expectedDouble.module = "ModuleA"
+
+                            let types = parseModules(
+                                (name: "ModuleA", contents:
+                                    """
+                                    extension Double {}
+                                    struct Foo {
+                                            struct Bar {
+                                                let batDouble: Double
+                                                let batInt: Int
+                                            }
+
+                                            struct Baz<T> {
+                                            }
+
+                                            let bar: Bar
+                                            let bazbars: Baz<Bar>
+                                            let bazDoubles: Baz<Double>
+                                            let bazInts: Baz<Int>
+                                    }
+                                    """
+                                ))
+
+                            expect(types).to(equal([expectedDouble, expectedFoo, expectedBar, expectedBaz]))
+
+                            func check(variable: String, typeName: String?, type: String?, onType globalName: String) {
+                                let entity = types.first(where: { $0.globalName == globalName })
+                                expect(entity).toNot(beNil())
+
+                                let variable = entity?.allVariables.first(where: { $0.name == variable })
+                                expect(variable).toNot(beNil())
+                                if let typeName = typeName {
+                                    expect(variable?.typeName.description).to(equal(typeName))
+                                } else {
+                                    expect(variable?.typeName.description).to(beNil())
+                                }
+
+                                if let type = type {
+                                    expect(variable?.type?.name).to(equal(type))
+                                } else {
+                                    expect(variable?.type?.name).to(beNil())
+                                }
+                            }
+
+                            check(variable: "bar", typeName: "Bar", type: "Foo.Bar", onType: "ModuleA.Foo")
+                            check(variable: "bazbars", typeName: "Baz<Bar>", type: "Foo.Baz", onType: "ModuleA.Foo")
+                            check(variable: "bazDoubles", typeName: "Baz<Double>", type: "Foo.Baz", onType: "ModuleA.Foo")
+                            check(variable: "bazInts", typeName: "Baz<Int>", type: "Foo.Baz", onType: "ModuleA.Foo")
+                            check(variable: "batDouble", typeName: "Double", type: "Double", onType: "ModuleA.Foo.Bar")
+                            check(variable: "batInt", typeName: "Int", type: nil, onType: "ModuleA.Foo.Bar")
+                        }
                     }
                 }
 


### PR DESCRIPTION
- `Self` reference is resolved to correct type. [Enchancement Request](https://github.com/krzysztofzablocki/Sourcery/issues/900)
- Sourcery will now attempt to resolve local type names across modules when it can be done without ambiguity. Previously we only supported fully qualified names. [Enchancement Request](https://github.com/krzysztofzablocki/Sourcery/issues/899)