### PR TITLE
Add a flag to parse serially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Sourcery CHANGELOG
 
 ## 1.8.1
+## New Features
+- Added a new flag `--serialParse` to support parsing the sources in serial, rather than in parallel (the default), which can address stability issues in SwiftSyntax [#1063](https://github.com/krzysztofzablocki/Sourcery/pull/1063)
+
 ## Internal Changes
 - Lower project requirements to allow compilation using Swift 5.5/Xcode 13.x [#1049](https://github.com/krzysztofzablocki/Sourcery/pull/1049)
 - Update Stencil to 0.14.2

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -38,9 +38,9 @@ public class Sourcery {
     // content annotated with file annotations per file path to write it to
     fileprivate var fileAnnotatedContent: [Path: [String]] = [:]
 
-    private (set) var numberOfFilesThatHadToBeParsed: Int32 = 0
+    private (set) var numberOfFilesThatHadToBeParsed = 0
     func incrementFileParsedCount() {
-        OSAtomicIncrement32(&numberOfFilesThatHadToBeParsed)
+        numberOfFilesThatHadToBeParsed += 1
     }
 
     /// Creates Sourcery processor
@@ -309,7 +309,7 @@ extension Sourcery {
             numberOfFilesThatHadToBeParsed = 0
 
             var lastError: Swift.Error?
-            let results = parserGenerator.parallelCompactMap { parser -> FileParserResult? in
+            let results = parserGenerator.compactMap { parser -> FileParserResult? in
                 do {
                     return try self.loadOrParse(parser: parser, cachesPath: cachesDir(sourcePath: from))
                 } catch {

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -38,9 +38,9 @@ public class Sourcery {
     // content annotated with file annotations per file path to write it to
     fileprivate var fileAnnotatedContent: [Path: [String]] = [:]
 
-    private (set) var numberOfFilesThatHadToBeParsed = 0
+    private (set) var numberOfFilesThatHadToBeParsed: Int32 = 0
     func incrementFileParsedCount() {
-        numberOfFilesThatHadToBeParsed += 1
+        OSAtomicIncrement32(&numberOfFilesThatHadToBeParsed)
     }
 
     /// Creates Sourcery processor

--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -96,6 +96,7 @@ func runCLI() {
         Flag("parseDocumentation", description: "Include documentation comments for all declarations."),
         Flag("quiet", flag: "q", description: "Turn off any logging, only emmit errors."),
         Flag("prune", flag: "p", description: "Remove empty generated files"),
+        Flag("serialParse", description: "Parses the specified sources in serial, rather than in parallel (the default), which can address stability issues in SwiftSyntax."),
         VariadicOption<Path>("sources", description: "Path to a source swift files. File or Directory."),
         VariadicOption<Path>("exclude-sources", description: "Path to a source swift files to exclude. File or Directory."),
         VariadicOption<Path>("templates", description: "Path to templates. File or Directory."),
@@ -111,7 +112,7 @@ func runCLI() {
         	via `argument.<name>`. To pass in string you should use escaped quotes (\\").
         	"""),
         Option<Path>("ejsPath", default: "", description: "Path to EJS file for JavaScript templates.")
-    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, sources, excludeSources, templates, excludeTemplates, output, configPaths, forceParse, args, ejsPath in
+    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, configPaths, forceParse, args, ejsPath in
         do {
             switch (quiet, verboseLogging) {
             case (true, _):
@@ -192,6 +193,7 @@ func runCLI() {
                                         cacheDisabled: disableCache,
                                         cacheBasePath: configuration.cacheBasePath,
                                         prune: prune,
+                                        serialParse: serialParse,
                                         arguments: configuration.args)
 
                 return try sourcery.processFiles(


### PR DESCRIPTION
Parsing in parallel is leading to unexpected `EXC_BAD_ACCESS`es in our codebase.  By switching to `compactMap`, the crashes go away.

The specific crash is deep in the internals of `SwiftSyntax` mid-parse, which leads me to believe that there's some internal global thread-unsafe state that's being shared between parser instances. I'm not sure if there's any guarantees about thread safety in `SwiftSyntax`, but I couldn't find any. Here's an example (abbreviated) stacktrace:
```
#0	0x00000001001209e4 in protocol witness for SyntaxProtocol._syntaxNode.getter in conformance Syntax ()
#1	0x0000000100121ec3 in SyntaxProtocol.raw.getter at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/Syntax.swift:129
#2	0x0000000100b85c32 in SimpleTypeIdentifierSyntax.init(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift:68
#3	0x0000000100b89979 in protocol witness for SyntaxProtocol.init(_:) in conformance SimpleTypeIdentifierSyntax ()
#4	0x00000001001acab7 in TypeSyntax.as<τ_0_0>(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift:421
…
#165	0x0000000100566152 in SyntaxVisitor.visitImplCodeBlockItemSyntax(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:2584
#166	0x00000001005abbca in SyntaxVisitor.visit(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:5215
#167	0x00000001005b33bc in SyntaxVisitor.visitChildren<τ_0_0>(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:5694
#168	0x0000000100566602 in SyntaxVisitor.visitImplCodeBlockItemListSyntax(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:2595
#169	0x00000001005abc43 in SyntaxVisitor.visit(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:5217
#170	0x00000001005b33bc in SyntaxVisitor.visitChildren<τ_0_0>(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:5694
#171	0x0000000100583162 in SyntaxVisitor.visitImplSourceFileSyntax(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:3673
#172	0x00000001005aea95 in SyntaxVisitor.visit(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:5413
#173	0x0000000100557854 in SyntaxVisitor.walk<τ_0_0>(_:) at /Users/eric_horacek/Library/Developer/Xcode/DerivedData/Sourcery-hibchsafsxkdcjaxxaylrbeyoydh/SourcePackages/checkouts/swift-syntax/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift:32
#174	0x0000000100c35418 in FileParserSyntax.parse() at /Users/eric_horacek/Developer/Sourcery/SourceryFramework/Sources/Parsing/SwiftSyntax/FileParserSyntax.swift:51
```

I was able to reproduce this in the debugger, but there was no information available with either TSAN or ASAN.

Fixes #1009. With this change Sourcery 1.8.1 now works on our very large codebase where we run one instance of Sourcery per module. However it's important to note that this crash was occurring consistently on a single module—even if no other Sourcery processes were running concurrently.

I know that a lot of folks rely on the performance of parsing in parallel and it only seems to be crashing on our codebase, so perhaps we could put this behind an argument?