### PR TITLE
Update dependencies to fix build on Xcode 13 and support Swift 5.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     macos:
-      xcode: "12.4.0"
+      xcode: "13.0.0"
     environment:
       - XCODE_WORKSPACE: Sourcery.xcworkspace
       - XCODE_PROJECT: Sourcery.xcodeproj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sourcery CHANGELOG
 
+## Master
+## Fixes
+- Update dependencies to fix build on Xcode 13 and support Swift 5.5 [#989](https://github.com/krzysztofzablocki/Sourcery/issues/989)
+
 ## 1.5.2
 ## Fixes
 - Fixes unstable ordering of `TypeName.attributes` 

--- a/Package.resolved
+++ b/Package.resolved
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj",
         "state": {
           "branch": null,
-          "revision": "56af16e4237215b447f8ab72c737c494a3a20c97",
-          "version": "8.3.0"
+          "revision": "446f3a0db73e141c7f57e26fcdb043096b1db52c",
+          "version": "8.3.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "AEXML",
-        "repositoryURL": "https://github.com/tadija/AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "8623e73b193386909566a9ca20203e33a09af142",
-          "version": "4.5.0"
+          "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+          "version": "4.6.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "2fff9fc25cdc059379b6bd309377cfab45d8520c",
-          "version": "0.50400.0"
+          "revision": "75e60475d9d8fd5bbc16a12e0eaa2cb01b0c322e",
+          "version": "0.50500.0"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj",
         "state": {
           "branch": null,
-          "revision": "82bf5efcaa27e94ed8c761c1eb3e397b6dea82b9",
-          "version": "7.18.0"
+          "revision": "56af16e4237215b447f8ab72c737c494a3a20c97",
+          "version": "8.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
         .package(name: "PathKit", url: "https://github.com/kylef/PathKit.git", .exact("1.0.1")),
         .package(name: "StencilSwiftKit", url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.8.0")),
-        .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", .exact("8.3.0")),
+        .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", .exact("8.3.1")),
         .package(name: "SwiftSyntax",
                  url: "https://github.com/apple/swift-syntax.git",
                  .exact("0.50500.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -22,12 +22,12 @@ let package = Package(
         .package(name: "Yams", url: "https://github.com/jpsim/Yams.git", .exact("4.0.0")),
         .package(name: "Commander", url: "https://github.com/kylef/Commander.git", .exact("0.9.1")),
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
-        .package(name: "PathKit", url: "https://github.com/kylef/PathKit.git", .exact("1.0.0")),
+        .package(name: "PathKit", url: "https://github.com/kylef/PathKit.git", .exact("1.0.1")),
         .package(name: "StencilSwiftKit", url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.8.0")),
-        .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", .exact("7.18.0")),
+        .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", .exact("8.3.0")),
         .package(name: "SwiftSyntax",
                  url: "https://github.com/apple/swift-syntax.git",
-                 .exact("0.50400.0")),
+                 .exact("0.50500.0")),
         .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
     ],


### PR DESCRIPTION
This tries to fix https://github.com/krzysztofzablocki/Sourcery/issues/989 and add support for Swift 5.5.

I think that I also need to update `lib_InternalSwiftSyntaxParser.dylib` but I don't know how.