### PR TITLE
Update StencilSwiftKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Sourcery CHANGELOG
 
+## 1.8.3
+- Update StencilSwiftKit to fix SPM resolving issue when building as a Command Plugin [#1023](https://github.com/krzysztofzablocki/Sourcery/issues/1023)
+
 ## 1.8.2
 ## New Features
 - Added `deletingLastComponent` filter to turn `/Path/Class.swift` into `/Path`

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/shibapm/Komondor.git",
         "state": {
           "branch": null,
-          "revision": "855c74f395a4dc9e02828f58d931be6920bcbf6f",
-          "version": "1.0.6"
+          "revision": "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+          "version": "1.1.3"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
         "state": {
           "branch": null,
-          "revision": "bf90dc69fa0792894b08a0b74cf34029694ae486",
-          "version": "0.13.0"
+          "revision": "58523193c26fb821ed1720dcd8a21009055c7cdb",
+          "version": "1.1.3"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/StencilProject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "ccd9402682f4c07dac9561befd207c8156e80e20",
-          "version": "0.14.2"
+          "revision": "4f222ac85d673f35df29962fc4c36ccfdaf9da5b",
+          "version": "0.15.1"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
         "state": {
           "branch": null,
-          "revision": "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
-          "version": "2.8.0"
+          "revision": "20e2de5322c83df005939d9d9300fab130b49f97",
+          "version": "2.10.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
         .package(url: "https://github.com/kylef/PathKit.git", .exact("1.0.1")),
         .package(url: "https://github.com/StencilProject/Stencil.git", .upToNextMajor(from: "0.14.0")),
-        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.8.0")),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.10.1")),
         .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.3.1")),
         .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1")),
         .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),


### PR DESCRIPTION
Updated StencilSwiftKit to v2.10.1 to fix the issue where building Sourcery as a Command Plugin fails. https://github.com/krzysztofzablocki/Sourcery/issues/1023#issuecomment-1180284670
The issue was caused by [Komondor v1.1.3](https://github.com/shibapm/Komondor), which StencilSwiftKit used to rely on, [added extra dependencies that are unnecessary](https://github.com/shibapm/Komondor/compare/1.1.3...1.1.4).
v2.10.1 release for StencilSwiftKit now pins Komondor to the old version.