### PR TITLE
Use modifiers to determine `isFinal`

### DIFF
--- a/SourceryRuntime/Sources/AST/Class.swift
+++ b/SourceryRuntime/Sources/AST/Class.swift
@@ -8,7 +8,7 @@ import Foundation
 
     /// Whether type is final 
     public var isFinal: Bool {
-        return attributes[Attribute.Identifier.final.name] != nil
+        return modifiers.first { $0.name == "final" } != nil
     }
 
     /// :nodoc:

--- a/SourceryRuntime/Sources/AST/Method.swift
+++ b/SourceryRuntime/Sources/AST/Method.swift
@@ -299,7 +299,7 @@ extension Array where Element == ClosureParameter {
     // sourcery: skipEquality, skipDescription
     /// Whether method is final
     public var isFinal: Bool {
-        return attributes[Attribute.Identifier.final.name] != nil
+        return modifiers.first { $0.name == "final" } != nil
     }
 
     // sourcery: skipEquality, skipDescription

--- a/SourceryRuntime/Sources/AST/Subscript.swift
+++ b/SourceryRuntime/Sources/AST/Subscript.swift
@@ -38,7 +38,7 @@ import Foundation
 
     /// Whether method is final
     public var isFinal: Bool {
-        return attributes[Attribute.Identifier.final.name] != nil
+        return modifiers.first { $0.name == "final" } != nil
     }
 
     /// Variable read access level, i.e. `internal`, `private`, `fileprivate`, `public`, `open`

--- a/SourceryRuntime/Sources/AST/Variable.swift
+++ b/SourceryRuntime/Sources/AST/Variable.swift
@@ -59,7 +59,7 @@ public typealias SourceryVariable = Variable
 
     /// Whether variable is final or not
     public var isFinal: Bool {
-        return attributes[Attribute.Identifier.final.name] != nil
+        return modifiers.first { $0.name == "final" } != nil
     }
 
     /// Whether variable is lazy or not


### PR DESCRIPTION
isFinal is no longer part of the parsed attributes but is instead classified as a modifier.

This fixes that.

I can't find good information on the repository about steps to take to write a test that is functional or how to update other documentation required. If you can provide any information about how to write a test for the project or other documentation that needs to be updated happy to help.
