### PR TITLE
Update `SwiftTemplate`'s cacheKey to use hash instead of modification date for included files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sourcery CHANGELOG
 
+## 2.0.3
+## Internal Changes
+- Modifications to included files of Swift Templates are now detected by hashing instead of using the modification date when invalidating the cache ([#1161](https://github.com/krzysztofzablocki/Sourcery/pull/1161))
+
 ## 2.0.2
 - Fixes incorrectly parsed variable names that include property wrapper and comments, closes #1140
 

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -284,8 +284,8 @@ open class SwiftTemplate {
         // For every included file, make sure that the path and modification date are included in the key
         let files = includedFiles.map({ $0.absolute() }).sorted(by: { $0.string < $1.string })
         for file in files {
-            let modificationDate = file.modifiedDate?.timeIntervalSinceReferenceDate ?? 0
-            contents += "\n// \(file.string)-\(modificationDate)"
+            let hash = (try? file.read().sha256().base64EncodedString()) ?? ""
+            contents += "\n// \(file.string)-\(hash)"
         }
 
         return contents.sha256()


### PR DESCRIPTION
# Background 

- #1042

In #1042, I solved #889 by including the modification date of each `include` file in order to correctly invalidate the cache when these files were modified, however today while trying to optimise caching on my CI, I noticed that our .swifttemplate binaries were being recompiled even though I had been preserving the ~/Library/Caches/Sourcery directory. 

After a little amount of digging, I realised that this was because Git doesn't preserve modification dates. It's likely that this isn't an issue for most uses, but it prevents the cache from being useful in the scenario that I described above.

# Changes

To overcome the issue, I've instead updated the `cacheKey` implementation to include a SHA256 hash of each included file. I opted against this before because checking the modification date was more efficient, but given that this option is out of the question (should we want to support the CI use case), I figure that hashing the files should be the next best thing.

Rendering only happens once per template anyway and I can't see included files ever being big enough for this to cause a performance issue so let me know what you think! If I'm being too naive here then let me know... This change is based on my limited personal usage so I'd love some feedback.

I haven't updated tests since the existing ones capture the change: 

https://github.com/krzysztofzablocki/Sourcery/blob/d441f56ba972d04014c6de0f48ac17861ce629f3/SourceryTests/Generating/SwiftTemplateSpecs.swift#L232-L249