### PR TITLE
Add a new command line argument to allow setting an optional build directory for .swifttemplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Inside a project/package that uses this command plugin, right-click the project 
 - `--version` - Display the current version of Sourcery
 - `--help` - Display help information
 - `--cacheBasePath` - Base path to the cache directory. Can be overriden by the config file.
+-  `--buildPath` - Path to directory used when building from .swifttemplate files. This defaults to system temp directory
 
 ### Configuration file
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Inside a project/package that uses this command plugin, right-click the project 
 - `--version` - Display the current version of Sourcery
 - `--help` - Display help information
 - `--cacheBasePath` - Base path to the cache directory. Can be overriden by the config file.
--  `--buildPath` - Path to directory used when building from .swifttemplate files. This defaults to system temp directory
+- `--buildPath` - Path to directory used when building from .swifttemplate files. This defaults to system temp directory
 
 ### Configuration file
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -29,6 +29,7 @@ public class Sourcery {
     fileprivate let arguments: [String: NSObject]
     fileprivate let cacheDisabled: Bool
     fileprivate let cacheBasePath: Path?
+    fileprivate let buildPath: Path?
     fileprivate let prune: Bool
     fileprivate let serialParse: Bool
 
@@ -44,12 +45,13 @@ public class Sourcery {
     fileprivate var fileAnnotatedContent: [Path: [String]] = [:]
 
     /// Creates Sourcery processor
-    public init(verbose: Bool = false, watcherEnabled: Bool = false, cacheDisabled: Bool = false, cacheBasePath: Path? = nil, prune: Bool = false, serialParse: Bool = false, arguments: [String: NSObject] = [:]) {
+  public init(verbose: Bool = false, watcherEnabled: Bool = false, cacheDisabled: Bool = false, cacheBasePath: Path? = nil, buildPath: Path? = nil, prune: Bool = false, serialParse: Bool = false, arguments: [String: NSObject] = [:]) {
         self.verbose = verbose
         self.arguments = arguments
         self.watcherEnabled = watcherEnabled
         self.cacheDisabled = cacheDisabled
         self.cacheBasePath = cacheBasePath
+        self.buildPath = buildPath
         self.prune = prune
         self.serialParse = serialParse
     }
@@ -242,7 +244,7 @@ public class Sourcery {
                 }
             } else if $0.extension == "swifttemplate" {
                 let cachePath = cachesDir(sourcePath: $0)
-                return try SwiftTemplate(path: $0, cachePath: cachePath, version: type(of: self).version)
+                return try SwiftTemplate(path: $0, cachePath: cachePath, version: type(of: self).version, buildPath: buildPath)
             } else if $0.extension == "ejs" {
                 guard EJSTemplate.ejsPath != nil else {
                     Log.warning("Skipping template \($0). JavaScript templates require EJS path to be set manually when using Sourcery built with Swift Package Manager. Use `--ejsPath` command line argument to set it.")
@@ -272,7 +274,7 @@ extension Sourcery {
 
     typealias ParserWrapper = (path: Path, parse: () throws -> FileParserResult?)
 
-    fileprivate func parse(from: [Path], exclude: [Path] = [], forceParse: [String] = [], parseDocumentation: Bool, modules: [String]?, requiresFileParserCopy: Bool) throws -> ParsingResult {
+  fileprivate func parse(from: [Path], exclude: [Path] = [], forceParse: [String] = [], parseDocumentation: Bool, modules: [String]?, requiresFileParserCopy: Bool) throws -> ParsingResult {
         if let modules = modules {
             precondition(from.count == modules.count, "There should be module for each file to parse")
         }

--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -115,8 +115,9 @@ func runCLI() {
         	via `argument.<name>`. To pass in string you should use escaped quotes (\\").
         	"""),
         Option<Path>("ejsPath", default: "", description: "Path to EJS file for JavaScript templates."),
-        Option<Path>("cacheBasePath", default: "", description: "Base path to Sourcery's cache directory")
-    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, ejsPath, cacheBasePath in
+        Option<Path>("cacheBasePath", default: "", description: "Base path to Sourcery's cache directory"),
+        Option<Path>("buildPath", default: "", description: "Sets a custom build path")
+    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, ejsPath, cacheBasePath, buildPath in
         do {
             Log.stackMessages = isDryRun
             switch (quiet, verboseLogging) {
@@ -200,6 +201,7 @@ func runCLI() {
                                         watcherEnabled: watcherEnabled,
                                         cacheDisabled: disableCache,
                                         cacheBasePath: shouldUseCacheBasePathArg ? cacheBasePath : configuration.cacheBasePath,
+                                        buildPath: buildPath.string.isEmpty ? nil : buildPath,
                                         prune: prune,
                                         serialParse: serialParse,
                                         arguments: configuration.args)

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -25,6 +25,7 @@ private struct ProcessResult {
 open class SwiftTemplate {
 
     public let sourcePath: Path
+    let buildPath: Path?
     let cachePath: Path?
     let code: String
     let version: String?
@@ -32,12 +33,18 @@ open class SwiftTemplate {
 
     private lazy var buildDir: Path = {
         let pathComponent = "SwiftTemplate" + (version.map { "/\($0)" } ?? "")
+
+         if let buildPath {
+            return buildPath + pathComponent
+         }
+
         guard let tempDirURL = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(pathComponent) else { fatalError("Unable to get temporary path") }
         return Path(tempDirURL.path)
     }()
 
-    public init(path: Path, cachePath: Path? = nil, version: String? = nil) throws {
+  public init(path: Path, cachePath: Path? = nil, version: String? = nil, buildPath: Path? = nil) throws {
         self.sourcePath = path
+        self.buildPath = buildPath
         self.cachePath = cachePath
         self.version = version
         (self.code, self.includedFiles) = try SwiftTemplate.parse(sourcePath: path)


### PR DESCRIPTION
what:

This adds a new command line argument to allow setting an optional build directory for .swifttemplates. When this is set the custom directory is used. If it's not set, then the system temp directory is used as before. 

why: 

As documented in [1142](https://github.com/krzysztofzablocki/Sourcery/issues/1142), when running several concurrent instances of sourcery there can be conflicts if they are all trying to write to the same temporary directory. 

This scenario in which this happened for me is after creating a swift package manager plugin to generate mocks, and running that plugin on multiple targets within the same project or package file.  This was causing build failures. 

Allowing the plugin to set this new command line argument to its own work directory has resolved this issue as each target the plugin operates on has its own work directory. 

