### PR TITLE
Support multibyte in annotation parsing

### DIFF
--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -152,11 +152,13 @@ public struct AnnotationsParser {
         return documentation.reversed()
     }
 
-
+    
     func inlineFrom(line lineInfo: (line: Int, character: Int), stop: inout Bool) -> Annotations {
         let sourceLine = lines[lineInfo.line - 1]
-        var prefix = sourceLine.content.bridge()
-            .substring(to: max(0, lineInfo.character - 1))
+        
+        let string = String(String(cString: Array(sourceLine.content.utf8CString[0...max(0, lineInfo.character)] + CollectionOfOne(CChar(0)))).dropLast(1))
+        
+        var prefix = string.bridge()
             .trimmingCharacters(in: .whitespaces)
 
         guard !prefix.isEmpty else { return [:] }


### PR DESCRIPTION
I got a minor issue that fails to parse when codes are using multibyte, like following

```swift
enum Foo {
  case こんにちは(Int)
}
```

It crashes by out-of-bounds in a string due to making a substring from the offset.
Offset is technically bytes offset, it's not UTF8's offset.

I did only work on processing string with offset in a correct way.

I'm not an expert on string processing.
Please correct me in a better way.

Thank you for your super helpful tool.

