### PR TITLE
Add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: sourcery
+  name: Sourcery
+  description: ''
+  language: swift
+  entry: sourcery
+  require_serial: true
+  pass_filenames: false
+  always_run: true
+  args: ["--sources", "<sources path>", "--templates", "<templates path>", "--output", "<output path>"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: sourcery
   name: Sourcery
-  description: ''
+  description: 'Meta-programming for Swift, stop writing boilerplate code.'
   language: swift
   entry: sourcery
   require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,4 +6,3 @@
   require_serial: true
   pass_filenames: false
   always_run: true
-  args: ["--sources", "<sources path>", "--templates", "<templates path>", "--output", "<output path>"]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Add the package dependency to your `Package.swift` manifest from version `1.8.3`
 .package(url: "https://github.com/krzysztofzablocki/Sourcery.git", from: "1.8.3")
 ```
 
+- _[pre-commit](https://pre-commit.com/)_
+Add the dependency to `.pre-commit-config.yaml`.
+
+```
+- repo: https://github.com/krzysztofzablocki/Sourcery
+  rev: 1.9.1
+  hooks:
+  - id: sourcery
+```
+
 ## Documentation
 
 Full documentation for the latest release is available [here](http://merowing.info/Sourcery/).


### PR DESCRIPTION
We want to switch managing code generators / formatters / linters to https://pre-commit.com/ because it easily allows updating at different times in different repos, as opposed to brew always installing the latest version globally. This requires the presence of a `.pre-commit-hooks.yaml` in the root.