### PR TITLE
📦 Adds Swift package command plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .library(name: "SourceryJS", targets: ["SourceryJS"]),
         .library(name: "SourcerySwift", targets: ["SourcerySwift"]),
         .library(name: "SourceryFramework", targets: ["SourceryFramework"]),
+        .plugin(name: "SourceryCommandPlugin", targets: ["SourceryCommandPlugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),

--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
-        .package(url: "https://github.com/kylef/Commander.git", .exact("0.9.1")),
+        .package(url: "https://github.com/kylef/Commander.git", exact: "0.9.1"),
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
-        .package(url: "https://github.com/kylef/PathKit.git", .exact("1.0.1")),
+        .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
         .package(url: "https://github.com/StencilProject/Stencil.git", .upToNextMajor(from: "0.14.0")),
-        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.10.1")),
-        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.3.1")),
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1")),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
+        .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50600.1"),
         .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
     ],
@@ -242,7 +242,8 @@ let package = Package(
                 permissions: [
                     .writeToPackageDirectory(reason: "Need permission to write generated files to package directory")
                 ]
-            )
+            ),
+            dependencies: ["SourceryExecutable"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 
 import PackageDescription
 import Foundation
@@ -231,6 +231,12 @@ let package = Package(
             name: "lib_InternalSwiftSyntaxParser",
             url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
             checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
+        ),
+        .plugin(
+            name: "SourceryCommandPlugin",
+            capability: .command(
+                intent: .custom(verb: "sourcery-command", description: "Sourcery command plugin for code generation"),
+                permissions: [.writeToPackageDirectory(reason: "Need permission to write generated files to package directory")]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
         .package(url: "https://github.com/kylef/Commander.git", exact: "0.9.1"),
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
         .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
-        .package(url: "https://github.com/StencilProject/Stencil.git", .upToNextMajor(from: "0.14.0")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
         .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
         .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50600.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -235,8 +235,14 @@ let package = Package(
         .plugin(
             name: "SourceryCommandPlugin",
             capability: .command(
-                intent: .custom(verb: "sourcery-command", description: "Sourcery command plugin for code generation"),
-                permissions: [.writeToPackageDirectory(reason: "Need permission to write generated files to package directory")]
+                intent: .custom(
+                    verb: "sourcery-command",
+                    description: "Sourcery command plugin for code generation"
+                ),
+                permissions: [
+                    .writeToPackageDirectory(reason: "Need permission to write generated files to package directory")
+                ]
+            )
         )
     ]
 )

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -11,7 +11,7 @@ struct SourceryCommandPlugin {
         process.arguments = [
             "--config",
             configFilePath,
-            "--cachePath",
+            "--cacheBasePath",
             cachePath
         ]
         

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main
 struct SourceryCommandPlugin {
-    private func run(_ sourcery: String, withConfig configFilePath: String) throws {
+    private func run(_ sourcery: String, withConfig configFilePath: String, cachePath: String) throws {
         let sourceryURL = URL(fileURLWithPath: sourcery)
         
         let process = Process()
@@ -11,7 +11,8 @@ struct SourceryCommandPlugin {
         process.arguments = [
             "--config",
             configFilePath,
-            "--disableCache"
+            "--cachePath",
+            cachePath
         ]
         
         try process.run()
@@ -38,7 +39,7 @@ extension SourceryCommandPlugin: CommandPlugin {
                 return
             }
             
-            try run(sourcery, withConfig: configFilePath)
+            try run(sourcery, withConfig: configFilePath, cachePath: context.pluginWorkDirectory.string)
         }
     }
 }
@@ -62,7 +63,7 @@ extension SourceryCommandPlugin: XcodeCommandPlugin {
             }
             let sourcery = try context.tool(named: "SourceryExecutable").path.string
             
-            try run(sourcery, withConfig: configFilePath)
+            try run(sourcery, withConfig: configFilePath, cachePath: context.pluginWorkDirectory.string)
         }
     }
 }

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -19,7 +19,7 @@ struct SourceryCommandPlugin {
         
         let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
         if !gracefulExit {
-            throw "🛑 The plugin execution failed with reason: \(process.terminationReason.rawValue) and status: \(process.terminationStatus)"
+            throw "🛑 The plugin execution failed with reason: \(process.terminationReason.rawValue) and status: \(process.terminationStatus) "
         }
     }
 }
@@ -60,7 +60,6 @@ extension SourceryCommandPlugin: XcodeCommandPlugin {
                 Diagnostics.warning("⚠️ Could not find `.sourcery.yml` in Xcode's input file list")
                 return
             }
-            
             let sourcery = try context.tool(named: "SourceryExecutable").path.string
             
             try run(sourcery, withConfig: configFilePath)

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -4,27 +4,35 @@ import Foundation
 @main
 struct SourceryCommandPlugin: CommandPlugin {
     func performCommand(context: PluginContext, arguments: [String]) async throws {
-        let configFilePath = context.package.directory.appending(subpath: ".sourcery.yml").string
-        guard FileManager.default.fileExists(atPath: configFilePath) else {
-            Diagnostics.error("🤷‍♂️ Could not find config at: \(configFilePath)")
-            return
-        }
-        
-        let sourceryExecutable = try context.tool(named: "SourceryExecutable")
-        let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
-        
-        let process = Process()
-        process.executableURL = sourceryURL
-        process.arguments = [
-            "--disableCache"
-        ]
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
-        if !gracefulExit {
-            Diagnostics.error("🛑 The plugin execution failed")
+        // Run one per target
+        for target in context.package.targets {
+            let configFilePath = target.directory.appending(subpath: ".sourcery.yml").string
+            
+            guard FileManager.default.fileExists(atPath: configFilePath) else {
+                Diagnostics.warning("🤷‍♂️ Could not find config at: \(configFilePath), skipping...")
+                return
+            }
+            
+            print(configFilePath)
+            
+            let sourceryExecutable = try context.tool(named: "SourceryExecutable")
+            let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
+            
+            let process = Process()
+            process.executableURL = sourceryURL
+            process.arguments = [
+                "--config",
+                configFilePath,
+                "--disableCache"
+            ]
+            
+            try process.run()
+            process.waitUntilExit()
+            
+            let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
+            if !gracefulExit {
+                Diagnostics.error("🛑 The plugin execution failed")
+            }
         }
     }
 }

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -1,0 +1,8 @@
+import PackagePlugin
+
+@main
+struct SourceryCommandPlugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        
+    }
+}

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -1,8 +1,30 @@
 import PackagePlugin
+import Foundation
 
 @main
 struct SourceryCommandPlugin: CommandPlugin {
     func performCommand(context: PluginContext, arguments: [String]) async throws {
+        let configFilePath = context.package.directory.appending(subpath: ".sourcery.yml").string
+        guard FileManager.default.fileExists(atPath: configFilePath) else {
+            Diagnostics.error("🤷‍♂️ Could not find config at: \(configFilePath)")
+            return
+        }
         
+        let sourceryExecutable = try context.tool(named: "SourceryExecutable")
+        let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
+        
+        let process = Process()
+        process.executableURL = sourceryURL
+        process.arguments = [
+            "--disableCache"
+        ]
+        
+        try process.run()
+        process.waitUntilExit()
+        
+        let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
+        if !gracefulExit {
+            Diagnostics.error("🛑 The plugin execution failed")
+        }
     }
 }

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -9,11 +9,10 @@ struct SourceryCommandPlugin: CommandPlugin {
             let configFilePath = target.directory.appending(subpath: ".sourcery.yml").string
             
             guard FileManager.default.fileExists(atPath: configFilePath) else {
-                Diagnostics.warning("🤷‍♂️ Could not find config at: \(configFilePath), skipping...")
+                Diagnostics.warning("⚠️ Could not find `.sourcery.yml` for the given target")
                 return
             }
             
-            print(configFilePath)
             
             let sourceryExecutable = try context.tool(named: "SourceryExecutable")
             let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
@@ -36,3 +35,43 @@ struct SourceryCommandPlugin: CommandPlugin {
         }
     }
 }
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension SourceryCommandPlugin: XcodeCommandPlugin {
+    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+        for target in context.xcodeProject.targets {
+            guard let configFilePath = target
+                .inputFiles
+                .filter({ $0.path.lastComponent == ".sourcery.yml" })
+                .first?
+                .path
+                .string else {
+                Diagnostics.warning("⚠️ Could not find `.sourcery.yml` in Xcode's input file list")
+                return
+            }
+
+            let sourceryExecutable = try context.tool(named: "SourceryExecutable")
+            let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
+            
+            let process = Process()
+            process.executableURL = sourceryURL
+            process.arguments = [
+                "--config",
+                configFilePath,
+                "--disableCache"
+            ]
+            
+            try process.run()
+            process.waitUntilExit()
+            
+            let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
+            if !gracefulExit {
+                Diagnostics.error("🛑 The plugin execution failed")
+            }
+        }
+        debugPrint(context)
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -120,11 +120,20 @@ You can also watch this quick getting started and intro to mocking video by Insi
 
         Run `xcodebuild -scheme sourcery -destination generic/platform=macOS -archivePath sourcery.xcarchive archive` and export the binary from the archive.
 
+- _SPM (for plugin use only)_
+Add the package dependency to your `Package.swift` manifest from version `1.8.3`.
+
+```
+.package(url: "https://github.com/krzysztofzablocki/Sourcery.git", from: "1.8.3")
+```
+
 ## Documentation
 
 Full documentation for the latest release is available [here](http://merowing.info/Sourcery/).
 
 ## Usage
+
+### Running the executable
 
 Sourcery is a command line tool; you can either run it manually or in a custom build phase using the following command:
 
@@ -133,6 +142,32 @@ $ ./bin/sourcery --sources <sources path> --templates <templates path> --output 
 ```
 
 > Note: this command differs depending on how you installed Sourcery (see [Installing](#installing))
+
+### Swift Package command
+
+Sourcery can now be used as a Swift package command plugin. In order to do this, the package must be added as a dependency to your Swift package or Xcode project (see [Installing](#installing) above).
+
+To provide a configuration for the plugin to use, place a `.sourcery.yml` file at the root of the target's directory (in the sources folder rather than the root of the package).
+
+#### Running from the command line
+
+To verify the plugin can be found by SwiftPM, use:
+
+```
+$ swift package --list
+```
+
+To run the code generator, you need to allow changes to the project with the `--allow-writing-to-package-directory` flag:
+
+```
+$ swift package --allow-writing-to-package-directory sourcery-code-generation
+```
+
+#### Running in Xcode
+
+Inside a project/package that uses this command plugin, right-click the project and select "SourceryCommand" from the "SourceryPlugins" menu group.
+
+> ⚠️ Note that this is only available from Xcode 14 onwards.
 
 ### Command line options
 


### PR DESCRIPTION
This PR starts the work to add support for Swift Package Plugins for `Sourcery`. At the moment, this PR only includes support for Swift Package command plugins but not for build plugins yet, I'll be investigating those next as there are a set of challenges which must be overcome.

This PR also updates to using `swift-tools` version 5.6 to be able to make use of SPM plugins.