### PR TITLE
Fixes information being lost when extending unknown type more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Sourcery CHANGELOG
 
 ---
+
+## Master
+## Fixes
+- Fixes information being lost when extending unknown type more than once
+
 ## 1.3.2
 ## New Features
 - Configuration file now supports multiple configurations at once

--- a/SourceryFramework/Sources/Parsing/Composer.swift
+++ b/SourceryFramework/Sources/Parsing/Composer.swift
@@ -22,8 +22,8 @@ public enum Composer {
 
 
         // TODO: This logic should really be more complicated
-        // For any resolution we need to be looking at accesssLevel and module boundries
-        // e.g. there might be a typealias `private typealias Something = MyType` in one module and same name in another with public modifier, one could be acccesed and the other could not
+        // For any resolution we need to be looking at accessLevel and module boundaries
+        // e.g. there might be a typealias `private typealias Something = MyType` in one module and same name in another with public modifier, one could be accessed and the other could not
 
 
         var typeMap = [String: Type]()
@@ -104,7 +104,12 @@ public enum Composer {
 
                 // for unknown types we still store their extensions but mark them as unknown
                 type.isUnknownExtension = true
-                typeMap[type.globalName] = type
+                if let existingType = typeMap[type.globalName] {
+                    existingType.extend(type)
+                    typeMap[type.globalName] = existingType
+                } else {
+                    typeMap[type.globalName] = type
+                }
 
                 let inheritanceClause = type.inheritedTypes.isEmpty ? "" :
                     ": \(type.inheritedTypes.joined(separator: ", "))"

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -1687,6 +1687,33 @@ class ParserComposerSpec: QuickSpec {
                         expect(types.first?.globalName).to(equal("AnyPublisher"))
                     }
 
+                    it("combines unknown extensions from different files correctly") {
+                        let extensionType = Type(name: "AnyPublisher", isExtension: true, variables: [
+                        .init(name: "property1", typeName: .Int, accessLevel: (read: .internal, write: .none), isComputed: true, definedInTypeName: TypeName(name: "AnyPublisher")),
+                        .init(name: "property2", typeName: .String, accessLevel: (read: .internal, write: .none), isComputed: true, definedInTypeName: TypeName(name: "AnyPublisher"))
+                        ])
+                        extensionType.isUnknownExtension = true
+                        extensionType.module = "MyModule"
+
+                        let types = parseModules(
+                          (name: "MyModule", contents:
+                          """
+                          extension AnyPublisher {
+                            var property1: Int { 0 }
+                          }
+                          """),
+                          (name: "MyModule", contents:
+                          """
+                          extension AnyPublisher {
+                            var property2: String { "" }
+                          }
+                          """)
+                        ).types
+
+                        expect(types).to(equal([extensionType]))
+                        expect(types.first?.globalName).to(equal("AnyPublisher"))
+                    }
+
                     it("combines known types with extensions correctly") {
                         let fooType = Struct(name: "Foo", variables: [
                             .init(name: "property1", typeName: .Int, accessLevel: (read: .internal, write: .none), isComputed: true, definedInTypeName: TypeName(name: "Foo")),


### PR DESCRIPTION
Just a minor regression I've encountered while upgrading to 1.3.2 😊 