### PR TITLE
Fix: inline:auto annotations can be inserted at wrong locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Fixes
 - Fix a test failing on macOS 11.3
+- Fix generation of inline:auto annotations in files with other inline annotations.
 
 ---
 ## 1.4.1

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -719,7 +719,7 @@ class SourcerySpecTests: QuickSpec {
                         expect(newResult).to(equal(expectedResult))
                     }
 
-                    it("inserts generated code from different templates (inline and inline:auto)") {
+                    it("inserts generated code from different templates (both inline)") {
                         let templatePathA = outputDir + Path("InlineTemplateA.stencil")
                         let templatePathB = outputDir + Path("InlineTemplateB.stencil")
                         let sourcePath = outputDir + Path("ClassWithMultipleInlineAnnotations.swift")
@@ -782,10 +782,19 @@ class SourcerySpecTests: QuickSpec {
                         expect(result).to(equal(expectedResult))
                     }
 
-                    it("inserts generated code from different templates (both inline)") {
+                    it("inserts generated code from different templates (inline and inline:auto)") {
                         let templatePathA = outputDir + Path("InlineTemplateA.stencil")
                         let templatePathB = outputDir + Path("InlineTemplateB.stencil")
                         let sourcePath = outputDir + Path("ClassWithMultipleInlineAnnotations.swift")
+
+                        /*
+                         inline:auto annotations are inserted at the beginning of the last line of a declaration,
+                         OR at the beginning of the last line of the containing file,
+                         if proposed location out of bounds, which should not be.
+
+                         To differentiate such cases the last line of a declaration
+                         shall not be the last line of the file.
+                         */
 
                         update(code: """
                                      class ClassWithMultipleInlineAnnotations {
@@ -793,6 +802,7 @@ class SourcerySpecTests: QuickSpec {
                                      var a0: Int
                                      // sourcery:end
                                      }
+                                     // the last line of the file
                                      """, in: sourcePath)
 
                         update(code: """
@@ -835,6 +845,7 @@ class SourcerySpecTests: QuickSpec {
                                              var b2: Int
                                              // sourcery:end
                                              }
+                                             // the last line of the file
                                              """
 
                         let result = try? sourcePath.read(.utf8)


### PR DESCRIPTION
It turns out, it was important too:
https://github.com/krzysztofzablocki/Sourcery/pull/930/files#diff-7f4054a27fafedc450c7c113e7721ea126d50a26acef361f51b328649f1a3247R29.

Since inline annotation bodies replaced with padding of the same length, a change for `bodyBytesRange` and `completeDeclarationRange` must be calculated the same way as for inline annotations.