### PR TITLE
Fix enum case with rawValue includes trailing comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Modifications to included files of Swift Templates are now detected by hashing instead of using the modification date when invalidating the cache ([#1161](https://github.com/krzysztofzablocki/Sourcery/pull/1161))
 - Fixes incorrectly parsed /r/n newline sequences ([#1165](https://github.com/krzysztofzablocki/Sourcery/issues/1165) and [#1138](https://github.com/krzysztofzablocki/Sourcery/issues/1138))
 - Fixes incorrect parsing of annotations if there are attributes on lines preceeding declaration ([#1141](https://github.com/krzysztofzablocki/Sourcery/issues/1141))
+- Fixes incorrect parsing of trailing inline comments following enum case' rawValue ([#1154](https://github.com/krzysztofzablocki/Sourcery/issues/1154))
 
 ## 2.0.2
 - Fixes incorrectly parsed variable names that include property wrapper and comments, closes #1140

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/EnumCase+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/EnumCase+SwiftSyntax.swift
@@ -36,7 +36,7 @@ extension EnumCase {
         }
 
         let rawValue: String? = {
-            var value = node.rawValue?.withEqual(nil).description.trimmed
+            var value = node.rawValue?.withEqual(nil).withTrailingTrivia(.zero).description.trimmed
             if let unwrapped = value, unwrapped.hasPrefix("\""), unwrapped.hasSuffix("\""), unwrapped.count > 2 {
                 let substring = unwrapped[unwrapped.index(after: unwrapped.startIndex) ..< unwrapped.index(before: unwrapped.endIndex)]
                 value = String(substring)

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -827,6 +827,15 @@ class FileParserSpec: QuickSpec {
                                         EnumCase(name: "optionB", rawValue: "0")
                                     ])
                             ]))
+
+                        expect(parse("""
+                                     enum Foo: Int {
+                                       case optionA = 2 // comment
+                                     }
+                                     """))
+                            .to(equal([
+                                Enum(name: "Foo", accessLevel: .internal, isExtension: false, inheritedTypes: ["Int"], cases: [EnumCase(name: "optionA", rawValue: "2")])
+                            ]))
                     }
 
                     it("extracts enums without rawType") {


### PR DESCRIPTION
## Context

When `SyntaxTreeCollector` visits `EnumDeclSyntax`, `EnumDeclSyntax` is being parsed from `EnumCase` extension (file `EnumCase+SwiftSyntax.swift`).

In there there's a logic which extracts the rawValue from the `EnumDeclSyntax` by assigning `equal` sign to `nil`:

    var value = node.rawValue?.withEqual(nil).description.trimmed

## Problem Statement

Using `node.rawValue` does not eliminate contents of trailing trivia:

```swift
po node.rawValue?.withEqual(nil)
...
    ▿ value : IntegerLiteralExprSyntax
      - unexpectedBeforeDigits : nil
      ▿ digits : integerLiteral("0")
        - text : "0"
        ▿ leadingTrivia : []
          - pieces : 0 elements
        ▿ trailingTrivia : [spaces(1), lineComment("// some comment")]
          ▿ pieces : 2 elements
            ▿ 0 : spaces(1)
              - spaces : 1
            ▿ 1 : lineComment("// some comment")
              - lineComment : "// some comment"
        ▿ tokenKind : TokenKind
          - integerLiteral : "0"
...
```

By adding `withTrailingTrivia(.zero).` it is possible to eliminate comments before and after defined rawValue.

## Notes

Resolves #1154 