### PR TITLE
Fix unintentionally losing attributes of closures inside extra optional closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - corrects `isMutable` regression on protocol variables #964
 - Added multiple targets to link
 - Fix groups creation
+- Fix unintentionally losing attributes of closures inside extra optional closure #974
 
 ---
 ## 1.4.2

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -65,7 +65,7 @@ extension TypeName {
         } else if let typeIdentifier = node.as(OptionalTypeSyntax.self) {
             let type = TypeName(typeIdentifier.wrappedType)
             let needsWrapping = type.isClosure || type.isProtocolComposition
-            self.init(name: needsWrapping ? "(\(type.name))" : type.name,
+            self.init(name: needsWrapping ? "(\(type.asSource))" : type.asSource,
                       isOptional: true,
                       isImplicitlyUnwrappedOptional: false,
                       tuple: type.tuple,

--- a/SourceryTests/Parsing/FileParser + TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser + TypeNameSpec.swift
@@ -72,8 +72,10 @@ class TypeNameSpec: QuickSpec {
                     expect(typeName("((Int, Int) -> ())").unwrappedTypeName).to(equal("(Int, Int) -> ()"))
                 }
                 
-                it("keeps wrapped closure's attributes") {
+                it("deals with wrapped closure's attributes correctly") {
                     expect(typeName("(@convention(c) () -> ())?").unwrappedTypeName).to(equal("(@convention(c) () -> ())"))
+                    expect(typeName("((@convention(c) () -> ()))?").unwrappedTypeName).to(equal("(@convention(c) () -> ())"))
+                    expect(typeName("(((@convention(c) () -> ())))?").unwrappedTypeName).to(equal("(@convention(c) () -> ())"))
                 }
             }
 
@@ -165,6 +167,9 @@ class TypeNameSpec: QuickSpec {
 
             it("removes attributes in unwrappedTypeName") {
                 expect(typeName("@escaping (@escaping ()->())->()").unwrappedTypeName).to(equal("(@escaping () -> ()) -> ()"))
+                expect(typeName("(@escaping (@escaping ()->())->())").unwrappedTypeName).to(equal("(@escaping () -> ()) -> ()"))
+                expect(typeName("((@escaping (@escaping ()->())->()))").unwrappedTypeName).to(equal("(@escaping () -> ()) -> ()"))
+                expect(typeName("(((@escaping (@escaping ()->())->())))").unwrappedTypeName).to(equal("(@escaping () -> ()) -> ()"))
             }
         }
     }

--- a/SourceryTests/Parsing/FileParser + TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser + TypeNameSpec.swift
@@ -71,6 +71,10 @@ class TypeNameSpec: QuickSpec {
                     expect(typeName("((Int, Int))").unwrappedTypeName).to(equal("(Int, Int)"))
                     expect(typeName("((Int, Int) -> ())").unwrappedTypeName).to(equal("(Int, Int) -> ()"))
                 }
+                
+                it("keeps wrapped closure's attributes") {
+                    expect(typeName("(@convention(c) () -> ())?").unwrappedTypeName).to(equal("(@convention(c) () -> ())"))
+                }
             }
 
             context("given tuple type") {


### PR DESCRIPTION
This PR fixes #974.

For example, when parsing this type:
`(@convention(c) () -> ())?`

The old behavior of unwrapping it turns into `(() -> ())`.

The new behavior now retains the attributes as well as follow existing closure behavior `(@convention(c) () -> ())`.