### PR TITLE
Fix file parsing for indirect enum cases with inline documentation

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/EnumCase+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/EnumCase+SwiftSyntax.swift
@@ -52,11 +52,7 @@ extension EnumCase {
         let indirect = parent
           .modifiers?
           .contains { modifier in
-              if modifier.description.trimmed == "indirect" {
-                  return true
-              }
-
-              return false
+              modifier.description.trimmed.hasSuffix("indirect")
           } ?? false
 
         self.init(

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -766,6 +766,24 @@ class FileParserSpec: QuickSpec {
                                             EnumCase(name: "optionC", associatedValues: [AssociatedValue(typeName: TypeName(name: "Foo"))], indirect: true)
                                         ])
                                 ]))
+                        expect(parse("""
+                                     enum Foo {
+                                         /// Option A
+                                         case optionA
+                                         /// Option B
+                                         case optionB
+                                         /// Option C
+                                         indirect case optionC(Foo)
+                                     }
+                                     """))
+                                .to(equal([
+                                    Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: [], cases:
+                                        [
+                                            EnumCase(name: "optionA", indirect: false),
+                                            EnumCase(name: "optionB"),
+                                            EnumCase(name: "optionC", associatedValues: [AssociatedValue(typeName: TypeName(name: "Foo"))], indirect: true)
+                                        ])
+                                ]))
                     }
 
                     it("extracts enums with Void associated type") {


### PR DESCRIPTION
**What version of Swift are you using (swift --version)?**
5.3.2

**What did you do?**
Generated enum code where the cases (some of which are `indirect`) had inline documentation.

**What did you expect to see?**
Expected `indirect` to be `true` in the appropriate `EnumCase`s.

**What did you see instead?**
`indirect` was always false for cases with inline documentation.

---

This change fixes file parsing for indirect enum cases that have inline documentation, like the following:

```swift
enum Foo {
    /// Option A
    case optionA

    /// Option B
    case optionB

    /// Option C
    indirect case optionC(Foo)
}
```

The problem is that the trimmed `modifier.description` in the `optionC` case contains the comment on the previous line, i.e. 

```swift
/// Option C\n    indirect
```

so the `indirect` property for the `optionC` `EnumCase` was coming back `false`.

---

One edge case that this fix doesn't address would be the following:

```swift
enum Bar {
    /// Better to be direct than indirect
    case assertive
}
```

I didn't test for this, but it's possible that the `EnumCase` for `assertive` could have an `indirect` value of `true`.