### PR TITLE
Add SPM config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sourcery CHANGELOG
 
+## 2.1.0
+## Changes
+- Added support for Swift Package Manager config ([#1184](https://github.com/krzysztofzablocki/Sourcery/pull/1184))
+
 ## 2.0.3
 ## Internal Changes
 - Modifications to included files of Swift Templates are now detected by hashing instead of using the modification date when invalidating the cache ([#1161](https://github.com/krzysztofzablocki/Sourcery/pull/1161))

--- a/Package.resolved
+++ b/Package.resolved
@@ -118,12 +118,83 @@
       }
     },
     {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "e394bf350e38cb100b6bc4172834770ede1b7232",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "75ec60b8b4cc0f085c3ac414f3dca5625fa3588e",
+        "version" : "2.2.4"
+      }
+    },
+    {
+      "identity" : "swift-driver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-driver.git",
+      "state" : {
+        "branch" : "release/5.8",
+        "revision" : "7cfe0c0b6e6297efe88a3ce34e6138ee7eda969e"
+      }
+    },
+    {
+      "identity" : "swift-llbuild",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-llbuild.git",
+      "state" : {
+        "branch" : "release/5.8",
+        "revision" : "168f9dc3798def1ecdd7d40049f6e1841bf761d0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-package-manager",
+      "state" : {
+        "revision" : "fa3db13e0bd00e33c187c63c80673b3ac7c82f55"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
         "revision" : "cd793adf5680e138bf2bcbaacc292490175d0dcd",
         "version" : "508.0.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "836bc4557b74fe6d2660218d56e3ce96aff76574",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-tools-support-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-tools-support-core.git",
+      "state" : {
+        "branch" : "release/5.8",
+        "revision" : "ac4871e01ef338cb95b5d28328cab0ec1dfae935"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 let package = Package(
     name: "Sourcery",
     platforms: [
-       .macOS(.v10_15),
+       .macOS(.v12),
     ],
     products: [
         // SPM won't generate .swiftmodule for a target directly used by a product,
@@ -29,7 +29,8 @@ let package = Package(
         .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0")
+        .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
+        .package(url: "https://github.com/apple/swift-package-manager", revision: "fa3db13e0bd00e33c187c63c80673b3ac7c82f55"),
     ],
     targets: [
         .executableTarget(
@@ -55,7 +56,8 @@ let package = Package(
                 "StencilSwiftKit",
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 "XcodeProj",
-                "TryCatch"
+                "TryCatch",
+                .product(name: "SwiftPM-auto", package: "swift-package-manager"),
             ],
             path: "Sourcery",
             exclude: [

--- a/Sourcery/Configuration.swift
+++ b/Sourcery/Configuration.swift
@@ -199,11 +199,11 @@ public struct Package {
             guard targetNames.contains(target.name) else {
                 return nil
             }
-            let rootPath = target.path ?? target.name
+            let rootPath = target.path.map { Path($0, relativeTo: path) } ?? Path(target.name, relativeTo: sourcesPath)
             let excludePaths = target.exclude.map { path in
-                Path(path, relativeTo: sourcesPath)
+                Path(path, relativeTo: rootPath)
             }
-            return Target(name: target.name, root: Path(rootPath, relativeTo: sourcesPath), excludes: excludePaths)
+            return Target(name: target.name, root: rootPath, excludes: excludePaths)
         })
     }
 }

--- a/SourceryTests/ConfigurationSpec.swift
+++ b/SourceryTests/ConfigurationSpec.swift
@@ -117,7 +117,7 @@ class ConfigurationSpec: QuickSpec {
 
                 it("throws error on missing sources") {
                     let config: [String: Any] = ["templates": ["."], "output": "."]
-                    expect(configError(config)).to(equal("Invalid sources. 'sources' or 'project' key are missing."))
+                    expect(configError(config)).to(equal("Invalid sources. 'sources', 'project' or 'package' key are missing."))
                 }
 
                 it("throws error on invalid sources format") {

--- a/guides/Usage.md
+++ b/guides/Usage.md
@@ -100,6 +100,22 @@ project:
         - <path to xcframework file>
 ```
 
+You can also provide a Swift Package which will be scanned. Source files will be scanned based on the package's `path` and `exclude` options.
+
+```yaml
+package:
+  path: <path to to the Package.swift root directory>
+  target: <target name>
+```
+Multiple targets:
+```yaml
+package:
+  path: <path to to the Package.swift root directory>
+  target:
+    - <target name>
+    - <target name>
+```
+
 #### Excluding sources or templates
 
 You can specify paths to sources files that should be scanned using `include` key and paths that should be excluded using `exclude` key. These can be directory or file paths.


### PR DESCRIPTION
This PR adds support for Swift Packages in the config. This allows Sourcery to determine the module name of the scanned sources.

It depends on https://github.com/apple/swift-package-manager which is quite a big dependency (binary size also almost doubled after adding it). It is however the easiest way to read the contents of the package. Other method could be use the JSON output from `swift package dump-package` and parsing that ourselves. The upside to this is that we're not dependent on this big dependency and we're less attached to local Xcode version vs shipped SPM version. Downside is we have to parse stuff ourselves.

I'd love to hear your thoughts on that.