### PR TITLE
Add support for async and throwing properties to AutoMockable template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Main
 ## New Features
 - Adds support for public protocols in AutoMockable template [#1100](https://github.com/krzysztofzablocki/Sourcery/pull/1100)
+- Adds support for async and throwing properties to AutoMockable template [#1101](https://github.com/krzysztofzablocki/Sourcery/pull/1101)
 
 ## 1.9.0
 - Update StencilSwiftKit to fix SPM resolving issue when building as a Command Plugin [#1023](https://github.com/krzysztofzablocki/Sourcery/issues/1023)

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -128,8 +128,8 @@ import {{ import }}
 {% endmacro %}
 
 {% macro variableThrowableErrorUsage variable %}
-            if let {% call mockedVariableName variable %}ThrowableError {
-                throw {% call mockedVariableName variable %}ThrowableError
+            if let error = {% call mockedVariableName variable %}ThrowableError {
+                throw error
             }
 {% endmacro %}
 

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -115,18 +115,54 @@ import {{ import }}
     {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {{ variable.typeName }} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
 {% endmacro %}
 
-{% macro variableThrowableErrorUsage variable %}
-            if let {% call mockedVariableName variable %}ThrowableError {
-                throw {% call mockedVariableName variable %}ThrowableError
-            }
-{% endmacro %}
-
 {% macro mockNonOptionalVariable variable %}
     {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {{ variable.typeName }} {
         get { return {% call underlyingMockedVariableName variable %} }
         set(value) { {% call underlyingMockedVariableName variable %} = value }
     }
     {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}!
+{% endmacro %}
+
+{% macro variableThrowableErrorDeclaration variable %}
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}ThrowableError: Error?
+{% endmacro %}
+
+{% macro variableThrowableErrorUsage variable %}
+            if let {% call mockedVariableName variable %}ThrowableError {
+                throw {% call mockedVariableName variable %}ThrowableError
+            }
+{% endmacro %}
+
+{% macro variableClosureDeclaration variable %}
+    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}-> {{ variable.typeName }})?
+{% endmacro %}
+
+{% macro variableClosureName variable %}{% call mockedVariableName variable %}Closure{% endmacro %}
+
+{% macro mockAsyncOrThrowingVariable variable %}
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}CallsCount = 0
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}Called: Bool {
+        return {% call mockedVariableName variable %}CallsCount > 0
+    }
+
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {{ variable.typeName }} {
+        get {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}{
+            {% if variable.throws %}
+            {% call variableThrowableErrorUsage variable %}
+            {% endif %}
+            {% call mockedVariableName variable %}CallsCount += 1
+            if let {% call variableClosureName variable %} = {% call variableClosureName variable %} {
+                return {{ 'try ' if variable.throws }}{{ 'await ' if variable.isAsync }}{% call variableClosureName variable %}()
+            } else {
+                return {% call underlyingMockedVariableName variable %}
+            }
+        }
+    }
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}!
+    {% if variable.throws %}
+        {% call variableThrowableErrorDeclaration variable %}
+    {% endif %}
+    {% call variableClosureDeclaration method %}
 {% endmacro %}
 
 {% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
@@ -138,7 +174,7 @@ import {{ import }}
     {% if type.accessLevel == "public" %}public init() {}{% endif %}
 
 {% for variable in type.allVariables|!definedInExtension %}
-    {% if variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
+    {% if variable.isAsync or variable.throws %}{% call mockAsyncOrThrowingVariable variable %}{% elif variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
 {% endfor %}
 
 {% for method in type.allMethods|!definedInExtension %}

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -158,7 +158,7 @@ import {{ import }}
             }
         }
     }
-    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}!
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}{{ '!' if not variable.isOptional }}
     {% if variable.throws %}
         {% call variableThrowableErrorDeclaration variable %}
     {% endif %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -90,6 +90,21 @@ protocol FunctionWithMultilineDeclaration: AutoMockable {
                of model: String)
 }
 
+protocol ThrowingVariablesProtocol: AutoMockable {
+    var title: String? { get throws }
+    var firstName: String { get throws }
+}
+
+protocol AsyncVariablesProtocol: AutoMockable {
+    var title: String? { get async }
+    var firstName: String { get async }
+}
+
+protocol AsyncThrowingVariablesProtocol: AutoMockable {
+    var title: String? { get async throws }
+    var firstName: String { get async throws }
+}
+
 protocol AsyncProtocol: AutoMockable {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func callAsync(parameter: Int) async -> String

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -153,8 +153,8 @@ class AsyncThrowingVariablesProtocolMock: AsyncThrowingVariablesProtocol {
 
     var title: String? {
         get async throws {
-            if let titleThrowableError {
-                throw titleThrowableError
+            if let error = titleThrowableError {
+                throw error
             }
             titleCallsCount += 1
             if let titleClosure = titleClosure {
@@ -174,8 +174,8 @@ class AsyncThrowingVariablesProtocolMock: AsyncThrowingVariablesProtocol {
 
     var firstName: String {
         get async throws {
-            if let firstNameThrowableError {
-                throw firstNameThrowableError
+            if let error = firstNameThrowableError {
+                throw error
             }
             firstNameCallsCount += 1
             if let firstNameClosure = firstNameClosure {
@@ -645,8 +645,8 @@ class ThrowingVariablesProtocolMock: ThrowingVariablesProtocol {
 
     var title: String? {
         get throws {
-            if let titleThrowableError {
-                throw titleThrowableError
+            if let error = titleThrowableError {
+                throw error
             }
             titleCallsCount += 1
             if let titleClosure = titleClosure {
@@ -666,8 +666,8 @@ class ThrowingVariablesProtocolMock: ThrowingVariablesProtocol {
 
     var firstName: String {
         get throws {
-            if let firstNameThrowableError {
-                throw firstNameThrowableError
+            if let error = firstNameThrowableError {
+                throw error
             }
             firstNameCallsCount += 1
             if let firstNameClosure = firstNameClosure {

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -145,6 +145,88 @@ class AsyncProtocolMock: AsyncProtocol {
     }
 
 }
+class AsyncThrowingVariablesProtocolMock: AsyncThrowingVariablesProtocol {
+    var titleCallsCount = 0
+    var titleCalled: Bool {
+        return titleCallsCount > 0
+    }
+
+    var title: String? {
+        get async throws {
+            if let titleThrowableError {
+                throw titleThrowableError
+            }
+            titleCallsCount += 1
+            if let titleClosure = titleClosure {
+                return try await titleClosure()
+            } else {
+                return underlyingTitle
+            }
+        }
+    }
+    var underlyingTitle: String?!
+    var titleThrowableError: Error?
+    var titleClosure: (() async throws -> String?)?
+    var firstNameCallsCount = 0
+    var firstNameCalled: Bool {
+        return firstNameCallsCount > 0
+    }
+
+    var firstName: String {
+        get async throws {
+            if let firstNameThrowableError {
+                throw firstNameThrowableError
+            }
+            firstNameCallsCount += 1
+            if let firstNameClosure = firstNameClosure {
+                return try await firstNameClosure()
+            } else {
+                return underlyingFirstName
+            }
+        }
+    }
+    var underlyingFirstName: String!
+    var firstNameThrowableError: Error?
+    var firstNameClosure: (() async throws -> String)?
+
+}
+class AsyncVariablesProtocolMock: AsyncVariablesProtocol {
+    var titleCallsCount = 0
+    var titleCalled: Bool {
+        return titleCallsCount > 0
+    }
+
+    var title: String? {
+        get async {
+            titleCallsCount += 1
+            if let titleClosure = titleClosure {
+                return await titleClosure()
+            } else {
+                return underlyingTitle
+            }
+        }
+    }
+    var underlyingTitle: String?!
+    var titleClosure: (() async -> String?)?
+    var firstNameCallsCount = 0
+    var firstNameCalled: Bool {
+        return firstNameCallsCount > 0
+    }
+
+    var firstName: String {
+        get async {
+            firstNameCallsCount += 1
+            if let firstNameClosure = firstNameClosure {
+                return await firstNameClosure()
+            } else {
+                return underlyingFirstName
+            }
+        }
+    }
+    var underlyingFirstName: String!
+    var firstNameClosure: (() async -> String)?
+
+}
 class BasicProtocolMock: BasicProtocol {
 
     //MARK: - loadConfiguration
@@ -553,6 +635,51 @@ class ThrowableProtocolMock: ThrowableProtocol {
         doOrThrowVoidCallsCount += 1
         try doOrThrowVoidClosure?()
     }
+
+}
+class ThrowingVariablesProtocolMock: ThrowingVariablesProtocol {
+    var titleCallsCount = 0
+    var titleCalled: Bool {
+        return titleCallsCount > 0
+    }
+
+    var title: String? {
+        get throws {
+            if let titleThrowableError {
+                throw titleThrowableError
+            }
+            titleCallsCount += 1
+            if let titleClosure = titleClosure {
+                return try titleClosure()
+            } else {
+                return underlyingTitle
+            }
+        }
+    }
+    var underlyingTitle: String?!
+    var titleThrowableError: Error?
+    var titleClosure: (() throws -> String?)?
+    var firstNameCallsCount = 0
+    var firstNameCalled: Bool {
+        return firstNameCallsCount > 0
+    }
+
+    var firstName: String {
+        get throws {
+            if let firstNameThrowableError {
+                throw firstNameThrowableError
+            }
+            firstNameCallsCount += 1
+            if let firstNameClosure = firstNameClosure {
+                return try firstNameClosure()
+            } else {
+                return underlyingFirstName
+            }
+        }
+    }
+    var underlyingFirstName: String!
+    var firstNameThrowableError: Error?
+    var firstNameClosure: (() throws -> String)?
 
 }
 class VariablesProtocolMock: VariablesProtocol {

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -164,7 +164,7 @@ class AsyncThrowingVariablesProtocolMock: AsyncThrowingVariablesProtocol {
             }
         }
     }
-    var underlyingTitle: String?!
+    var underlyingTitle: String?
     var titleThrowableError: Error?
     var titleClosure: (() async throws -> String?)?
     var firstNameCallsCount = 0
@@ -206,7 +206,7 @@ class AsyncVariablesProtocolMock: AsyncVariablesProtocol {
             }
         }
     }
-    var underlyingTitle: String?!
+    var underlyingTitle: String?
     var titleClosure: (() async -> String?)?
     var firstNameCallsCount = 0
     var firstNameCalled: Bool {
@@ -656,7 +656,7 @@ class ThrowingVariablesProtocolMock: ThrowingVariablesProtocol {
             }
         }
     }
-    var underlyingTitle: String?!
+    var underlyingTitle: String?
     var titleThrowableError: Error?
     var titleClosure: (() throws -> String?)?
     var firstNameCallsCount = 0


### PR DESCRIPTION
## Description

In this PR I added support for async and throwing properties to the AutoMockable template.

I stuck to the conventions and naming format for methods that are async or throwing so hopefully will fit in nicely.

Also as part of #1100 I accidentally used newer Swift 5.7 syntax for short hand `if let` [here](https://github.com/krzysztofzablocki/Sourcery/pull/1100/files#diff-d1a76d8be64f16b06e46276c0629c11faccb5bba6b1e3db81c79f6a1bad6c44aR119) in a Stencil macro, but nothing called that macro (it was for this PR). I've reverted to the older style anyways in this PR to not break the template for anyone using an older version of Swift.

Happy for any feedback or changes that I can make to help get this merged. Thanks again :)