### PR TITLE
[CI] fix failing doc generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -113,7 +113,7 @@ task :docs do
   print_info "Updating docs"
   temp_build_dir = "#{BUILD_DIR}tmp/"
   # tac Enum.html | sed '2d' | tac > Enum.html
-  sh "sourcekitten doc --spm --module-name SourceryRuntime > docs.json && bundle exec jazzy --clean --skip-undocumented --exclude=/*/*.generated.swift,/*/BytesRange.swift,/*/Typealias.swift,/*/FileParserResult.swift && rm docs.json"
+  sh "sourcekitten doc --spm --module-name SourceryRuntime > docs.json && bundle exec jazzy --clean --skip-undocumented && rm docs.json"
   clean_jazzy
   sh "rm -fr #{temp_build_dir}"
 end
@@ -122,7 +122,7 @@ desc "Validate docs"
 task :validate_docs do
   print_info "Checking docs are up to date"
   temp_build_dir = "#{BUILD_DIR}tmp/"
-  sh "sourcekitten doc --spm --module-name SourceryRuntime > docs.json && bundle exec jazzy --skip-undocumented --exclude=/*/*.generated.swift,/*/BytesRange.swift,/*/Typealias.swift,/*/FileParserResult.swift && rm docs.json"
+  sh "sourcekitten doc --spm --module-name SourceryRuntime > docs.json && bundle exec jazzy --skip-undocumented && rm docs.json"
   clean_jazzy
   sh "rm -fr #{temp_build_dir}"
 end


### PR DESCRIPTION
Hey @krzysztofzablocki 🙌

I am unsure about this change, but seems like `jazzy` fails to work if the folders or files cannot be located / found. I have checked, and these files do not exist in the `sourcery` folder, maybe these are leftovers?

Thank you 🙏 