### PR TITLE
Added "SourceryLib" product to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .library(name: "SourceryJS", targets: ["SourceryJS"]),
         .library(name: "SourcerySwift", targets: ["SourcerySwift"]),
         .library(name: "SourceryFramework", targets: ["SourceryFramework"]),
+        .library(name: "SourceryLib", targets: ["SourceryLib"]),
         .plugin(name: "SourceryCommandPlugin", targets: ["SourceryCommandPlugin"])
     ],
     dependencies: [


### PR DESCRIPTION
In order to facilitate importing of `SourceryLib` when `Sourcery` and `Configuration` types are needed, 
"SourceryLib" product needs to be exposed.

Example:

```swift
import SourceryLib
import PathKit

public struct SourceryUseExample {
    public private(set) var text = "Hello, World!"

    public init() throws {
        let sourcery = Sourcery()
        let configuration = try Configuration(path: Path(), relativePath: Path())
        let watchers = try sourcery.processFiles(configuration.source, usingTemplates: configuration.templates, output: configuration.output, baseIndentation: configuration.baseIndentation)
        // use [FolderWatcher.Local] ...
    }
}
```

Here, user of `SourceryLib` can implement custom additonal post-processing, as well as use different techniques around calls to `Sourcery` as compared to using compiled executable when these types are inaccessible, as well as `SouceryFramework` which does not expose these types does not help in achieving such uses.

