### PR TITLE
Corrects args name in the writing-templates doc

### DIFF
--- a/docs/writing-templates.html
+++ b/docs/writing-templates.html
@@ -220,7 +220,7 @@
 <ul>
 <li><code>types: Types</code> - access collections of types, i.e. <code>types.implementing.AutoCoding</code> (<code>types.implementing[&quot;AutoCoding&quot;]</code> in swift templates). See <a href="https://cdn.rawgit.com/krzysztofzablocki/Sourcery/master/docs/Classes/Types.html">Types</a>.</li>
 <li><code>type: [String: Type]</code> - access types by their names, i.e. <code>type.MyType</code> (<code>type[&quot;MyType&quot;]</code> in swift templates)</li>
-<li><code>arguments: [String: NSObject]</code> - access additional parameters passed with <code>--args</code> command line flag or set in <code>.sourcery.yml</code> file</li>
+<li><code>argument: [String: NSObject]</code> - access additional parameters passed with <code>--args</code> command line flag or set in <code>.sourcery.yml</code> file</li>
 </ul>
 
 <blockquote>


### PR DESCRIPTION
Previously, it was documented as "arguments" but it's implemented as "argument".