### PR TITLE
Update Type.uniqueMethodFilter(_:_:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sourcery CHANGELOG
 
+## 1.5.1
+## Fixes
+- Fixing `Type.uniqueMethodFilter(_:_:)` so it compares return types of methods as well.
+
 ## 1.5.0
 ## Features
 - Adds support for variadic parameters in functions

--- a/SourceryRuntime/Sources/AST/Type.swift
+++ b/SourceryRuntime/Sources/AST/Type.swift
@@ -128,7 +128,7 @@ public typealias AttributeList = [String: [Attribute]]
     }
 
     private static func uniqueMethodFilter(_ lhs: Method, rhs: Method) -> Bool {
-        return lhs.name == rhs.name && lhs.isStatic == rhs.isStatic && lhs.isClass == rhs.isClass
+        return lhs.name == rhs.name && lhs.isStatic == rhs.isStatic && lhs.isClass == rhs.isClass && lhs.actualReturnTypeName == rhs.actualReturnTypeName
     }
 
     // sourcery: skipEquality, skipDescription

--- a/SourceryTests/Models/TypeSpec.swift
+++ b/SourceryTests/Models/TypeSpec.swift
@@ -17,6 +17,7 @@ class TypeSpec: QuickSpec {
             let storedVariable = Variable(name: "otherVariable", typeName: TypeName(name: "Int"), isComputed: false)
             let supertypeVariable = Variable(name: "supertypeVariable", typeName: TypeName(name: "Int"), isComputed: true)
             let superTypeMethod = Method(name: "doSomething()", definedInTypeName: TypeName(name: "Protocol"))
+            let secondMethod = Method(name: "doSomething()", returnTypeName: TypeName(name: "Int"))
             let overrideMethod = superTypeMethod
             let overrideVariable = supertypeVariable
             let initializer = Method(name: "init()", definedInTypeName: TypeName(name: "Foo"))
@@ -26,7 +27,7 @@ class TypeSpec: QuickSpec {
             superType.implements["Protocol"] = protocolType
 
             beforeEach {
-                sut = Type(name: "Foo", parent: parentType, variables: [storedVariable, computedVariable, staticVariable, overrideVariable], methods: [initializer, overrideMethod], inheritedTypes: ["NSObject"], annotations: ["something": NSNumber(value: 161)])
+                sut = Type(name: "Foo", parent: parentType, variables: [storedVariable, computedVariable, staticVariable, overrideVariable], methods: [initializer, overrideMethod, secondMethod], inheritedTypes: ["NSObject"], annotations: ["something": NSNumber(value: 161)])
                 sut?.supertype = superType
             }
 
@@ -71,7 +72,7 @@ class TypeSpec: QuickSpec {
             }
 
             it("flattens methods from supertype") {
-                expect(sut?.allMethods).to(equal([initializer, overrideMethod]))
+                expect(sut?.allMethods).to(equal([initializer, overrideMethod, secondMethod]))
             }
 
             it("flattens variables from supertype") {
@@ -140,7 +141,7 @@ class TypeSpec: QuickSpec {
 
                     sut?.extend(type)
 
-                    expect(sut?.methods).to(equal([initializer, overrideMethod, extraMethod]))
+                    expect(sut?.methods).to(equal([initializer, overrideMethod, secondMethod, extraMethod]))
                 }
 
                 it("does not duplicate methods with protocol extension") {
@@ -199,7 +200,7 @@ class TypeSpec: QuickSpec {
             describe("When testing equality") {
                 context("given same items") {
                     it("is equal") {
-                        expect(sut).to(equal(Type(name: "Foo", parent: parentType, accessLevel: .internal, isExtension: false, variables: [storedVariable, computedVariable, staticVariable, overrideVariable], methods: [initializer, overrideMethod], inheritedTypes: ["NSObject"], annotations: ["something": NSNumber(value: 161)])))
+                        expect(sut).to(equal(Type(name: "Foo", parent: parentType, accessLevel: .internal, isExtension: false, variables: [storedVariable, computedVariable, staticVariable, overrideVariable], methods: [initializer, overrideMethod, secondMethod], inheritedTypes: ["NSObject"], annotations: ["something": NSNumber(value: 161)])))
                     }
                 }
 


### PR DESCRIPTION
I was facing an issue where I had two methods with the same name but they had different return types but `type.allMethods` would only list one of them (the first) and `Type.uniqueMethodFilter(_:_:)` seems to be the culprit, since it's not checking the return types.

An example of what I was doing:
```
protocol MyProtocol: AutoMockable {

    // Sync version
    func method() -> Element?

    // Async version
    func method() -> Observable<Element>
}
```
Then, in the stencil if you call:
```
{{ type.allMethods }}
```
You'll notice that just the first declaration is listed, because both methods have the same name, but have different return types (which Swift allows to)