### PR TITLE
Added ability to wrap mocks under define

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -1,6 +1,7 @@
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
 
+{% if argument.mockWrapDefine != nil %}#if {{ argument.mockWrapDefine }}{% endif %}
 import Foundation
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
@@ -225,3 +226,4 @@ import {{ import }}
 {% endfor %}
 }
 {% endif %}{% endfor %}
+{% if argument.mockWrapDefine != nil %}#endif // {{ argument.mockWrapDefine }}{% endif %}


### PR DESCRIPTION
Currently mocks don't have ability to be hidden for some purposes, e.g. release/production.
Yes, we can generate them only in unit-test targets, but this approach does not work in multi-modules real app:
when I want mocks from moduleA in tests of moduleB and moduleC.

So it's better to put generated mocks in moduleA, but wrap them under define, so they will not expose in release code.
To do that, I add new optional argument ```mockWrapDefine```