### PR TITLE
Fix group duplication while linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Sourcery CHANGELOG
 
+## master
+
+## Fixes
+- Use name or path parameter to parse groups to avoid duplicated group creation, fixes #904, #906
+
 ## 1.6.1
 
 ## Fixes

--- a/Sourcery/Utils/Xcode+Extensions.swift
+++ b/Sourcery/Utils/Xcode+Extensions.swift
@@ -71,11 +71,7 @@ extension XcodeProj {
         // Find existing group to reuse
         // Having `ProjectRoot/Data/` exists and given group to create `ProjectRoot/Data/Generated`
         // will create `Generated` group under ProjectRoot/Data to link files to
-        let existingGroup = components.reduce((group: fileGroup as PBXGroup?, components: components)) { current, name in
-            let first = current.group?.children.first { $0.path == name } as? PBXGroup
-            let result = first ?? current.group
-            return (result, current.components.filter { $0 != result?.path })
-        }
+        let existingGroup = findGroup(in: fileGroup, components: components)
 
         var groupName: String?
 
@@ -107,4 +103,27 @@ extension XcodeProj {
         }
         return fileGroup
     }
+    
+}
+
+private extension XcodeProj {
+    
+    func findGroup(in group: PBXGroup, components: [String]) -> (group: PBXGroup?, components: [String]) {
+        let existingGroup = findGroup(in: group, components: components, validate: { $0?.path == $1 })
+        
+        if existingGroup.group?.path != nil {
+            return existingGroup
+        }
+        
+        return findGroup(in: group, components: components, validate: { $0?.name == $1 })
+    }
+    
+    func findGroup(in group: PBXGroup, components: [String], validate: (PBXFileElement?, String?) -> Bool) -> (group: PBXGroup?, components: [String]) {
+        return components.reduce((group: group as PBXGroup?, components: components)) { current, name in
+            let first = current.group?.children.first { validate($0, name) } as? PBXGroup
+            let result = first ?? current.group
+            return (result, current.components.filter { !validate(result, $0) })
+        }
+    }
+    
 }


### PR DESCRIPTION
Depending on the project setup, the children of the project main group can have either path property, or name property, or both together.

For example, the Pods projects generated by Cocoapods would not add path property to the groups, but only names.

Previously, sourcery was checking only path property to find out if the group exists or not. This PR adds check with the name of groups, but only if there is no existing group with path.