### PR TITLE
Orders TypeName attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sourcery CHANGELOG
 
+## 1.5.2
+## Fixes
+- Fixes unstable ordering of `TypeName.attributes` 
+
 ## 1.5.1
 ## Fixes
 - Fixing `Type.uniqueMethodFilter(_:_:)` so it compares return types of methods as well.

--- a/SourceryRuntime/Sources/AST/TypeName/TypeName.swift
+++ b/SourceryRuntime/Sources/AST/TypeName/TypeName.swift
@@ -132,7 +132,7 @@ import Foundation
         let specialTreatment = isOptional && name.hasPrefix("Optional<")
 
         var description = (
-          attributes.flatMap({ $0.value }).map({ $0.asSource }) +
+          attributes.flatMap({ $0.value }).map({ $0.asSource }).sorted() +
           modifiers.map({ $0.asSource }) +
           [specialTreatment ? name : unwrappedTypeName]
         ).joined(separator: " ")
@@ -160,7 +160,7 @@ import Foundation
 
     public override var description: String {
        (
-          attributes.flatMap({ $0.value }).map({ $0.asSource }) +
+          attributes.flatMap({ $0.value }).map({ $0.asSource }).sorted() +
           modifiers.map({ $0.asSource }) +
           [name]
         ).joined(separator: " ")

--- a/SourceryTests/Parsing/FileParser + TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser + TypeNameSpec.swift
@@ -159,8 +159,15 @@ class TypeNameSpec: QuickSpec {
                 }
             }
 
-            it("removes attributes in unwrappedTypeName") {
-                expect(typeName("@escaping (@escaping ()->())->()").unwrappedTypeName).to(equal("(@escaping () -> ()) -> ()"))
+            context("given closure type with attributes") {
+                it("removes attributes in unwrappedTypeName") {
+                    expect(typeName("@escaping (@escaping ()->())->()").unwrappedTypeName).to(equal("(@escaping () -> ()) -> ()"))
+                }
+
+                it("orders attributes alphabetically") {
+                    expect(typeName("@escaping @autoclosure () -> String").asSource).to(equal("@autoclosure @escaping () -> String"))
+                    expect(typeName("@escaping @autoclosure () -> String").description).to(equal("@autoclosure @escaping () -> String"))
+                }
             }
         }
     }


### PR DESCRIPTION
`TypeName.attribute` is a `Dictionary` which does not guarantee an ordering.
If a `TypeName` has several different attributes the ordering of these in generated code is not guaranteed.
As an example: having both `@autoclosure` and `@escaping` arguments on a closure in a file that is used to generate code will result the generated file being regenerated with both `@autoclosure @escaping` and `@escaping @autoclosure` orderings.

This pull request adds sorting to:
- `TypeName.asSource`
- `TypeName.description`