### PR TITLE
Fixes TypeName.isClosure to handle composed types correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed inferring raw value type from inherited types for enums with no cases or with associated values
 - Fixed access level of protocol members
 - Fixes parsing indirect enum cases correctly even when inline documentation is used
+- Fixes TypeName.isClosure to handle composed types correctly
 
 ## Internal changes
 - Removes manual parsing of `TypeName`, only explicit parser / configuration is now used

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/SyntaxTreeCollector.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/SyntaxTreeCollector.swift
@@ -270,6 +270,8 @@ class SyntaxTreeCollector: SyntaxVisitor {
 
     /// Extracts list of type names from composition e.g. `ProtocolA & ProtocolB`
     internal func extractComposedTypeNames(from value: String, trimmingCharacterSet: CharacterSet? = nil) -> [TypeName]? {
+        guard case let closureComponents = value.components(separatedBy: "->"),
+              closureComponents.count <= 1 else { return nil }
         guard case let components = value.components(separatedBy: CharacterSet(charactersIn: "&")),
               components.count > 1 else { return nil }
 

--- a/SourceryTests/Parsing/FileParser + TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser + TypeNameSpec.swift
@@ -20,6 +20,13 @@ class TypeNameSpec: QuickSpec {
                 return variable?.typeName ?? TypeName(name: "")
             }
 
+            func typeNameFromTypealias(_ code: String) -> TypeName {
+                let wrappedCode = "typealias Wrapper = \(code)"
+                guard let parser = try? makeParser(for: wrappedCode) else { fail(); return TypeName(name: "") }
+                let result = try? parser.parse()
+                return result?.typealiases.first?.typeName ?? TypeName(name: "")
+            }
+
             context("given optional type with short syntax") {
                 it("reports optional true") {
                     expect(typeName("Int?").isOptional).to(beTrue())
@@ -120,6 +127,8 @@ class TypeNameSpec: QuickSpec {
                     expect(typeName("(Int) -> Foo<Bool>").isClosure).to(beTrue())
                     expect(typeName("(Foo<String>) -> Foo<Bool>").isClosure).to(beTrue())
                     expect(typeName("((Int, Int) -> (), Int)").isClosure).to(beFalse())
+                    expect(typeNameFromTypealias("(Foo) -> Bar").isClosure).to(beTrue())
+                    expect(typeNameFromTypealias("(Foo) -> Bar & Baz").isClosure).to(beTrue())
                 }
 
                 it("reports optional status correctly") {


### PR DESCRIPTION
Scenario:
`typealias SomeType = (Foo) -> Bar & Baz`

Expected:
`TypeName.isClosure` should return true

Actual:
`TypeName.isClosure` returns false