### PR TITLE
Bump swift-syntax to 0.50800.0-SNAPSHOT-2022-12-29-a

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
         .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("093e5ee151d206454e2c1950d81333c4d4a4472e")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", branch: "0.50800.0-SNAPSHOT-2022-12-29-a"),
         .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
     ],


### PR DESCRIPTION
As discussed in: https://github.com/krzysztofzablocki/Sourcery/issues/1102#issuecomment-1386498064