### PR TITLE
Parsing .swiftinterface form xcframework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sourcery CHANGELOG
 
+## Main
+## New Features
+- Adds `xcframework` key to `target` object in configuration file to enable processing of `swiftinterface`
+
 ## 1.7.0
 
 ## New Features

--- a/Sourcery/Configuration.swift
+++ b/Sourcery/Configuration.swift
@@ -16,6 +16,7 @@ public struct Project {
         public struct XCFramework {
 
             public let path: Path
+            public let swiftInterfacePath: Path
 
             public init(rawPath: String, relativePath: Path) throws {
                 let frameworkRelativePath = Path(rawPath, relativeTo: relativePath)
@@ -38,7 +39,8 @@ public struct Project {
                 else {
                     throw Configuration.Error.invalidXCFramework(message: "Framework path invalid. Expected to find .swiftinterface.")
                 }
-                self.path = interface
+                self.path = frameworkRelativePath
+                self.swiftInterfacePath = interface
             }
         }
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -95,6 +95,10 @@ public class Sourcery {
                             paths.append(file)
                             modules.append(target.module)
                         }
+                        if let xcframework = target.xcframework {
+                            paths.append(xcframework.path)
+                            modules.append(target.module)
+                        }
                     }
                 }
                 result = try self.parse(from: paths, forceParse: forceParse, parseDocumentation: parseDocumentation, modules: modules, requiresFileParserCopy: hasSwiftTemplates)

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -95,8 +95,8 @@ public class Sourcery {
                             paths.append(file)
                             modules.append(target.module)
                         }
-                        if let xcframework = target.xcframework {
-                            paths.append(xcframework.swiftInterfacePath)
+                        for framework in target.xcframeworks {
+                            paths.append(framework.swiftInterfacePath)
                             modules.append(target.module)
                         }
                     }

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -96,7 +96,7 @@ public class Sourcery {
                             modules.append(target.module)
                         }
                         if let xcframework = target.xcframework {
-                            paths.append(xcframework.path)
+                            paths.append(xcframework.swiftInterfacePath)
                             modules.append(target.module)
                         }
                     }

--- a/SourceryUtils/Sources/Path+Extensions.swift
+++ b/SourceryUtils/Sources/Path+Extensions.swift
@@ -52,7 +52,7 @@ extension Path {
     }
 
     public var isSwiftSourceFile: Bool {
-        return !self.isDirectory && self.extension == "swift"
+        return !self.isDirectory && (self.extension == "swift" || self.extension == "swiftinterface")
     }
 
     public func hasExtension(as string: String) -> Bool {

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -293,12 +293,15 @@ Single configuration file can contain multiple configurations under root <code>c
   <span class="pi">-</span> <span class="s">&lt;source file path&gt;</span>
 </code></pre>
 
-<p>Or you can provide project which will be scanned and which source files will be processed. You can use several <code>project</code> or <code>target</code> objects to scan multiple targets from one project or to scan multiple projects.</p>
+<p>Or you can provide project which will be scanned and which source files will be processed. You can use several <code>project</code> or <code>target</code> objects to scan multiple targets from one project or to scan multiple projects. You can provide paths to XCFramework files if your target has any and you want to process their <code>swiftinterface</code> files.</p>
 <pre class="highlight yaml"><code><span class="na">project</span><span class="pi">:</span>
   <span class="na">file</span><span class="pi">:</span> <span class="s">&lt;path to xcodeproj file&gt;</span>
   <span class="na">target</span><span class="pi">:</span>
     <span class="na">name</span><span class="pi">:</span> <span class="s">&lt;target name&gt;</span>
     <span class="na">module</span><span class="pi">:</span> <span class="s">&lt;module name&gt; //required if different from target name</span>
+    <span class="na">xcframeworks</span><span class="pi">:</span>
+    <span class="pi">-</span> <span class="s">&lt;path to xcframework file&gt;</span>
+    <span class="pi">-</span> <span class="s">&lt;path to xcframework file&gt;</span>
 </code></pre>
 <h4 id='excluding-sources-or-templates' class='heading'>Excluding sources or templates</h4>
 

--- a/guides/Usage.md
+++ b/guides/Usage.md
@@ -87,7 +87,7 @@ sources:
   - <source file path>
 ```
 
-Or you can provide project which will be scanned and which source files will be processed. You can use several `project` or `target` objects to scan multiple targets from one project or to scan multiple projects.
+Or you can provide project which will be scanned and which source files will be processed. You can use several `project` or `target` objects to scan multiple targets from one project or to scan multiple projects. You can provide paths to XCFramework files if your target has any and you want to process their `swiftinterface` files.
 
 ```yaml
 project:
@@ -95,6 +95,9 @@ project:
   target:
     name: <target name>
     module: <module name> //required if different from target name
+    xcframeworks:
+        - <path to xcframework file>
+        - <path to xcframework file>
 ```
 
 #### Excluding sources or templates


### PR DESCRIPTION
*Problem*
Issue: https://github.com/krzysztofzablocki/Sourcery/issues/87
Our project is really big so we decided to use it's dependencies as binary XCFrameworks.
The problem is to mock types declared in modules from such binary frameworks which we manage with CocoaPods.
The idea to work this limitation around was to scan `.swiftinterface` file inside the xcframework.

*Line of thought*
At first I considered I could use `sources` key to set this up. But `sources` is mutually exclusive
with `project` which is an issue in our case. I gave it a try to make `sources` usable along with `project`
but it didn't work quite well. The thing is we need to use module name to namespace types in mocks. The case of matching
type names is not so rare. So `sources` was not entirely working. Another consideration was to scan `.xcodeproj` to find a path
to xcframework and add it to sources list. But CocoaPods makes target so placeholder-ish that there is no way that I could find
to extract that path.

*Proposed solution*
Finally I introduced optional key `xcframework` to configuration.

```
project:
  - file: "Pods/Pods.xcodeproj"
    target:
      - name: "Alamofire"
        xcframework: "Pods/Alamofire/Alamofire.xcframework"
```
This path is added to target and gets scaned. Some messy fiddling with paths inside `.xcframework` file could be avoided but
for now it just works. Also the `xcframework` key could be made an array (not done yet)


This Pull Request might not be the the right way to do it, but might as well be the starting point for a discussion.
I am sure there is a better way to achieve this.