### PR TITLE
chore: makes sourcery buildable starting from Xcode 13.0 / Swift 5.5 (#1045)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Sourcery CHANGELOG
 
+## 1.9.0
+## Internal Changes
+- Swift 5.5 and Xcode 13.0 is now required to build the project
+- `lib_internalSwiftSyntaxParser` has removed
+
 ## 1.8.0
 ## New Features
 - Adds `xcframework` key to `target` object in configuration file to enable processing of `swiftinterface`

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,149 +1,151 @@
 {
-  "pins" : [
-    {
-      "identity" : "aexml",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tadija/AEXML.git",
-      "state" : {
-        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-        "version" : "4.6.1"
+  "object": {
+    "pins": [
+      {
+        "package": "AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML.git",
+        "state": {
+          "branch": null,
+          "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+          "version": "4.6.1"
+        }
+      },
+      {
+        "package": "Commander",
+        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "state": {
+          "branch": null,
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "Komondor",
+        "repositoryURL": "https://github.com/shibapm/Komondor.git",
+        "state": {
+          "branch": null,
+          "revision": "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
+        }
+      },
+      {
+        "package": "PackageConfig",
+        "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
+        "state": {
+          "branch": null,
+          "revision": "58523193c26fb821ed1720dcd8a21009055c7cdb",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
+        "state": {
+          "branch": null,
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "8cce6acd38f965f5baa3167b939f86500314022b",
+          "version": "3.1.2"
+        }
+      },
+      {
+        "package": "ShellOut",
+        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
+        "state": {
+          "branch": null,
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
+        }
+      },
+      {
+        "package": "Stencil",
+        "repositoryURL": "https://github.com/stencilproject/Stencil.git",
+        "state": {
+          "branch": null,
+          "revision": "ccd9402682f4c07dac9561befd207c8156e80e20",
+          "version": "0.14.2"
+        }
+      },
+      {
+        "package": "StencilSwiftKit",
+        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
+        "state": {
+          "branch": null,
+          "revision": "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
+          "version": "2.8.0"
+        }
+      },
+      {
+        "package": "SwiftSyntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "state": {
+          "branch": null,
+          "revision": "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
+          "version": "0.50600.1"
+        }
+      },
+      {
+        "package": "XcodeProj",
+        "repositoryURL": "https://github.com/tuist/XcodeProj.git",
+        "state": {
+          "branch": null,
+          "revision": "446f3a0db73e141c7f57e26fcdb043096b1db52c",
+          "version": "8.3.1"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
       }
-    },
-    {
-      "identity" : "commander",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/Commander.git",
-      "state" : {
-        "revision" : "4b6133c3071d521489a80c38fb92d7983f19d438",
-        "version" : "0.9.1"
-      }
-    },
-    {
-      "identity" : "cwlcatchexception",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
-      "state" : {
-        "revision" : "f809deb30dc5c9d9b78c872e553261a61177721a",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "cwlpreconditiontesting",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-      "state" : {
-        "revision" : "02b7a39a99c4da27abe03cab2053a9034379639f",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "komondor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/shibapm/Komondor.git",
-      "state" : {
-        "revision" : "855c74f395a4dc9e02828f58d931be6920bcbf6f",
-        "version" : "1.0.6"
-      }
-    },
-    {
-      "identity" : "nimble",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Quick/Nimble.git",
-      "state" : {
-        "revision" : "e491a6731307bb23783bf664d003be9b2fa59ab5",
-        "version" : "9.0.0"
-      }
-    },
-    {
-      "identity" : "packageconfig",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/shibapm/PackageConfig.git",
-      "state" : {
-        "revision" : "bf90dc69fa0792894b08a0b74cf34029694ae486",
-        "version" : "0.13.0"
-      }
-    },
-    {
-      "identity" : "pathkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/PathKit.git",
-      "state" : {
-        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
-        "version" : "1.0.1"
-      }
-    },
-    {
-      "identity" : "quick",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Quick/Quick.git",
-      "state" : {
-        "revision" : "8cce6acd38f965f5baa3167b939f86500314022b",
-        "version" : "3.1.2"
-      }
-    },
-    {
-      "identity" : "shellout",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/ShellOut.git",
-      "state" : {
-        "revision" : "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
-        "version" : "2.3.0"
-      }
-    },
-    {
-      "identity" : "spectre",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/Spectre.git",
-      "state" : {
-        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
-        "version" : "0.10.1"
-      }
-    },
-    {
-      "identity" : "stencil",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stencilproject/Stencil.git",
-      "state" : {
-        "revision" : "94197b3adbbf926348ad8765476a158aa4e54f8a",
-        "version" : "0.14.0"
-      }
-    },
-    {
-      "identity" : "stencilswiftkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftGen/StencilSwiftKit.git",
-      "state" : {
-        "revision" : "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
-        "version" : "2.8.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-        "version" : "0.50600.1"
-      }
-    },
-    {
-      "identity" : "xcodeproj",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/xcodeproj",
-      "state" : {
-        "revision" : "446f3a0db73e141c7f57e26fcdb043096b1db52c",
-        "version" : "8.3.1"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-        "version" : "4.0.6"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,44 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 
 import PackageDescription
 import Foundation
 
+var dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
+    .package(url: "https://github.com/kylef/Commander.git", .exact("0.9.1")),
+    // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
+    .package(url: "https://github.com/kylef/PathKit.git", .exact("1.0.1")),
+    .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.8.0")),
+    .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.3.1")),
+    .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
+    .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
+]
+#if swift(>=5.6)
+dependencies.append(
+    .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1"))
+)
+#else
+dependencies.append(
+    .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0"))
+)
+#endif
+
+var sourceryFrameworkDependencies: [PackageDescription.Target.Dependency] = [
+    "PathKit",
+    .product(name: "SwiftSyntax", package: "swift-syntax"),
+    "SourceryUtils",
+    "SourceryRuntime"
+]
+#if swift(>=5.6)
+sourceryFrameworkDependencies.append(
+    .product(name: "SwiftSyntaxParser", package: "swift-syntax")
+)
+#endif
+
 let package = Package(
     name: "Sourcery",
     platforms: [
-       .macOS(.v10_12),
+       .macOS(.v10_11),
     ],
     products: [
         // SPM won't generate .swiftmodule for a target directly used by a product,
@@ -18,17 +50,7 @@ let package = Package(
         .library(name: "SourcerySwift", targets: ["SourcerySwift"]),
         .library(name: "SourceryFramework", targets: ["SourceryFramework"]),
     ],
-    dependencies: [
-        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
-        .package(url: "https://github.com/kylef/Commander.git", exact: "0.9.1"),
-        // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
-        .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
-        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.8.0"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
-        .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50600.1"),
-        .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
-    ],
+    dependencies: dependencies,
     targets: [
         .executableTarget(
             name: "SourceryExecutable",
@@ -52,19 +74,12 @@ let package = Package(
                 "Yams",
                 "StencilSwiftKit",
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
-                "lib_InternalSwiftSyntaxParser",
                 "XcodeProj",
                 "TryCatch"
             ],
             path: "Sourcery",
             exclude: [
-                "Templates",
-            ],
-            // Pass `-dead_strip_dylibs` to ignore the dynamic version of `lib_InternalSwiftSyntaxParser`
-            // that ships with SwiftSyntax because we want the static version from
-            // `StaticInternalSwiftSyntaxParser`.
-            linkerSettings: [
-                .unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])
+                "Templates"
             ]
         ),
         .target(
@@ -86,23 +101,10 @@ let package = Package(
         ),
         .target(
             name: "SourceryFramework",
-            dependencies: [
-              "PathKit",
-              .product(name: "SwiftSyntax", package: "swift-syntax"),
-              .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
-              "lib_InternalSwiftSyntaxParser",
-              "SourceryUtils",
-              "SourceryRuntime"
-            ],
+            dependencies: sourceryFrameworkDependencies,
             path: "SourceryFramework",
             exclude: [
                 "Info.plist"
-            ],
-            // Pass `-dead_strip_dylibs` to ignore the dynamic version of `lib_InternalSwiftSyntaxParser`
-            // that ships with SwiftSyntax because we want the static version from
-            // `StaticInternalSwiftSyntaxParser`.
-            linkerSettings: [
-                .unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])
             ]
         ),
         .target(
@@ -225,11 +227,6 @@ let package = Package(
                 .copy("Tests/Context"),
                 .copy("Tests/Expected")
             ]
-        ),
-        .binaryTarget(
-            name: "lib_InternalSwiftSyntaxParser",
-            url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
-            checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
         )
     ]
 )

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/FileParserSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/FileParserSyntax.swift
@@ -1,6 +1,8 @@
 import Foundation
 import SwiftSyntax
+#if swift(>=5.6)
 import SwiftSyntaxParser
+#endif
 import PathKit
 import SourceryRuntime
 import SourceryUtils


### PR DESCRIPTION
Solves the issue of #1045. Further the size of the build artifact has been reduced dramatically. Now Sourcery is buildable starting from Xcode 13.0.