### PR TITLE
Support for trailing line annotations

### DIFF
--- a/SourceryTests/Parsing/FileParser + VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser + VariableSpec.swift
@@ -295,6 +295,14 @@ class FileParserVariableSpec: QuickSpec {
                                                            "var name: Int { return 2 }")
                         expect(result).to(equal(expectedVariable))
                     }
+                    
+                    it("extracts trailing annotations") {
+                        let expectedVariable = Variable(name: "name", typeName: TypeName(name: "Int"), accessLevel: (read: .internal, write: .none), isComputed: true)
+                        expectedVariable.annotations["jsonKey"] = "json_key" as NSString
+                        expectedVariable.annotations["skipEquability"] = NSNumber(value: true)
+
+                        expect(variable("// sourcery: jsonKey = \"json_key\"\nvar name: Int { return 2 } // sourcery: skipEquability")).to(equal(expectedVariable))
+                    }
                 }
             }
         }

--- a/SourceryTests/Parsing/Helpers/AnnotationsParserSpec.swift
+++ b/SourceryTests/Parsing/Helpers/AnnotationsParserSpec.swift
@@ -92,6 +92,21 @@ class AnnotationsParserSpec: QuickSpec {
                     expect(result).to(equal(annotations))
                 }
 
+                it("extracts end of line annotations") {
+                    let result = parse("// sourcery: first = 1 \n let property: Int // sourcery: second = 2, third = \"three\"")
+                    expect(result).to(equal(["first": NSNumber(value: 1), "second": NSNumber(value: 2), "third": "three" as NSString]))
+                }
+
+                it("extracts end of line block comment annotations") {
+                    let result = parse("// sourcery: first = 1 \n let property: Int /* sourcery: second = 2, third = \"three\" */ // comment")
+                    expect(result).to(equal(["first": NSNumber(value: 1), "second": NSNumber(value: 2), "third": "three" as NSString]))
+                }
+
+                it ("ignores annotations in string literals") {
+                    let result = parse("// sourcery: first = 1 \n let property = \"// sourcery: second = 2\" // sourcery: third = 3")
+                    expect(result).to(equal(["first": NSNumber(value: 1), "third": NSNumber(value: 3)]))
+                }
+
                 it("extracts file annotations") {
                     let annotations = ["isSet": NSNumber(value: true)]
 

--- a/guides/Writing templates.md
+++ b/guides/Writing templates.md
@@ -101,6 +101,13 @@ Sourcery supports annotating your classes and variables with special annotations
 var precomputedHash: Int
 ```
 
+You can also add attributes to the end of a line of code:
+
+```swift
+var firstVariable: Int // default = 1
+var secondVariable: Int // default = 2
+```
+
 If you want to attribute multiple items with same attributes, you can use section annotations `sourcery:begin` and `sourcery:end`:
 
 ```swift
@@ -132,7 +139,8 @@ This will effectively annotate with `decoding.key` and `decoding.default` annota
 - Multiple annotations values with the same key are merged into array
 - You can interleave annotations with documentation
 - Sourcery scans all `sourcery:` annotations in the given comment block above the source until first non-comment/doc line
-- Using `/*` and `*/` for annotation comment you can put it on the same line with your code. This is useful for annotating methods parameters and enum case associated values. All such annotations should be placed in one comment block. Do not mix inline and regular annotations for the same declaration (using inline and block annotations is fine)!
+- Annotations at the end of a line will be applied to all declarations on the same line
+- Using `/*` and `*/` for annotation comment you can put annotations on the same line preceding your declaration. This is useful for annotating methods parameters and enum case associated values. All such annotations should be placed in one comment block. Do not mix inline and regular annotations for the same declaration (using inline and block annotations is fine)!
 
 #### Format:
 


### PR DESCRIPTION
Add support for annotations at the end of a line of code - see #965 

For example:

```
let number: Int // sourcery: first = 1
```
or
```
enum Foo {
    case bar /* sourcery: first = "value" */
}
```

If there are multiple declarations on the same line, they will all inherit the annotation:
```
let one: Int, two: Int // sourcery: default = 1
```

I'm open to any thoughts or feedback - thanks!
