### PR TITLE
Fixed properties with composite type in mock template

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -154,7 +154,8 @@ import {{ import }}
         get { return {% call underlyingMockedVariableName variable %} }
         set(value) { {% call underlyingMockedVariableName variable %} = value }
     }
-    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}!
+    {% set wrappedTypeName %}{% if variable.typeName.isProtocolComposition %}({{ variable.typeName }}){% else %}{{ variable.typeName }}{% endif %}{% endset %}
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {{ wrappedTypeName }}!
 {% endmacro %}
 
 {% macro variableThrowableErrorDeclaration variable %}


### PR DESCRIPTION
I found a small issue with composite types in mocks.

Example
```swift
protocol Prot1 {}
protocol Prot2 {}

// sourcery: AutoMockable
protocol Abc {
    var property: Prot2 & Prot1 { get }
}
```

Sourcery generates:
```swift
protocol Prot1 {}
protocol Prot2 {}

// sourcery: AutoMockable
class AbcMock: Abc {
    var property: Prot2 & Prot1 {
        get { return underlyingProperty }
        set(value) { underlyingProperty = value }
    }
    var underlyingProperty: Prot2 & Prot1!
}
```

But compiler doesn't like ``` var underlyingProperty: Prot2 & Prot1!```
Should be ```var underlyingProperty: (Prot2 & Prot1)!```

This PR fixes it