### PR TITLE
Update Yams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master
 ## New Features
 - Added `CLI-Only` subspec to `Sourcery.podspec` [#997](https://github.com/krzysztofzablocki/Sourcery/pull/997)
+- Updates Yams to 4.0.6
 
 ---
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "88caa2e6fffdbef2e91c2022d038576062042907",
-          "version": "4.0.0"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .library(name: "SourceryFramework", targets: ["SourceryFramework"]),
     ],
     dependencies: [
-        .package(name: "Yams", url: "https://github.com/jpsim/Yams.git", .exact("4.0.0")),
+        .package(name: "Yams", url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
         .package(name: "Commander", url: "https://github.com/kylef/Commander.git", .exact("0.9.1")),
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
         .package(name: "PathKit", url: "https://github.com/kylef/PathKit.git", .exact("1.0.1")),


### PR DESCRIPTION
Changed the dependency requirement for Yams to match the preferred rule in [the document](https://github.com/jpsim/Yams#swift-package-manager).
This will help resolve SPM dependencies when other dependencies require 4.0.6 or higher version of Yams. #1006