### PR TITLE
Fixed parsing of multibyte enum case' identifier with associated value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixes incorrectly parsed /r/n newline sequences ([#1165](https://github.com/krzysztofzablocki/Sourcery/issues/1165) and [#1138](https://github.com/krzysztofzablocki/Sourcery/issues/1138))
 - Fixes incorrect parsing of annotations if there are attributes on lines preceeding declaration ([#1141](https://github.com/krzysztofzablocki/Sourcery/issues/1141))
 - Fixes incorrect parsing of trailing inline comments following enum case' rawValue ([#1154](https://github.com/krzysztofzablocki/Sourcery/issues/1154))
+- Fixes incorrect parsing of multibyte enum case identifiers with associated values
 
 ## 2.0.2
 - Fixes incorrectly parsed variable names that include property wrapper and comments, closes #1140

--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -153,9 +153,15 @@ public struct AnnotationsParser {
 
     func inlineFrom(line lineInfo: (line: Int, character: Int), stop: inout Bool) -> Annotations {
         let sourceLine = lines[lineInfo.line - 1]
-        var prefix = sourceLine.content.bridge()
-            .substring(to: max(0, lineInfo.character - 1))
-            .trimmingCharacters(in: .whitespaces)
+
+        let utf8View = sourceLine.content.utf8
+        let startIndex = utf8View.startIndex
+        let endIndex = sourceLine.content.utf8.index(startIndex, offsetBy: (lineInfo.character - 2))
+        let utf8Slice = utf8View[startIndex ... endIndex]
+
+        let relevantContent = String(decoding: utf8Slice, as: UTF8.self)
+
+        var prefix = relevantContent.trimmingCharacters(in: .whitespaces)
 
         guard !prefix.isEmpty else { return [:] }
         var annotations = sourceLine.blockAnnotations // get block annotations for this line

--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -156,8 +156,8 @@ public struct AnnotationsParser {
 
         let utf8View = sourceLine.content.utf8
         let startIndex = utf8View.startIndex
-        let endIndex = sourceLine.content.utf8.index(startIndex, offsetBy: (lineInfo.character - 2))
-        let utf8Slice = utf8View[startIndex ... endIndex]
+        let endIndex = sourceLine.content.utf8.index(startIndex, offsetBy: (lineInfo.character - 1))
+        let utf8Slice = utf8View[startIndex ..< endIndex]
 
         let relevantContent = String(decoding: utf8Slice, as: UTF8.self)
 

--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -153,14 +153,11 @@ public struct AnnotationsParser {
 
     func inlineFrom(line lineInfo: (line: Int, character: Int), stop: inout Bool) -> Annotations {
         let sourceLine = lines[lineInfo.line - 1]
-
         let utf8View = sourceLine.content.utf8
         let startIndex = utf8View.startIndex
         let endIndex = sourceLine.content.utf8.index(startIndex, offsetBy: (lineInfo.character - 1))
         let utf8Slice = utf8View[startIndex ..< endIndex]
-
         let relevantContent = String(decoding: utf8Slice, as: UTF8.self)
-
         var prefix = relevantContent.trimmingCharacters(in: .whitespaces)
 
         guard !prefix.isEmpty else { return [:] }

--- a/SourceryTests/Parsing/FileParserSpec.swift
+++ b/SourceryTests/Parsing/FileParserSpec.swift
@@ -868,6 +868,15 @@ class FileParserSpec: QuickSpec {
                                 ]))
                     }
 
+                    it("parses enums with multibyte cases with associated types") {
+                        let expectedEnum = Enum(name: "Foo", cases: [
+                            EnumCase(name: "こんにちは", associatedValues: [
+                                AssociatedValue(localName: nil, externalName: nil, typeName: TypeName(name: "Int"))
+                            ])
+                        ])
+                        expect(parse("enum Foo { case こんにちは(Int) }")).to(equal([expectedEnum]))
+                    }
+
                     it("extracts enums with indirect cases") {
                         expect(parse("enum Foo { case optionA; case optionB; indirect case optionC(Foo) }"))
                                 .to(equal([


### PR DESCRIPTION
## Context
Given the following declaration of an `enum`:

```swift
enum Foo {
  case こんにちは(Int)
}
```

sourcery crashes while parsing such definition:

    Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSCFString substringToIndex:]: Index 25 out of bounds; string length 24'

## Problem Statement

While processing, `SwiftSyntax` uses `utf8` view of `String` for calculating offset from the beginning of the file until the given token:

and if to try to map UTF8 character index back to `String` representation, even if to use String.Index type, the length of the original index is insufficient and would cause `Thread 1: Fatal error: String index is out of bounds` exception.

## Solution

AnnotationParser should use UTF8 indexing when working with SwiftSyntax.

## Notes

Inspired by #1132 
