### PR TITLE
Added hasPrefix and hasSuffix filters on String

### DIFF
--- a/Sourcery/Generating/Templates/Stencil/StencilTemplate.swift
+++ b/Sourcery/Generating/Templates/Stencil/StencilTemplate.swift
@@ -155,6 +155,13 @@ extension Stencil.Extension {
 
         let capitalise = FilterOr<String, TypeName>.make({ $0.capitalized }, other: { $0.name.capitalized })
         registerFilter("capitalise", filter: capitalise)
+
+        registerBoolFilterWithArguments("hasPrefix") { (string: String, argument: String) in
+            string.hasPrefix(argument)
+        }
+        registerBoolFilterWithArguments("hasSuffix") { (string: String, argument: String) in
+            string.hasSuffix(argument)
+        }
     }
 
     func registerFilterWithTwoArguments<T, A, B>(_ name: String, filter: @escaping (T, A, B) throws -> Any?) {


### PR DESCRIPTION
I have used Swiftgen quite a lot and I'm quite used to having `hasPrefix` and `hasSuffix` filters when using stencil templates. I thought it would be a good addition for Sourcery as well.