### PR TITLE
Resolving types of typealiases in a single thread

### DIFF
--- a/SourceryRuntime/Sources/Composer.swift
+++ b/SourceryRuntime/Sources/Composer.swift
@@ -284,7 +284,7 @@ public enum Composer {
 
         /// Resolve typealiases
         let typealiases = Array(state.unresolvedTypealiases.values)
-        typealiases.parallelPerform { alias in
+        typealiases.forEach { alias in
             alias.type = resolveType(alias.typeName, alias.parent)
         }
 


### PR DESCRIPTION
For the past several months we experienced occasional crashes of Sourcery with `EXC_BAD_ACCESS`. To get more details what might be causing it, I enabled Thread sanitizer and run all tests from the repo. This is what I found:

<img width="903" alt="Screenshot 2022-03-25 at 13 42 53" src="https://user-images.githubusercontent.com/102046801/160421555-cd4fe247-54cd-4e57-a80d-a3679b184353.png">

It appears that instance of one typealias could be used to resolve type of another typealias. And, becase `Typealias` is a class, it's possible that some typealias is mutated at the same time when another thread reads its property. I found similar situation described in one of the issues: #1009. For us, the crash was reproducing both on 1.6.1 and 1.7.0.

To resolve the issue, I simply replaced `parallelPerform` with a regular `forEach`. This led to a slight performance degradation (about 4%), but stability seems to be more important in this case. 
