### PR TITLE
Added allImports property to Type class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Sourcery CHANGELOG
 
+- Added `allImports` property to `Type`, which returns all imports exited in all files containing this type and all its super classes/protocols.
+
 ---
 ## 1.3.4
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sourcery CHANGELOG
 
-- Added `allImports` property to `Type`, which returns all imports exited in all files containing this type and all its super classes/protocols.
+- Added `allImports` property to `Type`, which returns all imports existed in all files containing this type and all its super classes/protocols.
 
 ---
 ## 1.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Sourcery CHANGELOG
 
 - Added `allImports` property to `Type`, which returns all imports existed in all files containing this type and all its super classes/protocols.
+- Added `basedTypes` property to `Type`, which contains all Types this type inherits from or implements, including unknown (not scanned) types with extensions defined.
 
 ---
 ## 1.3.4

--- a/SourceryRuntime/Sources/AST/Type.swift
+++ b/SourceryRuntime/Sources/AST/Type.swift
@@ -20,17 +20,14 @@ public typealias AttributeList = [String: [Attribute]]
     // sourcery: skipEquality
     /// Imports existed in all files containing this type and all its super classes/protocols
     public var allImports: [Import] {
-        return Type.gatherAllImports(for: self).removingDuplicates()
+        return self.unique({ $0.gatherAllImports() }, filter: { $0 == $1 })
     }
 
-    private static func gatherAllImports(for type: Type) -> [Import] {
-        var allImports: [Import] = Array(type.imports)
-        let typesToScan = Array(type.implements.values)
-            + Array(type.inherits.values)
-            + Array(type.basedWithTypes.values)
+    private func gatherAllImports() -> [Import] {
+        var allImports: [Import] = Array(self.imports)
 
-        typesToScan.forEach { (typeToScan) in
-            allImports.append(contentsOf: Type.gatherAllImports(for: typeToScan))
+        self.basedTypes.values.forEach { (basedType) in
+            allImports.append(contentsOf: basedType.imports)
         }
         return allImports
     }
@@ -275,7 +272,7 @@ public typealias AttributeList = [String: [Attribute]]
 
     // sourcery: skipEquality, skipDescription
     /// Types this type inherits from or implements, including unknown (not scanned) types with extensions defined
-    public var basedWithTypes = [String: Type]()
+    public var basedTypes = [String: Type]()
 
     /// Types this type inherits from
     public var inherits = [String: Type]()
@@ -411,7 +408,7 @@ public typealias AttributeList = [String: [Attribute]]
             guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
             guard let inheritedTypes: [String] = aDecoder.decode(forKey: "inheritedTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inheritedTypes"])); fatalError() }; self.inheritedTypes = inheritedTypes
             guard let based: [String: String] = aDecoder.decode(forKey: "based") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["based"])); fatalError() }; self.based = based
-            guard let basedWithTypes: [String: Type] = aDecoder.decode(forKey: "basedWithTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["basedWithTypes"])); fatalError() }; self.basedWithTypes = basedWithTypes
+            guard let basedTypes: [String: Type] = aDecoder.decode(forKey: "basedTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["basedTypes"])); fatalError() }; self.basedTypes = basedTypes
             guard let inherits: [String: Type] = aDecoder.decode(forKey: "inherits") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inherits"])); fatalError() }; self.inherits = inherits
             guard let implements: [String: Type] = aDecoder.decode(forKey: "implements") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["implements"])); fatalError() }; self.implements = implements
             guard let containedTypes: [Type] = aDecoder.decode(forKey: "containedTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["containedTypes"])); fatalError() }; self.containedTypes = containedTypes
@@ -440,7 +437,7 @@ public typealias AttributeList = [String: [Attribute]]
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.inheritedTypes, forKey: "inheritedTypes")
             aCoder.encode(self.based, forKey: "based")
-            aCoder.encode(self.basedWithTypes, forKey: "basedWithTypes")
+            aCoder.encode(self.basedTypes, forKey: "basedTypes")
             aCoder.encode(self.inherits, forKey: "inherits")
             aCoder.encode(self.implements, forKey: "implements")
             aCoder.encode(self.containedTypes, forKey: "containedTypes")
@@ -462,11 +459,5 @@ extension Type {
     var isClass: Bool {
         let isNotClass = self is Struct || self is Enum || self is Protocol
         return !isNotClass && !isExtension
-    }
-}
-
-private extension Sequence where Element == Import {
-    func removingDuplicates() -> [Import] {
-        return Array(Set(self))
     }
 }

--- a/SourceryRuntime/Sources/AST/Type.swift
+++ b/SourceryRuntime/Sources/AST/Type.swift
@@ -16,6 +16,20 @@ public typealias AttributeList = [String: [Attribute]]
     /// Imports that existed in the file that contained this type declaration
     public var imports: [Import] = []
 
+    // sourcery: skipEquality
+    /// Imports existed in all files containing this type and all its super classes/protocols
+    public var allImports: [Import] {
+        return Array(Set(Type.gatherAllImports(for: self)))
+    }
+
+    private static func gatherAllImports(for type: Type) -> [Import] {
+        var allImports: [Import] = Array(type.imports)
+        type.implements.values.forEach { (inheritedType) in
+            allImports.append(contentsOf: Type.gatherAllImports(for: inheritedType))
+        }
+        return allImports
+    }
+
     // All local typealiases
     // sourcery: skipJSExport
     /// :nodoc:

--- a/SourceryRuntime/Sources/AST/Type.swift
+++ b/SourceryRuntime/Sources/AST/Type.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 
+/// :nodoc:
 public typealias AttributeList = [String: [Attribute]]
 
 /// Defines Swift type
@@ -60,8 +61,8 @@ public typealias AttributeList = [String: [Attribute]]
         return "\(parentName).\(localName)"
     }
 
-    /// Whether the type has been resolved as unknown extension
     // sourcery: skipCoding
+    /// Whether the type has been resolved as unknown extension
     public var isUnknownExtension: Bool = false
 
     // sourcery: skipDescription

--- a/SourceryRuntime/Sources/AST/Type.swift
+++ b/SourceryRuntime/Sources/AST/Type.swift
@@ -277,6 +277,7 @@ public typealias AttributeList = [String: [Attribute]]
     /// Types this type inherits from or implements, including unknown (not scanned) types with extensions defined
     public var basedWithTypes = [String: Type]()
 
+    /// Types this type inherits from
     public var inherits = [String: Type]()
 
     // sourcery: skipEquality, skipDescription

--- a/SourceryRuntime/Sources/Composer.swift
+++ b/SourceryRuntime/Sources/Composer.swift
@@ -675,6 +675,7 @@ public enum Composer {
             }
 
             baseType.based.keys.forEach { type.based[$0] = $0 }
+            baseType.basedWithTypes.forEach { type.basedWithTypes[$0.key] = $0.value }
             baseType.inherits.forEach { type.inherits[$0.key] = $0.value }
             baseType.implements.forEach { type.implements[$0.key] = $0.value }
 
@@ -693,6 +694,8 @@ public enum Composer {
                 // TODO: associated types?
                 type.implements[globalName] = baseType
             }
+
+            type.basedWithTypes[globalName] = baseType
         }
     }
 }

--- a/SourceryRuntime/Sources/Composer.swift
+++ b/SourceryRuntime/Sources/Composer.swift
@@ -675,7 +675,7 @@ public enum Composer {
             }
 
             baseType.based.keys.forEach { type.based[$0] = $0 }
-            baseType.basedWithTypes.forEach { type.basedWithTypes[$0.key] = $0.value }
+            baseType.basedTypes.forEach { type.basedTypes[$0.key] = $0.value }
             baseType.inherits.forEach { type.inherits[$0.key] = $0.value }
             baseType.implements.forEach { type.implements[$0.key] = $0.value }
 
@@ -695,7 +695,7 @@ public enum Composer {
                 type.implements[globalName] = baseType
             }
 
-            type.basedWithTypes[globalName] = baseType
+            type.basedTypes[globalName] = baseType
         }
     }
 }

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -5883,6 +5883,20 @@ public typealias AttributeList = [String: [Attribute]]
     /// Imports that existed in the file that contained this type declaration
     public var imports: [Import] = []
 
+    // sourcery: skipEquality
+    /// Imports existed in all files containing this type and all its super classes/protocols
+    public var allImports: [Import] {
+        return Array(Set(Type.gatherAllImports(for: self)))
+    }
+
+    private static func gatherAllImports(for type: Type) -> [Import] {
+        var allImports: [Import] = Array(type.imports)
+        type.implements.values.forEach { (inheritedType) in
+            allImports.append(contentsOf: Type.gatherAllImports(for: inheritedType))
+        }
+        return allImports
+    }
+
     // All local typealiases
     // sourcery: skipJSExport
     /// :nodoc:

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -1376,6 +1376,7 @@ public enum Composer {
             }
 
             baseType.based.keys.forEach { type.based[$0] = $0 }
+            baseType.basedWithTypes.forEach { type.basedWithTypes[$0.key] = $0.value }
             baseType.inherits.forEach { type.inherits[$0.key] = $0.value }
             baseType.implements.forEach { type.implements[$0.key] = $0.value }
 
@@ -1394,6 +1395,8 @@ public enum Composer {
                 // TODO: associated types?
                 type.implements[globalName] = baseType
             }
+
+            type.basedWithTypes[globalName] = baseType
         }
     }
 }
@@ -5886,13 +5889,17 @@ public typealias AttributeList = [String: [Attribute]]
     // sourcery: skipEquality
     /// Imports existed in all files containing this type and all its super classes/protocols
     public var allImports: [Import] {
-        return Array(Set(Type.gatherAllImports(for: self)))
+        return Type.gatherAllImports(for: self).removingDuplicates()
     }
 
     private static func gatherAllImports(for type: Type) -> [Import] {
         var allImports: [Import] = Array(type.imports)
-        type.implements.values.forEach { (inheritedType) in
-            allImports.append(contentsOf: Type.gatherAllImports(for: inheritedType))
+        let typesToScan = Array(type.implements.values)
+            + Array(type.inherits.values)
+            + Array(type.basedWithTypes.values)
+
+        typesToScan.forEach { (typeToScan) in
+            allImports.append(contentsOf: Type.gatherAllImports(for: typeToScan))
         }
         return allImports
     }
@@ -6136,7 +6143,9 @@ public typealias AttributeList = [String: [Attribute]]
     public var based = [String: String]()
 
     // sourcery: skipEquality, skipDescription
-    /// Types this type inherits from
+    /// Types this type inherits from or implements, including unknown (not scanned) types with extensions defined
+    public var basedWithTypes = [String: Type]()
+
     public var inherits = [String: Type]()
 
     // sourcery: skipEquality, skipDescription
@@ -6270,6 +6279,7 @@ public typealias AttributeList = [String: [Attribute]]
             guard let annotations: [String: NSObject] = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
             guard let inheritedTypes: [String] = aDecoder.decode(forKey: "inheritedTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inheritedTypes"])); fatalError() }; self.inheritedTypes = inheritedTypes
             guard let based: [String: String] = aDecoder.decode(forKey: "based") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["based"])); fatalError() }; self.based = based
+            guard let basedWithTypes: [String: Type] = aDecoder.decode(forKey: "basedWithTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["basedWithTypes"])); fatalError() }; self.basedWithTypes = basedWithTypes
             guard let inherits: [String: Type] = aDecoder.decode(forKey: "inherits") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["inherits"])); fatalError() }; self.inherits = inherits
             guard let implements: [String: Type] = aDecoder.decode(forKey: "implements") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["implements"])); fatalError() }; self.implements = implements
             guard let containedTypes: [Type] = aDecoder.decode(forKey: "containedTypes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["containedTypes"])); fatalError() }; self.containedTypes = containedTypes
@@ -6298,6 +6308,7 @@ public typealias AttributeList = [String: [Attribute]]
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.inheritedTypes, forKey: "inheritedTypes")
             aCoder.encode(self.based, forKey: "based")
+            aCoder.encode(self.basedWithTypes, forKey: "basedWithTypes")
             aCoder.encode(self.inherits, forKey: "inherits")
             aCoder.encode(self.implements, forKey: "implements")
             aCoder.encode(self.containedTypes, forKey: "containedTypes")
@@ -6319,6 +6330,12 @@ extension Type {
     var isClass: Bool {
         let isNotClass = self is Struct || self is Enum || self is Protocol
         return !isNotClass && !isExtension
+    }
+}
+
+private extension Sequence where Element == Import {
+    func removingDuplicates() -> [Import] {
+        return Array(Set(self))
     }
 }
 

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -5875,6 +5875,7 @@ extension Array where Element == TupleElement {
 
 import Foundation
 
+/// :nodoc:
 public typealias AttributeList = [String: [Attribute]]
 
 /// Defines Swift type
@@ -5930,8 +5931,8 @@ public typealias AttributeList = [String: [Attribute]]
         return "\\(parentName).\\(localName)"
     }
 
-    /// Whether the type has been resolved as unknown extension
     // sourcery: skipCoding
+    /// Whether the type has been resolved as unknown extension
     public var isUnknownExtension: Bool = false
 
     // sourcery: skipDescription

--- a/SourceryTests/Models/TypeSpec.swift
+++ b/SourceryTests/Models/TypeSpec.swift
@@ -184,10 +184,10 @@ class TypeSpec: QuickSpec {
                     let type = Type(name: "Foo", inheritedTypes: [superType.name])
                     let typeImports = [Import(path: "aModule"), Import(path: "bModule")]
                     type.imports = typeImports
-                    type.implements[superType.name] = superType
+                    type.basedTypes[superType.name] = superType
                     let expectedImports = [Import(path: "aModule"), Import(path: "bModule"), Import(path: "cModule")]
 
-                    expect(type.allImports.sortedByPath()).to(equal(expectedImports))
+                    expect(type.allImports.sorted { $0.path < $1.path }).to(equal(expectedImports))
                 }
             }
 
@@ -212,11 +212,5 @@ class TypeSpec: QuickSpec {
                 }
             }
         }
-    }
-}
-
-private extension Sequence where Element == Import {
-    func sortedByPath() -> [Import] {
-        return sorted { $0.path < $1.path }
     }
 }

--- a/SourceryTests/Models/TypeSpec.swift
+++ b/SourceryTests/Models/TypeSpec.swift
@@ -176,6 +176,21 @@ class TypeSpec: QuickSpec {
                 }
             }
 
+            describe("When accessing allImports property") {
+                it("returns correct imports after removing duplicates for type with a super type") {
+                    let superType = Type(name: "Bar")
+                    let superTypeImports = [Import(path: "cModule"), Import(path: "aModule")]
+                    superType.imports = superTypeImports
+                    let type = Type(name: "Foo", inheritedTypes: [superType.name])
+                    let typeImports = [Import(path: "aModule"), Import(path: "bModule")]
+                    type.imports = typeImports
+                    type.implements[superType.name] = superType
+                    let expectedImports = [Import(path: "aModule"), Import(path: "bModule"), Import(path: "cModule")]
+
+                    expect(type.allImports.sortedByPath()).to(equal(expectedImports))
+                }
+            }
+
             describe("When testing equality") {
                 context("given same items") {
                     it("is equal") {
@@ -197,5 +212,11 @@ class TypeSpec: QuickSpec {
                 }
             }
         }
+    }
+}
+
+private extension Sequence where Element == Import {
+    func sortedByPath() -> [Import] {
+        return sorted { $0.path < $1.path }
     }
 }


### PR DESCRIPTION
Added `allImports` property to `Type`, which returns all imports exited in all files containing this type and all its super classes/protocols.

**Example:**
In following scenario, `allImports` property for `SomeProtocol` type would return `["AModule", "BModule"]` removing duplicates if any.

```
File1.swift

import AModule

public protocol SomeProtocol: BaseProtocol {}
```
```
File2.swift

import AModule
import BModule

public protocol BaseProtocol {}
```