### PR TITLE
Adds hasSetter property to Variable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Sourcery CHANGELOG
 
 ---
+## 1.4.3
+
+## Fixes
+
+## New Feature
+- Added new `hasSetter` property to `Variable`.
+
+---
 ## 1.4.2
 
 ## Fixes

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Variable+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Variable+SwiftSyntax.swift
@@ -58,6 +58,7 @@ extension Variable {
           accessLevel: (read: readAccess, write: isWritable ? writeAccess : .none),
           isComputed: isComputed,
           isStatic: isStatic,
+          hasSetter: hadSetter,
           defaultValue: node.initializer?.value.description.trimmingCharacters(in: .whitespacesAndNewlines),
           attributes: Attribute.from(variableNode.attributes),
           modifiers: modifiers.map(SourceryModifier.init),

--- a/SourceryRuntime/Sources/AST/Variable.swift
+++ b/SourceryRuntime/Sources/AST/Variable.swift
@@ -44,6 +44,9 @@ public typealias SourceryVariable = Variable
     public var isMutable: Bool {
         return writeAccess != AccessLevel.none.rawValue
     }
+    
+    /// Whether variable has both a setter and getter
+    public var hasSetter: Bool
 
     /// Variable default value expression
     public var defaultValue: String?
@@ -88,6 +91,7 @@ public typealias SourceryVariable = Variable
                 accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
                 isComputed: Bool = false,
                 isStatic: Bool = false,
+                hasSetter: Bool = false,
                 defaultValue: String? = nil,
                 attributes: AttributeList = [:],
                 modifiers: [SourceryModifier] = [],
@@ -99,6 +103,7 @@ public typealias SourceryVariable = Variable
         self.type = type
         self.isComputed = isComputed
         self.isStatic = isStatic
+        self.hasSetter = hasSetter
         self.defaultValue = defaultValue
         self.readAccess = accessLevel.read.rawValue
         self.writeAccess = accessLevel.write.rawValue
@@ -119,6 +124,7 @@ public typealias SourceryVariable = Variable
             self.isStatic = aDecoder.decode(forKey: "isStatic")
             guard let readAccess: String = aDecoder.decode(forKey: "readAccess") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["readAccess"])); fatalError() }; self.readAccess = readAccess
             guard let writeAccess: String = aDecoder.decode(forKey: "writeAccess") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["writeAccess"])); fatalError() }; self.writeAccess = writeAccess
+            self.hasSetter = aDecoder.decode(forKey: "hasSetter")
             self.defaultValue = aDecoder.decode(forKey: "defaultValue")
             guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["annotations"])); fatalError() }; self.annotations = annotations
             guard let attributes: AttributeList = aDecoder.decode(forKey: "attributes") else { NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: getVaList(["attributes"])); fatalError() }; self.attributes = attributes
@@ -136,6 +142,7 @@ public typealias SourceryVariable = Variable
             aCoder.encode(self.isStatic, forKey: "isStatic")
             aCoder.encode(self.readAccess, forKey: "readAccess")
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
+            aCoder.encode(self.hasSetter, forKey: "hasSetter")
             aCoder.encode(self.defaultValue, forKey: "defaultValue")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.attributes, forKey: "attributes")

--- a/SourceryTests/Parsing/FileParser + VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser + VariableSpec.swift
@@ -59,6 +59,13 @@ class FileParserVariableSpec: QuickSpec {
                     expect(variable("private(set) var name: String")?.isMutable).to(beTrue())
                     expect(variable("var name: String { return \"\" }")?.isMutable).to(beFalse())
                 }
+                
+                it("reports variable has a setter") {
+                    expect(variable("var name: String { get { return \"Test\" } set { newValue } }")?.hasSetter).to(beTrue())
+                    expect(variable("var name: String { get { return \"Test\" } }")?.hasSetter).to(beFalse())
+                    expect(variable("var name: String = \"\"")?.hasSetter).to(beFalse())
+                    expect(variable("var name: String")?.hasSetter).to(beFalse())
+                }
 
                 it("extracts standard property correctly") {
                     expect(variable("var name: String")).to(equal(Variable(name: "name", typeName: TypeName(name: "String"), accessLevel: (read: .internal, write: .internal), isComputed: false)))


### PR DESCRIPTION
I've added a new property to the `Variable` type to tell when a variable is a property that has a setter implemented. The need arose while I was implementing my custom AutoMockable template where the setter for a property in a mock implementation is only generated if `set` is specified in the protocol declaration.

Note: In the AutoMockable template included with Sourcery will generate a getter and setter implementation for any non-optional property in a protocol regardless of how it is declared.

For example if you declare the following protocol:
```
// sourcery: AutoMockable
protocol Foo {
    var bar: String { get }
}
```

I want my mock class output to be this:
```
final class MockFoo: Foo {
    var bar: String {
        get { return underlyingValueBar }
    }
    var underlyingValueBar: String!
}
```