### PR TITLE
📦 Adds support for Swift Package plugin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.3
 - Update StencilSwiftKit to fix SPM resolving issue when building as a Command Plugin [#1023](https://github.com/krzysztofzablocki/Sourcery/issues/1023)
+- Adds new `--cacheBasePath` option to `SourceryExecutable` to allow for plugins setting a default cache [#1093](https://github.com/krzysztofzablocki/Sourcery/pull/1093)
 
 ## 1.8.2
 ## New Features

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .library(name: "SourceryJS", targets: ["SourceryJS"]),
         .library(name: "SourcerySwift", targets: ["SourcerySwift"]),
         .library(name: "SourceryFramework", targets: ["SourceryFramework"]),
+        .plugin(name: "SourceryCommandPlugin", targets: ["SourceryCommandPlugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),

--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
-        .package(url: "https://github.com/kylef/Commander.git", .exact("0.9.1")),
+        .package(url: "https://github.com/kylef/Commander.git", exact: "0.9.1"),
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
-        .package(url: "https://github.com/kylef/PathKit.git", .exact("1.0.1")),
+        .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
         .package(url: "https://github.com/StencilProject/Stencil.git", .upToNextMajor(from: "0.14.0")),
-        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.10.1")),
-        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.3.1")),
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1")),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
+        .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50600.1"),
         .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
     ],
@@ -242,7 +242,8 @@ let package = Package(
                 permissions: [
                     .writeToPackageDirectory(reason: "Need permission to write generated files to package directory")
                 ]
-            )
+            ),
+            dependencies: ["SourceryExecutable"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 
 import PackageDescription
 import Foundation
@@ -231,6 +231,12 @@ let package = Package(
             name: "lib_InternalSwiftSyntaxParser",
             url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
             checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
+        ),
+        .plugin(
+            name: "SourceryCommandPlugin",
+            capability: .command(
+                intent: .custom(verb: "sourcery-command", description: "Sourcery command plugin for code generation"),
+                permissions: [.writeToPackageDirectory(reason: "Need permission to write generated files to package directory")]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
         .package(url: "https://github.com/kylef/Commander.git", exact: "0.9.1"),
         // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
         .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
-        .package(url: "https://github.com/StencilProject/Stencil.git", .upToNextMajor(from: "0.14.0")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
         .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
         .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50600.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -235,8 +235,14 @@ let package = Package(
         .plugin(
             name: "SourceryCommandPlugin",
             capability: .command(
-                intent: .custom(verb: "sourcery-command", description: "Sourcery command plugin for code generation"),
-                permissions: [.writeToPackageDirectory(reason: "Need permission to write generated files to package directory")]
+                intent: .custom(
+                    verb: "sourcery-command",
+                    description: "Sourcery command plugin for code generation"
+                ),
+                permissions: [
+                    .writeToPackageDirectory(reason: "Need permission to write generated files to package directory")
+                ]
+            )
         )
     ]
 )

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -11,7 +11,7 @@ struct SourceryCommandPlugin {
         process.arguments = [
             "--config",
             configFilePath,
-            "--cachePath",
+            "--cacheBasePath",
             cachePath
         ]
         

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main
 struct SourceryCommandPlugin {
-    private func run(_ sourcery: String, withConfig configFilePath: String) throws {
+    private func run(_ sourcery: String, withConfig configFilePath: String, cachePath: String) throws {
         let sourceryURL = URL(fileURLWithPath: sourcery)
         
         let process = Process()
@@ -11,7 +11,8 @@ struct SourceryCommandPlugin {
         process.arguments = [
             "--config",
             configFilePath,
-            "--disableCache"
+            "--cachePath",
+            cachePath
         ]
         
         try process.run()
@@ -38,7 +39,7 @@ extension SourceryCommandPlugin: CommandPlugin {
                 return
             }
             
-            try run(sourcery, withConfig: configFilePath)
+            try run(sourcery, withConfig: configFilePath, cachePath: context.pluginWorkDirectory.string)
         }
     }
 }
@@ -62,7 +63,7 @@ extension SourceryCommandPlugin: XcodeCommandPlugin {
             }
             let sourcery = try context.tool(named: "SourceryExecutable").path.string
             
-            try run(sourcery, withConfig: configFilePath)
+            try run(sourcery, withConfig: configFilePath, cachePath: context.pluginWorkDirectory.string)
         }
     }
 }

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -19,7 +19,7 @@ struct SourceryCommandPlugin {
         
         let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
         if !gracefulExit {
-            throw "🛑 The plugin execution failed with reason: \(process.terminationReason.rawValue) and status: \(process.terminationStatus)"
+            throw "🛑 The plugin execution failed with reason: \(process.terminationReason.rawValue) and status: \(process.terminationStatus) "
         }
     }
 }
@@ -60,7 +60,6 @@ extension SourceryCommandPlugin: XcodeCommandPlugin {
                 Diagnostics.warning("⚠️ Could not find `.sourcery.yml` in Xcode's input file list")
                 return
             }
-            
             let sourcery = try context.tool(named: "SourceryExecutable").path.string
             
             try run(sourcery, withConfig: configFilePath)

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main
 struct SourceryCommandPlugin {
-    private func run(_ sourcery: String, withConfig configFilePath: String, cachePath: String) throws {
+    private func run(_ sourcery: String, withConfig configFilePath: String) throws {
         let sourceryURL = URL(fileURLWithPath: sourcery)
         
         let process = Process()
@@ -11,8 +11,7 @@ struct SourceryCommandPlugin {
         process.arguments = [
             "--config",
             configFilePath,
-            "--cacheBasePath",
-            cachePath
+            "--disableCache"
         ]
         
         try process.run()
@@ -39,7 +38,7 @@ extension SourceryCommandPlugin: CommandPlugin {
                 return
             }
             
-            try run(sourcery, withConfig: configFilePath, cachePath: context.pluginWorkDirectory.string)
+            try run(sourcery, withConfig: configFilePath)
         }
     }
 }
@@ -63,7 +62,7 @@ extension SourceryCommandPlugin: XcodeCommandPlugin {
             }
             let sourcery = try context.tool(named: "SourceryExecutable").path.string
             
-            try run(sourcery, withConfig: configFilePath, cachePath: context.pluginWorkDirectory.string)
+            try run(sourcery, withConfig: configFilePath)
         }
     }
 }

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -4,27 +4,35 @@ import Foundation
 @main
 struct SourceryCommandPlugin: CommandPlugin {
     func performCommand(context: PluginContext, arguments: [String]) async throws {
-        let configFilePath = context.package.directory.appending(subpath: ".sourcery.yml").string
-        guard FileManager.default.fileExists(atPath: configFilePath) else {
-            Diagnostics.error("🤷‍♂️ Could not find config at: \(configFilePath)")
-            return
-        }
-        
-        let sourceryExecutable = try context.tool(named: "SourceryExecutable")
-        let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
-        
-        let process = Process()
-        process.executableURL = sourceryURL
-        process.arguments = [
-            "--disableCache"
-        ]
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
-        if !gracefulExit {
-            Diagnostics.error("🛑 The plugin execution failed")
+        // Run one per target
+        for target in context.package.targets {
+            let configFilePath = target.directory.appending(subpath: ".sourcery.yml").string
+            
+            guard FileManager.default.fileExists(atPath: configFilePath) else {
+                Diagnostics.warning("🤷‍♂️ Could not find config at: \(configFilePath), skipping...")
+                return
+            }
+            
+            print(configFilePath)
+            
+            let sourceryExecutable = try context.tool(named: "SourceryExecutable")
+            let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
+            
+            let process = Process()
+            process.executableURL = sourceryURL
+            process.arguments = [
+                "--config",
+                configFilePath,
+                "--disableCache"
+            ]
+            
+            try process.run()
+            process.waitUntilExit()
+            
+            let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
+            if !gracefulExit {
+                Diagnostics.error("🛑 The plugin execution failed")
+            }
         }
     }
 }

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main
 struct SourceryCommandPlugin {
-    private func run(_ sourcery: String, withConfig configFilePath: String) throws {
+    private func run(_ sourcery: String, withConfig configFilePath: String, cacheBasePath: String) throws {
         let sourceryURL = URL(fileURLWithPath: sourcery)
         
         let process = Process()
@@ -11,7 +11,8 @@ struct SourceryCommandPlugin {
         process.arguments = [
             "--config",
             configFilePath,
-            "--disableCache"
+            "--cacheBasePath",
+            cacheBasePath
         ]
         
         try process.run()
@@ -38,7 +39,7 @@ extension SourceryCommandPlugin: CommandPlugin {
                 return
             }
             
-            try run(sourcery, withConfig: configFilePath)
+            try run(sourcery, withConfig: configFilePath, cacheBasePath: context.pluginWorkDirectory.string)
         }
     }
 }
@@ -62,7 +63,7 @@ extension SourceryCommandPlugin: XcodeCommandPlugin {
             }
             let sourcery = try context.tool(named: "SourceryExecutable").path.string
             
-            try run(sourcery, withConfig: configFilePath)
+            try run(sourcery, withConfig: configFilePath, cacheBasePath: context.pluginWorkDirectory.string)
         }
     }
 }

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -1,0 +1,8 @@
+import PackagePlugin
+
+@main
+struct SourceryCommandPlugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        
+    }
+}

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -1,8 +1,30 @@
 import PackagePlugin
+import Foundation
 
 @main
 struct SourceryCommandPlugin: CommandPlugin {
     func performCommand(context: PluginContext, arguments: [String]) async throws {
+        let configFilePath = context.package.directory.appending(subpath: ".sourcery.yml").string
+        guard FileManager.default.fileExists(atPath: configFilePath) else {
+            Diagnostics.error("🤷‍♂️ Could not find config at: \(configFilePath)")
+            return
+        }
         
+        let sourceryExecutable = try context.tool(named: "SourceryExecutable")
+        let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
+        
+        let process = Process()
+        process.executableURL = sourceryURL
+        process.arguments = [
+            "--disableCache"
+        ]
+        
+        try process.run()
+        process.waitUntilExit()
+        
+        let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
+        if !gracefulExit {
+            Diagnostics.error("🛑 The plugin execution failed")
+        }
     }
 }

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -9,11 +9,10 @@ struct SourceryCommandPlugin: CommandPlugin {
             let configFilePath = target.directory.appending(subpath: ".sourcery.yml").string
             
             guard FileManager.default.fileExists(atPath: configFilePath) else {
-                Diagnostics.warning("🤷‍♂️ Could not find config at: \(configFilePath), skipping...")
+                Diagnostics.warning("⚠️ Could not find `.sourcery.yml` for the given target")
                 return
             }
             
-            print(configFilePath)
             
             let sourceryExecutable = try context.tool(named: "SourceryExecutable")
             let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
@@ -36,3 +35,43 @@ struct SourceryCommandPlugin: CommandPlugin {
         }
     }
 }
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension SourceryCommandPlugin: XcodeCommandPlugin {
+    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+        for target in context.xcodeProject.targets {
+            guard let configFilePath = target
+                .inputFiles
+                .filter({ $0.path.lastComponent == ".sourcery.yml" })
+                .first?
+                .path
+                .string else {
+                Diagnostics.warning("⚠️ Could not find `.sourcery.yml` in Xcode's input file list")
+                return
+            }
+
+            let sourceryExecutable = try context.tool(named: "SourceryExecutable")
+            let sourceryURL = URL(fileURLWithPath: sourceryExecutable.path.string)
+            
+            let process = Process()
+            process.executableURL = sourceryURL
+            process.arguments = [
+                "--config",
+                configFilePath,
+                "--disableCache"
+            ]
+            
+            try process.run()
+            process.waitUntilExit()
+            
+            let gracefulExit = process.terminationReason == .exit && process.terminationStatus == 0
+            if !gracefulExit {
+                Diagnostics.error("🛑 The plugin execution failed")
+            }
+        }
+        debugPrint(context)
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -120,11 +120,20 @@ You can also watch this quick getting started and intro to mocking video by Insi
 
         Run `xcodebuild -scheme sourcery -destination generic/platform=macOS -archivePath sourcery.xcarchive archive` and export the binary from the archive.
 
+- _SPM (for plugin use only)_
+Add the package dependency to your `Package.swift` manifest from version `1.8.3`.
+
+```
+.package(url: "https://github.com/krzysztofzablocki/Sourcery.git", from: "1.8.3")
+```
+
 ## Documentation
 
 Full documentation for the latest release is available [here](http://merowing.info/Sourcery/).
 
 ## Usage
+
+### Running the executable
 
 Sourcery is a command line tool; you can either run it manually or in a custom build phase using the following command:
 
@@ -133,6 +142,32 @@ $ ./bin/sourcery --sources <sources path> --templates <templates path> --output 
 ```
 
 > Note: this command differs depending on how you installed Sourcery (see [Installing](#installing))
+
+### Swift Package command
+
+Sourcery can now be used as a Swift package command plugin. In order to do this, the package must be added as a dependency to your Swift package or Xcode project (see [Installing](#installing) above).
+
+To provide a configuration for the plugin to use, place a `.sourcery.yml` file at the root of the target's directory (in the sources folder rather than the root of the package).
+
+#### Running from the command line
+
+To verify the plugin can be found by SwiftPM, use:
+
+```
+$ swift package --list
+```
+
+To run the code generator, you need to allow changes to the project with the `--allow-writing-to-package-directory` flag:
+
+```
+$ swift package --allow-writing-to-package-directory sourcery-code-generation
+```
+
+#### Running in Xcode
+
+Inside a project/package that uses this command plugin, right-click the project and select "SourceryCommand" from the "SourceryPlugins" menu group.
+
+> ⚠️ Note that this is only available from Xcode 14 onwards.
 
 ### Command line options
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ To provide a configuration for the plugin to use, place a `.sourcery.yml` file a
 To verify the plugin can be found by SwiftPM, use:
 
 ```
-$ swift package --list
+$ swift package plugin --list
 ```
 
 To run the code generator, you need to allow changes to the project with the `--allow-writing-to-package-directory` flag:

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ $ swift package --list
 To run the code generator, you need to allow changes to the project with the `--allow-writing-to-package-directory` flag:
 
 ```
-$ swift package --allow-writing-to-package-directory sourcery-code-generation
+$ swift package --allow-writing-to-package-directory sourcery-command
 ```
 
 #### Running in Xcode

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Inside a project/package that uses this command plugin, right-click the project 
 - `--prune` [default: false] - Prune empty generated files
 - `--version` - Display the current version of Sourcery
 - `--help` - Display help information
+- `--cacheBasePath` - Base path to the cache directory. Can be overriden by the config file.
 
 ### Configuration file
 

--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -111,8 +111,9 @@ func runCLI() {
         	or should be passed one by one (e.g. --args arg1=value --args arg2). Arguments are accessible in templates \
         	via `argument.<name>`. To pass in string you should use escaped quotes (\\").
         	"""),
-        Option<Path>("ejsPath", default: "", description: "Path to EJS file for JavaScript templates.")
-    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, configPaths, forceParse, args, ejsPath in
+        Option<Path>("ejsPath", default: "", description: "Path to EJS file for JavaScript templates."),
+        Option<Path>("cacheBasePath", default: "", description: "Base path to Sourcery's cache directory")
+    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, configPaths, forceParse, args, ejsPath, cacheBasePath in
         do {
             switch (quiet, verboseLogging) {
             case (true, _):
@@ -140,7 +141,7 @@ func runCLI() {
                             sources: Paths(include: sources, exclude: excludeSources) ,
                             templates: Paths(include: templates, exclude: excludeTemplates),
                             output: output.string.isEmpty ? "." : output,
-                            cacheBasePath: Path.defaultBaseCachePath,
+                            cacheBasePath: cacheBasePath.string.isEmpty ? Path.defaultBaseCachePath : cacheBasePath,
                             forceParse: forceParse,
                             parseDocumentation: parseDocumentation,
                             args: arguments
@@ -187,11 +188,13 @@ func runCLI() {
 
             let keepAlive = try configurations.flatMap { configuration -> [FolderWatcher.Local] in
                 configuration.validate()
+                
+                let shouldUseCacheBasePathArg = configuration.cacheBasePath == Path.defaultBaseCachePath && !cacheBasePath.string.isEmpty
 
                 let sourcery = Sourcery(verbose: verboseLogging,
                                         watcherEnabled: watcherEnabled,
                                         cacheDisabled: disableCache,
-                                        cacheBasePath: configuration.cacheBasePath,
+                                        cacheBasePath: shouldUseCacheBasePathArg ? cacheBasePath : configuration.cacheBasePath,
                                         prune: prune,
                                         serialParse: serialParse,
                                         arguments: configuration.args)


### PR DESCRIPTION
Following a conversation with @krzysztofzablocki and the creation of issue #1090, this PR starts the work to add support for Swift Package Plugins for `Sourcery`

At the moment, this PR only includes support for Swift Package command plugins but not for build plugins yet, I'll be investigating those next as there are a set of challenges which must be overcome.

This PR also updates to using `swift-tools` version 5.6 to be able to make use of SPM plugins.

## Discussion

I have left the `--disableCache` flag in this PR as I wanted to hear your opinion on how we can tackle the issue. From what I can see, since `cacheBasePath` is only an argument on config and not a cli argument, we have a few options:

* Remove the `--disableCache` parameter and not do anything else. The client will have to provide a `cacheBasePath` in the configuration file that is within the package directory. It might be a bit misleading and the plugin won't work out of the box.
* Read and re-write the `.sourcery.yml` to always provide a `cacheBasePath` that is in the `pluginWorkDirectory`. This could be done only when the key isn't present on the `.sourcery.yml` file?
* Make `cacheBasePath` a command line argument which can be used only when the config key isn't present. This allows the package to provide a 'default value' that works while allowing the user to modify it?

I think my preferred option is the last one, but keen to hear your thoughts as you might have a different opinion on it 👍 

## How to test the plugin

I have create a small repo called [sourcery-plugins-playground](https://github.com/pol-piella/sourcery-plugins-playground) which will help with the testing. There are two folders:

### swift-package-playground

#### Command Line

* `cd` into `swift-package-playground`.
* Do `swift package plugin --list` and verify that `sourcery-command` is part of the list.
* Run `swift package --allow-writing-to-package-directory sourcery-command`.
* Assert that a file named `AutoMockable.generated.swift` is generated in the right directory.

#### Xcode 14

* `cd` into `swift-package-playground`.
* Open `Package.swift`
* Right click on `swift-package-playground` package
* Run the `sorcery-command` from the list.
* This should generate the same file.

### xcodeproj-playground

#### Xcode 14

* `cd` into `xcodeproj-playground`.
* Open `SourceryPluginSampleProj.xcodeproj`
* Right click on the project and select the plugin
* The file that is missing should now be present, you can see it in the file explorer.

