### PR TITLE
Add subspec for Sourcery.podspec to only include bin and lib folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Sourcery CHANGELOG
 
+## Master
+## New Features
+- Added `CLI-Only` subspec to `Sourcery.podspec` [#997](https://github.com/krzysztofzablocki/Sourcery/pull/997)
+
+---
+
 ## 1.6.0
 ## Fixes
 - Update dependencies to fix build on Xcode 13 and support Swift 5.5 [#989](https://github.com/krzysztofzablocki/Sourcery/issues/989)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ There are plenty of tutorials for different uses of Sourcery, and you can always
 
     Add `pod 'Sourcery'` to your `Podfile` and run `pod update Sourcery`. This will download the latest release binary and will put it in your project's CocoaPods path so you will run it with `$PODS_ROOT/Sourcery/bin/sourcery`
 
+    If you only want to install the `sourcery` binary and its `lib_InternalSwiftSyntaxParser.dylib` dependency, you may want to use the `CLI-Only` subspec: `pod 'Sourcery', :subspecs => ['CLI-Only']`.
 
 - _[Mint](https://github.com/yonaskolb/Mint)_
 

--- a/Sourcery.podspec
+++ b/Sourcery.podspec
@@ -19,4 +19,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*'
   s.exclude_files = '**/file.zip'
 
+  s.subspec 'CLI-Only' do |ss|
+    ss.preserve_paths = 'bin', 'lib'
+  end
 end


### PR DESCRIPTION
### Description
* This PR adds the ability to include only the `bin` and `lib` directories of a Sourcery release zip when installing via Cocoapods.
* This is achieved using a subspec inside the main `Sourcery.podspec` which configures `preserve_paths = 'bin', 'lib'`.
* Installation via `pod 'Sourcery'` remains untouched but users can optionally append `, :subspecs => ['CLI-Only']` to omit any directories inside `$PODS_ROOT/Sourcery/` not strictly required for using `sourcery`.

### Use case
We're working with an iOS project where dependencies are managed via Cocoapods and the content of `/Pods` is checked into the repository. When migrating our Sourcery installation from Mint over to Cocoapods, we've noticed that some files and directories would get checked in that we would not like to include (e.g. the __MACOSX directory and Sourcery.docset).

We had first thought about manually removing not needed files in a post-install script but prefer to contribute to and make this available as part of Sourcery as perhaps other users might find this useful too.

### Potential issues
* When additional, required directories are added in the future, the subspec needs to be modified or otherwise the installation might fail for users of the subspec.

I'm looking forward to hearing your feedback. I'm happy to make further adjustments if desired 🙂