### PR TITLE
[SPM] Update to latest stable swift-syntax release

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "branch" : "0.50800.0-SNAPSHOT-2022-12-29-a",
-        "revision" : "edd2d0cdb988ac45e2515e0dd0624e4a6de54a94"
+        "revision" : "cd793adf5680e138bf2bcbaacc292490175d0dcd",
+        "version" : "508.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
         .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
     ],
@@ -52,7 +52,7 @@ let package = Package(
                 "PathKit",
                 "Yams",
                 "StencilSwiftKit",
-                .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
                 "XcodeProj",
                 "TryCatch"
             ],
@@ -82,8 +82,8 @@ let package = Package(
             name: "SourceryFramework",
             dependencies: [
               "PathKit",
-              .product(name: "SwiftSyntax", package: "SwiftSyntax"),
-              .product(name: "SwiftParser", package: "SwiftSyntax"),
+              .product(name: "SwiftSyntax", package: "swift-syntax"),
+              .product(name: "SwiftParser", package: "swift-syntax"),
               "SourceryUtils",
               "SourceryRuntime"
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
         .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", branch: "0.50800.0-SNAPSHOT-2022-12-29-a"),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
     ],

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/FileParserSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/FileParserSyntax.swift
@@ -41,7 +41,7 @@ public final class FileParserSyntax: SyntaxVisitor, FileParserType {
         inlineIndentations = inline.annotatedRanges.mapValues { $0[0].indentation }
 
         // Syntax walking
-        let tree = try Parser.parse(source: contents)
+        let tree = Parser.parse(source: contents)
         let fileName = path ?? "in-memory"
         let sourceLocationConverter = SourceLocationConverter(file: fileName, tree: tree)
         let collector = SyntaxTreeCollector(


### PR DESCRIPTION
A [stable version of swift-syntax for Swift 5.8](https://github.com/apple/swift-syntax/releases/tag/508.0.0) has now been released. This PR updates Sourcery's `Package.swift` file to help fix the issues around SPM complaining about the source-unstable version when resolving dependencies.