### PR TITLE
Handle UTF-8 offsets as such

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sourcery CHANGELOG
 
+## x.x.x
+## Internal Changes
+- Fixed non-ASCII characters handling in source code parsing [#1130](https://github.com/krzysztofzablocki/Sourcery/pull/1130)
+
 ## 2.0.0
 ## Changes
 - sourcery:auto inline fragments will appear on the body definition level

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -6,7 +6,7 @@ extension SyntaxProtocol {
     @inlinable
     var sourcerySafeTypeIdentifier: String {
         let content = description
-        return String(content[content.index(content.startIndex, offsetBy: leadingTriviaLength.utf8Length)..<content.index(content.endIndex, offsetBy: -trailingTriviaLength.utf8Length)])
+        return String(content[content.utf8.index(content.startIndex, offsetBy: leadingTriviaLength.utf8Length)..<content.utf8.index(content.endIndex, offsetBy: -trailingTriviaLength.utf8Length)])
 
         // TBR: we only need this because we are trying to fit into old AST naming
         // TODO: there is a bug in syntax that sometimes crashes with unexpected nil when removing trivia


### PR DESCRIPTION
Closes #1129

UTF-8 offsets were incorrectly used as character offsets so I fixed that.