### PR TITLE
Fix test by updating expected result on macOS 11.3 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Sourcery CHANGELOG
 
 ---
+## 1.4.2
+
+## Fixes
+- Fix a test failing on macOS 11.3
+
+---
 ## 1.4.1
 
 ## New Feature

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -187,7 +187,11 @@ class SwiftTemplateTests: QuickSpec {
                     try Generator.generate(.init(path: nil, module: nil, types: [], functions: []), types: Types(types: []), functions: [], template: SwiftTemplate(path: templatePath))
                     }
                     .to(throwError(closure: { (error) in
-                        expect("\(error)").to(contain("\(templatePath): Fatal error: Index out of range"))
+                        if #available(macOS 11.3, *) {
+                            expect("\(error)").to(contain("\(templatePath): Swift/ContiguousArrayBuffer.swift:580: Fatal error: Index out of range"))
+                        } else {
+                            expect("\(error)").to(contain("\(templatePath): Fatal error: Index out of range"))
+                        }
                     }))
             }
 


### PR DESCRIPTION
It seems, format of exception strings has changed in Swift 5.4.