### PR TITLE
SPM Plugin: Display target name when .sourcery.yml is not found

### DIFF
--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -36,7 +36,7 @@ extension SourceryCommandPlugin: CommandPlugin {
             
             guard FileManager.default.fileExists(atPath: configFilePath) else {
                 Diagnostics.warning("⚠️ Could not find `.sourcery.yml` for target \(target.name)")
-                return
+                continue
             }
             
             try run(sourcery, withConfig: configFilePath, cacheBasePath: context.pluginWorkDirectory.string)

--- a/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
+++ b/Plugins/SourceryCommandPlugin/SourceryCommandPlugin.swift
@@ -35,7 +35,7 @@ extension SourceryCommandPlugin: CommandPlugin {
             let sourcery = try context.tool(named: "SourceryExecutable").path.string
             
             guard FileManager.default.fileExists(atPath: configFilePath) else {
-                Diagnostics.warning("⚠️ Could not find `.sourcery.yml` for the given target")
+                Diagnostics.warning("⚠️ Could not find `.sourcery.yml` for target \(target.name)")
                 return
             }
             


### PR DESCRIPTION
When running the plugin on multiple targets, if the yml file was not found, it's helpful to which target name has the missing file. And then, continue with the next target instead of exiting out completely.

I don't think this should have a changelog entry because I'm updating code that hasn't been released yet and already has a changelog.