### PR TITLE
Include `includeFile` paths and modification dates in `SwiftTemplate` cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## New Features
 - Adds `xcframework` key to `target` object in configuration file to enable processing of `swiftinterface`
 
+## Fixes
+- Modifications to included files of Swift Templates now correctly invalidate the cache - [#889](https://github.com/krzysztofzablocki/Sourcery/issues/889)
+
 ## 1.7.0
 
 ## New Features

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -232,6 +232,24 @@ class SwiftTemplateTests: QuickSpec {
                 let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
                 expect(result).to(equal(expectedResult))
             }
+
+            it("should change cacheKey based on includeFile modifications") {
+                let templatePath = outputDir + "Template.swifttemplate"
+                try templatePath.write(#"<%- includeFile("Utils.swift") -%>"#)
+
+                let utilsPath = outputDir + "Utils.swift"
+                try utilsPath.write(#"let foo = "bar""#)
+
+                let template = try SwiftTemplate(path: templatePath, cachePath: nil, version: "1.0.0")
+                let originalKey = template.cacheKey
+                let keyBeforeModification = template.cacheKey
+
+                try utilsPath.write(#"let foo = "baz""#)
+
+                let keyAfterModification = template.cacheKey
+                expect(originalKey).to(equal(keyBeforeModification))
+                expect(originalKey).toNot(equal(keyAfterModification))
+            }
         }
 
         describe("FolderSynchronizer") {


### PR DESCRIPTION
# Background 

- https://github.com/krzysztofzablocki/Sourcery/issues/889

`SwiftTemplate` has a caching mechanism that aims to avoid having to recompile the template binary if there have been no modifications to the template itself, but when using `includeFile` in the template, modifications to the referenced files are not considered resulting in the cache not being correctly invalidated.

To work around the issue, either the .swifttemplate file itself must be modified or the user must clear the cache path manually.

# Fix 

In this PR, I attempt to fix the problem by updating the cache key that is used to factor modifications to included files.

For the template itself, the cache key uses the generated code that makes **main.swift** since it has already been loaded. But since we don't load the contents of `includedFiles` into memory, I didn't want to have to load them just for the cache key and instead I decided just to use the absolute file path and file modification date. 

This does mean that the caching behaviour slightly differs between the source .swifttemplate and the referenced includeFiles (since touching the include file would cause the cache to invalidate, but not touching the .swiftemplate) however I don't think that's too much of a problem? 

I also added a small test to verify that this works as expected. 