### PR TITLE
Revert to using 'swift build' with sandbox disabled for 'rake build'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Internal Changes
 - Lower project requirements to allow compilation using Swift 5.5/Xcode 13.x [#1049](https://github.com/krzysztofzablocki/Sourcery/pull/1049)
 - Update Stencil to 0.14.2
+- Use `swift build` insead of `xcodebuild` when building binary [#1057](https://github.com/krzysztofzablocki/Sourcery/pull/1057)
 
 ## 1.8.0
 ## New Features


### PR DESCRIPTION
# Background

- https://github.com/krzysztofzablocki/Sourcery/issues/1054

When using a statically built version of lib_internalSwiftSyntaxParser in #1037, [SR-15802](https://bugs.swift.org/browse/SR-15802) prevented us from using `swift build` when specifying multiple architectures to build a universal (fat) binary. 

The initial workaround was to instead use `xcodebuild`, which seemed to work well up until we tried to push the new version to Homewbrew because `brew install` appears to run in a sandbox, some of the SPM build operations were blocked (I'm a little fuzzy on the exact details).

To work around this, we need to revert back to using `swift build --disable-sandbox` when running `rake build`.

# Description 

In this change, I decided to follow the approach that I saw being used in the SwiftLint project. For thin builds, we just run `swift build --disable-sandbox -c release` to build for the machine architecture with no problem. For universal builds, we invoke `swift build` for each architecture and then use `lipo` to merge the two binaries into a single universal binary and strip any redundant symbols. 