### PR TITLE
Support contained types as variable type name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixes incorrect parsing of annotations if there are attributes on lines preceeding declaration ([#1141](https://github.com/krzysztofzablocki/Sourcery/issues/1141))
 - Fixes incorrect parsing of trailing inline comments following enum case' rawValue ([#1154](https://github.com/krzysztofzablocki/Sourcery/issues/1154))
 - Fixes incorrect parsing of multibyte enum case identifiers with associated values
+- Improves type inference when using contained types for variables ([#1091](https://github.com/krzysztofzablocki/Sourcery/issues/1091))
 
 ## 2.0.2
 - Fixes incorrectly parsed variable names that include property wrapper and comments, closes #1140

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -1954,7 +1954,7 @@ class ParserComposerSpec: QuickSpec {
                             ])
                             expectedBar.module = "Foo"
 
-                            let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName(name: "Bar"), type: expectedBar, accessLevel: (.internal, .none), definedInTypeName: TypeName(name: "Foo"))], containedTypes: [expectedBar])
+                            let expectedFoo = Struct(name: "Foo", variables: [Variable(name: "bar", typeName: TypeName(name: "Foo.Bar"), type: expectedBar, accessLevel: (.internal, .none), definedInTypeName: TypeName(name: "Foo"))], containedTypes: [expectedBar])
                             expectedFoo.module = "Foo"
 
                             let types = parseModules(
@@ -1987,7 +1987,7 @@ class ParserComposerSpec: QuickSpec {
                             expectedBaz.module = "ModuleA"
 
                             let expectedFoo = Struct(name: "Foo", variables: [
-                                Variable(name: "bar", typeName: TypeName(name: "Bar"), type: expectedBar, accessLevel: (.internal, .none), definedInTypeName: TypeName(name: "Foo")),
+                                Variable(name: "bar", typeName: TypeName(name: "Foo.Bar"), type: expectedBar, accessLevel: (.internal, .none), definedInTypeName: TypeName(name: "Foo")),
                                 Variable(name: "bazbars", typeName: TypeName(name: "Baz<Bar>", generic: .init(name: "ModuleA.Foo.Baz", typeParameters: [.init(typeName: .init("ModuleA.Foo.Bar"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName(name: "Foo")),
                                 Variable(name: "bazDoubles", typeName: TypeName(name: "Baz<Double>", generic: .init(name: "ModuleA.Foo.Baz", typeParameters: [.init(typeName: .init("Double"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName(name: "Foo")),
                                 Variable(name: "bazInts", typeName: TypeName(name: "Baz<Int>", generic: .init(name: "ModuleA.Foo.Baz", typeParameters: [.init(typeName: .init("Int"))])), type: expectedBaz, accessLevel: (.internal, .none), definedInTypeName: TypeName(name: "Foo"))
@@ -2039,7 +2039,7 @@ class ParserComposerSpec: QuickSpec {
                                 }
                             }
 
-                            check(variable: "bar", typeName: "Bar", type: "Foo.Bar", onType: "ModuleA.Foo")
+                            check(variable: "bar", typeName: "Foo.Bar", type: "Foo.Bar", onType: "ModuleA.Foo")
                             check(variable: "bazbars", typeName: "Baz<Bar>", type: "Foo.Baz", onType: "ModuleA.Foo")
                             check(variable: "bazDoubles", typeName: "Baz<Double>", type: "Foo.Baz", onType: "ModuleA.Foo")
                             check(variable: "bazInts", typeName: "Baz<Int>", type: "Foo.Baz", onType: "ModuleA.Foo")


### PR DESCRIPTION
## Context

Given the following declaration:

```swift
struct X {
  struct A {}

  let a: A
}

struct A {}
```

code that is generated annotates variable `a` with type `A`, however it should automatically infer type for this variable as `X.A` based on the contained type.

## Problem Statement

In file `Variable+SwiftSyntax` there's this code which decides what type should be used for the given variable:
```swift
var typeName: TypeName? = node.typeAnnotation.map { TypeName($0.type) } ??
        node.initializer.flatMap { Self.inferType($0.value.description.trimmed) }
```

However, it does not take into account `containedTypes` array of `visitingType` variable.

## Solution

By iterating over all of the `containedTypes` in the `visitingType` and picking the one which name matches the one used in the declaration. 

## Notes

Resolves #1091

This MR does not cover `Method` and `MethodArgument` cases, which have the same issue for arguments and return values. Same should be true for typealiases.