### PR TITLE
Thin lib_InternalSwiftSyntaxParser.dylib in `rake build`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,8 @@ task :build do
   sh %Q(rm -fr #{CLI_DIR})
   sh %Q(mkdir -p "#{CLI_DIR}bin")
   sh %Q(mkdir -p "#{CLI_DIR}lib")
-  sh %Q(lipo -thin #{Hardware::CPU.arch} lib_InternalSwiftSyntaxParser.dylib -output #{CLI_DIR}lib/lib_InternalSwiftSyntaxParser.dylib)
+  ARCH = `uname -m`.chomp
+  sh %Q(lipo -thin #{ARCH} lib_InternalSwiftSyntaxParser.dylib -output #{CLI_DIR}lib/lib_InternalSwiftSyntaxParser.dylib)
   sh %Q(cp SourceryJS/Resources/ejs.js #{CLI_DIR}bin)
   `mv #{BUILD_DIR}release/sourcery #{CLI_DIR}bin/`
   #`mv #{BUILD_DIR}release/Sourcery_SourceryJS.bundle #{CLI_DIR}lib/`

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :build do
   sh %Q(rm -fr #{CLI_DIR})
   sh %Q(mkdir -p "#{CLI_DIR}bin")
   sh %Q(mkdir -p "#{CLI_DIR}lib")
-  sh %Q(cp lib_InternalSwiftSyntaxParser.dylib #{CLI_DIR}lib)
+  sh %Q(lipo -thin #{Hardware::CPU.arch} lib_InternalSwiftSyntaxParser.dylib -output #{CLI_DIR}lib/lib_InternalSwiftSyntaxParser.dylib)
   sh %Q(cp SourceryJS/Resources/ejs.js #{CLI_DIR}bin)
   `mv #{BUILD_DIR}release/sourcery #{CLI_DIR}bin/`
   #`mv #{BUILD_DIR}release/Sourcery_SourceryJS.bundle #{CLI_DIR}lib/`


### PR DESCRIPTION
`lipo` invalidates the signature but I think that shouldn't matter if the file doesn't have the quarantine attribute. I don't have my Mac with me ATM, so make sure to check that before merging/releasing.

~~edit: also I don't know how to get the current architecture inside the Rakefile~~

edit 2: `lib_InternalSwiftSyntaxParser.dylib` probably has the `linker-signed` flag, which should result in any operations breaking the signature to resign it.