### PR TITLE
Make --args usage more explicit

### DIFF
--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -107,7 +107,7 @@ func runCLI() {
         	Additional arguments to pass to templates. Each argument can have an explicit value or will have \
         	an implicit `true` value. Arguments should be comma-separated without spaces (e.g. --args arg1=value,arg2) \
         	or should be passed one by one (e.g. --args arg1=value --args arg2). Arguments are accessible in templates \
-        	via `argument.<name>`. To pass in string you should use escaped quotes (\").
+        	via `argument.<name>`. To pass in string you should use escaped quotes (\\").
         	"""),
         Option<Path>("ejsPath", default: "", description: "Path to EJS file for JavaScript templates.")
     ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, quiet, prune, sources, excludeSources, templates, excludeTemplates, output, configPaths, forceParse, args, ejsPath in

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -225,7 +225,7 @@
 <li><code>--templates</code> - Path to templates. File or Directory. You can provide multiple paths using multiple <code>--templates</code> options.</li>
 <li><code>--output</code> [default: current path] - Path to output. File or Directory.</li>
 <li><code>--config</code> [default: current path] - Path to config file. File or Directory. See <a href="usage.html#configuration-file">Configuration file</a>.</li>
-<li><code>--args</code> - Additional arguments to pass to templates. Each argument can have explicit value or will have implicit <code>true</code> value. Arguments should be separated with <code>,</code> without spaces (i.e. <code>--args arg1=value,arg2</code>) or should be passed one by one (i.e <code>--args arg1=value --args arg2</code>). Arguments are accessible in templates via <code>argument.name</code>. To pass in string you should use escaped quotes (<code>\&quot;</code>) .</li>
+<li><code>--args</code> - Additional arguments to pass to templates. Each argument can have an explicit value or will have an implicit <code>true</code> value. Arguments should be comma-separated without spaces (e.g. <code>--args arg1=value,arg2</code>) or should be passed one by one (e.g. <code>--args arg1=value --args arg2</code>). Arguments are accessible in templates via <code>argument.&lt;name&gt;</code>. To pass in string you should use escaped quotes (<code>\&quot;</code>).</li>
 <li><code>--watch</code> [default: false] - Watch both code and template folders for changes and regenerate automatically.</li>
 <li><code>--verbose</code> [default: false] - Turn on verbose logging</li>
 <li><code>--quiet</code> [default: false] - Turn off any logging, only emit errors</li>


### PR DESCRIPTION
Make `--args` usage more explicit. Fix for #1003. Seems like the readme was already updated.