### PR TITLE
Support for type method mocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Sourcery CHANGELOG
 
+## New Features
+
+- add support for type methods to AutoMockable
 ## 1.9.2
 ## Internal Changes
 - Reverts part of [#1113](https://github.com/krzysztofzablocki/Sourcery/pull/1113) due to incomplete implementation breaking type complex resolution

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -20,8 +20,10 @@ import {{ import }}
 
 {% macro accessLevel level %}{% if level != 'internal' %}{{ level }} {% endif %}{% endmacro %}
 
+{% macro staticSpecifier method %}{% if method.isStatic and not method.isInitializer %}static {% endif %}{% endmacro %}
+
 {% macro methodThrowableErrorDeclaration method %}
-    {% call accessLevel method.accessLevel %}var {% call swiftifyMethodName method.selectorName %}ThrowableError: Error?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ThrowableError: Error?
 {% endmacro %}
 
 {% macro methodThrowableErrorUsage method %}
@@ -47,7 +49,7 @@ import {{ import }}
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call closureReturnTypeName method %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call closureReturnTypeName method %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -59,20 +61,20 @@ import {{ import }}
         {% call methodThrowableErrorDeclaration method %}
     {% endif %}
     {% if not method.isInitializer %}
-    {% call accessLevel method.accessLevel %}var {% call swiftifyMethodName method.selectorName %}CallsCount = 0
-    {% call accessLevel method.accessLevel %}var {% call swiftifyMethodName method.selectorName %}Called: Bool {
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}CallsCount = 0
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}Called: Bool {
         return {% call swiftifyMethodName method.selectorName %}CallsCount > 0
     }
     {% endif %}
     {% if method.parameters.count == 1 %}
-    {% call accessLevel method.accessLevel %}var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
-    {% call accessLevel method.accessLevel %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 %}
-    {% call accessLevel method.accessLevel %}var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})?
-    {% call accessLevel method.accessLevel %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
-    {% call accessLevel method.accessLevel %}var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ method.returnTypeName }}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ '!' if not method.isOptionalReturnType }}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ method.returnTypeName }}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ '!' if not method.isOptionalReturnType }}
     {% endif %}
     {% call methodClosureDeclaration method %}
 
@@ -87,7 +89,7 @@ import {{ import }}
     {{ value }}
     {% endfor %}
     {% endfor %}
-    {% call accessLevel method.accessLevel %}func {{ method.name }}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}func {{ method.name }}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
         {% if method.throws %}
         {% call methodThrowableErrorUsage method %}
         {% endif %}
@@ -105,6 +107,28 @@ import {{ import }}
     }
 
 {% endif %}
+{% endmacro %}
+
+{% macro resetMethod method %}
+        {# for type method which are mocked, a way to reset the invocation, argument, etc #}
+        {% if method.isStatic and not method.isInitializer %} //MARK: - {{ method.shortName }}
+        {% if not method.isInitializer %}
+        {% call swiftifyMethodName method.selectorName %}CallsCount = 0
+        {% endif %}
+        {% if method.parameters.count == 1 %}
+        {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}{% endfor %} = nil
+        {% call swiftifyMethodName method.selectorName %}ReceivedInvocations = []
+        {% elif not method.parameters.count == 0 %}
+        {% call swiftifyMethodName method.selectorName %}ReceivedArguments = nil
+        {% call swiftifyMethodName method.selectorName %}ReceivedInvocations = []
+        {% endif %}
+        {% call methodClosureName method %} = nil
+        {% if method.throws %}
+        {% call swiftifyMethodName method.selectorName %}ThrowableError = nil
+        {% endif %}
+        
+        {% endif %}
+
 {% endmacro %}
 
 {% macro mockOptionalVariable variable %}
@@ -176,6 +200,15 @@ import {{ import }}
 {% for variable in type.allVariables|!definedInExtension %}
     {% if variable.isAsync or variable.throws %}{% call mockAsyncOrThrowingVariable variable %}{% elif variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
 {% endfor %}
+
+{% if type.allMethods|static|count != 0 and type.allMethods|initializer|count != type.allMethods|static|count %}
+    static func reset()
+    {
+    {% for method in type.allMethods|static %}
+        {% call resetMethod method %}
+    {% endfor %}
+    }
+{% endif %}
 
 {% for method in type.allMethods|!definedInExtension %}
     {% call mockMethod method %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -133,3 +133,7 @@ public protocol AccessLevelProtocol: AutoMockable {
     
     func loadConfiguration() -> String?
 }
+
+protocol StaticMethodProtocol:AutoMockable {
+    static func staticFunction(String) -> String
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1,3 +1,8 @@
+// Generated using Sourcery 1.9.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+// swiftlint:disable line_length
+// swiftlint:disable variable_name
+
 import Foundation
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
@@ -592,6 +597,43 @@ class SingleOptionalParameterFunctionMock: SingleOptionalParameterFunction {
         sendMessageReceivedMessage = message
         sendMessageReceivedInvocations.append(message)
         sendMessageClosure?(message)
+    }
+
+}
+class StaticMethodProtocolMock: StaticMethodProtocol {
+
+
+
+    static func reset()
+    {
+         //MARK: - staticFunction
+        staticFunctionCallsCount = 0
+        staticFunctionReceived = nil
+        staticFunctionReceivedInvocations = []
+        staticFunctionClosure = nil
+
+    }
+
+    //MARK: - staticFunction
+
+    static var staticFunctionCallsCount = 0
+    static var staticFunctionCalled: Bool {
+        return staticFunctionCallsCount > 0
+    }
+    static var staticFunctionReceived: String?
+    static var staticFunctionReceivedInvocations: [String] = []
+    static var staticFunctionReturnValue: String!
+    static var staticFunctionClosure: ((String) -> String)?
+
+    static func staticFunction(_: String) -> String {
+        staticFunctionCallsCount += 1
+        staticFunctionReceived = 
+        staticFunctionReceivedInvocations.append()
+        if let staticFunctionClosure = staticFunctionClosure {
+            return staticFunctionClosure()
+        } else {
+            return staticFunctionReturnValue
+        }
     }
 
 }


### PR DESCRIPTION
This pull request is to address issue #1072: adding support for mocking class methods

As no object is created when calling a class method, keeping track of calls is done on static variable and a reset method is added to reset the mock between tests