### PR TITLE
Don't generate invocations vars for methods with non-escaping closures in AutoMockable template

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -33,11 +33,16 @@ import {{ import }}
 {% endmacro %}
 
 {% macro methodReceivedParameters method %}
-    {%if method.parameters.count == 1 %}
+    {% set hasNonEscapingClosures %}
+        {%- for param in method.parameters where param.isClosure and not param.typeAttributes.escaping %}
+            {{ true }}
+        {% endfor -%}
+    {% endset %}
+    {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {{ param.name }}{% endfor %}
         {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append({% for param in method.parameters %}{{ param.name }}){% endfor %}
     {% else %}
-    {% if not method.parameters.count == 0 %}
+    {% if not method.parameters.count == 0 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method.selectorName %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
         {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append(({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}))
     {% endif %}
@@ -66,10 +71,15 @@ import {{ import }}
         return {% call swiftifyMethodName method.selectorName %}CallsCount > 0
     }
     {% endif %}
-    {% if method.parameters.count == 1 %}
+    {% set hasNonEscapingClosures %}
+        {%- for param in method.parameters where param.isClosure and not param.typeAttributes.escaping %}
+            {{ true }}
+        {% endfor -%}
+    {% endset %}
+    {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
-    {% elif not method.parameters.count == 0 %}
+    {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})?
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -71,6 +71,18 @@ protocol ClosureProtocol: AutoMockable {
     func setClosure(_ closure: @escaping () -> Void)
 }
 
+protocol MultiClosureProtocol: AutoMockable {
+    func setClosure(name: String, _ closure: @escaping () -> Void)
+}
+
+protocol NonEscapingClosureProtocol: AutoMockable {
+    func executeClosure(_ closure: () -> Void)
+}
+
+protocol MultiNonEscapingClosureProtocol: AutoMockable {
+    func executeClosure(name: String, _ closure: () -> Void)
+}
+
 /// sourcery: AutoMockable
 protocol AnnotatedProtocol {
     func sayHelloWith(name: String)

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -518,6 +518,58 @@ class InitializationProtocolMock: InitializationProtocol {
     }
 
 }
+class MultiClosureProtocolMock: MultiClosureProtocol {
+
+    //MARK: - setClosure
+
+    var setClosureNameCallsCount = 0
+    var setClosureNameCalled: Bool {
+        return setClosureNameCallsCount > 0
+    }
+    var setClosureNameReceivedArguments: (name: String, closure: () -> Void)?
+    var setClosureNameReceivedInvocations: [(name: String, closure: () -> Void)] = []
+    var setClosureNameClosure: ((String, @escaping () -> Void) -> Void)?
+
+    func setClosure(name: String, _ closure: @escaping () -> Void) {
+        setClosureNameCallsCount += 1
+        setClosureNameReceivedArguments = (name: name, closure: closure)
+        setClosureNameReceivedInvocations.append((name: name, closure: closure))
+        setClosureNameClosure?(name, closure)
+    }
+
+}
+class MultiNonEscapingClosureProtocolMock: MultiNonEscapingClosureProtocol {
+
+    //MARK: - executeClosure
+
+    var executeClosureNameCallsCount = 0
+    var executeClosureNameCalled: Bool {
+        return executeClosureNameCallsCount > 0
+    }
+    var executeClosureNameClosure: ((String, () -> Void) -> Void)?
+
+    func executeClosure(name: String, _ closure: () -> Void) {
+        executeClosureNameCallsCount += 1
+        executeClosureNameClosure?(name, closure)
+    }
+
+}
+class NonEscapingClosureProtocolMock: NonEscapingClosureProtocol {
+
+    //MARK: - executeClosure
+
+    var executeClosureCallsCount = 0
+    var executeClosureCalled: Bool {
+        return executeClosureCallsCount > 0
+    }
+    var executeClosureClosure: ((() -> Void) -> Void)?
+
+    func executeClosure(_ closure: () -> Void) {
+        executeClosureCallsCount += 1
+        executeClosureClosure?(closure)
+    }
+
+}
 class ReservedWordsProtocolMock: ReservedWordsProtocol {
 
     //MARK: - `continue`


### PR DESCRIPTION
### The issue
AutoMockable generated code cannot compile when used with methods with non-escaping closures.
```swift
    /// source
    func executeClosure(_ closure: () -> Void)
    /// generated
    var executeClosureReceivedClosure: (() -> Void)?
    func executeClosure(_ closure: () -> Void) {
        executeClosureCallsCount += 1
        executeClosureReceivedClosure = closure
        executeClosureReceivedInvocations.append(closure)
        executeClosureClosure?(closure)
    }
    /// error:
    // Assigning non-escaping parameter 'closure' to an @escaping closure
    // Parameter 'closure' is implicitly non-escaping
```
Non-escaping closures cannot be written to an escaping var

### Solution
Skip generation of Closure/Arguments/Invocations variables
Unit test various cases

### Possible improvements
1. Move implementation of hasNonEscapingClosures to a stencil filter
2. When using multiple parameters, generate Closure/Arguments/Invocations vars only without non-escaping parameters