### PR TITLE
Add support to any keyword for function return type to AutoMockable.stencil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.1.0
 ## Changes
 - Added support for Swift Package Manager config ([#1184](https://github.com/krzysztofzablocki/Sourcery/pull/1184))
+- Add support to any keyword for function parameter type to AutoMockable.stencil ([#1169](https://github.com/krzysztofzablocki/Sourcery/pull/1169))
+- Add support to any keyword for function return type to AutoMockable.stencil([#1186](https://github.com/krzysztofzablocki/Sourcery/pull/1186))
 
 ## 2.0.3
 ## Internal Changes

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -54,7 +54,7 @@ import {{ import }}
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call closureReturnTypeName method %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -84,7 +84,7 @@ import {{ import }}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName %}{% else %}{% call existentialClosureVariableTypeName param.typeName %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ method.returnTypeName }}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ '!' if not method.isOptionalReturnType }}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
     {% endif %}
     {% call methodClosureDeclaration method %}
 
@@ -99,7 +99,7 @@ import {{ import }}
     {{ value }}
     {% endfor %}
     {% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName %}{% endif %} {
         {% if method.throws %}
         {% call methodThrowableErrorUsage method %}
         {% endif %}
@@ -202,7 +202,7 @@ import {{ import }}
 
 {% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
 {% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
-{% macro existentialVariableTypeName typeName %}{% if typeName|contains:"any" and typeName|contains:"!" %}{{ typeName | replace:"any","(any" | replace:"!",")!" }}{% elif typeName|contains:"any" and typeName.isOptional %}{{ typeName | replace:"any","(any" | replace:"?",")?" }}{% elif typeName|contains:"any" and typeName.isClosure %}({{ typeName | replace:"any","(any" | replace:"?",")?" }}){%else%}{{ typeName }}{%endif%}{% endmacro %}
+{% macro existentialVariableTypeName typeName %}{% if typeName|contains:"any" and typeName|contains:"!" %}{{ typeName | replace:"any","(any" | replace:"!",")!" }}{% elif typeName|contains:"any" and typeName.isOptional %}{{ typeName | replace:"any","(any" | replace:"?",")?" }}{% elif typeName|contains:"any" and typeName.isClosure and typeName|contains:"?"%}({{ typeName | replace:"any","(any" | replace:"?",")?" }}){%else%}{{ typeName }}{%endif%}{% endmacro %}
 {% macro existentialClosureVariableTypeName typeName %}{% if typeName|contains:"any" and typeName|contains:"!" %}{{ typeName | replace:"any","(any" | replace:"!",")?" }}{% elif typeName|contains:"any" and typeName.isClosure and typeName|contains:"?" %}{{ typeName | replace:"any","(any" | replace:"?",")?" }}{% elif typeName|contains:"any" and typeName|contains:"?" %}{{ typeName | replace:"any","(any" | replace:"?",")?" }}{%else%}{{ typeName }}{%endif%}{% endmacro %}
 {% macro existentialParameterTypeName typeName %}{% if typeName|contains:"any" and typeName|contains:"!" %}{{ typeName | replace:"any","(any" | replace:"!",")!" }}{% elif typeName|contains:"any" and typeName.isClosure and typeName|contains:"?" %}{{ typeName | replace:"any","(any" | replace:"?",")?" }}{% elif typeName|contains:"any" and typeName.isOptional %}{{ typeName | replace:"any","(any" | replace:"?",")?" }}{%else%}{{ typeName }}{%endif%}{% endmacro %}
 {% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {{ param.name }}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% call existentialParameterTypeName param.typeName %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -171,4 +171,14 @@ protocol AnyProtocol: AutoMockable {
     func n(x: @escaping ((any StubProtocol)?) -> Void)
     var o: any StubWithAnyNameProtocol { get }
     func p(_ x: (any StubWithAnyNameProtocol)?)
+    func q() -> any StubProtocol
+    func r() -> (any StubProtocol)?
+    func s() -> () -> any StubProtocol
+    func t() -> () -> (any StubProtocol)?
+    func u() -> (Int, () -> (any StubProtocol)?)
+    func v() -> (Int, (() -> any StubProtocol)?)
+    func w() -> [(any StubProtocol)?]
+    func x() -> [String: (any StubProtocol)?]
+    func y() -> (any StubProtocol, (any StubProtocol)?)
+    func z() -> any StubProtocol & CustomStringConvertible
 }

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -215,6 +215,186 @@ class AnyProtocolMock: AnyProtocol {
         pClosure?(x)
     }
 
+    //MARK: - q
+
+    var qCallsCount = 0
+    var qCalled: Bool {
+        return qCallsCount > 0
+    }
+    var qReturnValue: (any StubProtocol)!
+    var qClosure: (() -> any StubProtocol)?
+
+    func q() -> any StubProtocol {
+        qCallsCount += 1
+        if let qClosure = qClosure {
+            return qClosure()
+        } else {
+            return qReturnValue
+        }
+    }
+
+    //MARK: - r
+
+    var rCallsCount = 0
+    var rCalled: Bool {
+        return rCallsCount > 0
+    }
+    var rReturnValue: ((any StubProtocol)?)
+    var rClosure: (() -> (any StubProtocol)?)?
+
+    func r() -> (any StubProtocol)? {
+        rCallsCount += 1
+        if let rClosure = rClosure {
+            return rClosure()
+        } else {
+            return rReturnValue
+        }
+    }
+
+    //MARK: - s
+
+    var sCallsCount = 0
+    var sCalled: Bool {
+        return sCallsCount > 0
+    }
+    var sReturnValue: (() -> any StubProtocol)!
+    var sClosure: (() -> () -> any StubProtocol)?
+
+    func s() -> () -> any StubProtocol {
+        sCallsCount += 1
+        if let sClosure = sClosure {
+            return sClosure()
+        } else {
+            return sReturnValue
+        }
+    }
+
+    //MARK: - t
+
+    var tCallsCount = 0
+    var tCalled: Bool {
+        return tCallsCount > 0
+    }
+    var tReturnValue: ((() -> (any StubProtocol)?))!
+    var tClosure: (() -> (() -> (any StubProtocol)?))?
+
+    func t() -> (() -> (any StubProtocol)?) {
+        tCallsCount += 1
+        if let tClosure = tClosure {
+            return tClosure()
+        } else {
+            return tReturnValue
+        }
+    }
+
+    //MARK: - u
+
+    var uCallsCount = 0
+    var uCalled: Bool {
+        return uCallsCount > 0
+    }
+    var uReturnValue: ((Int, () -> (any StubProtocol)?))!
+    var uClosure: (() -> (Int, () -> (any StubProtocol)?))?
+
+    func u() -> (Int, () -> (any StubProtocol)?) {
+        uCallsCount += 1
+        if let uClosure = uClosure {
+            return uClosure()
+        } else {
+            return uReturnValue
+        }
+    }
+
+    //MARK: - v
+
+    var vCallsCount = 0
+    var vCalled: Bool {
+        return vCallsCount > 0
+    }
+    var vReturnValue: ((Int, (() -> any StubProtocol)?))!
+    var vClosure: (() -> (Int, (() -> any StubProtocol)?))?
+
+    func v() -> (Int, (() -> any StubProtocol)?) {
+        vCallsCount += 1
+        if let vClosure = vClosure {
+            return vClosure()
+        } else {
+            return vReturnValue
+        }
+    }
+
+    //MARK: - w
+
+    var wCallsCount = 0
+    var wCalled: Bool {
+        return wCallsCount > 0
+    }
+    var wReturnValue: ([(any StubProtocol)?])!
+    var wClosure: (() -> [(any StubProtocol)?])?
+
+    func w() -> [(any StubProtocol)?] {
+        wCallsCount += 1
+        if let wClosure = wClosure {
+            return wClosure()
+        } else {
+            return wReturnValue
+        }
+    }
+
+    //MARK: - x
+
+    var xCallsCount = 0
+    var xCalled: Bool {
+        return xCallsCount > 0
+    }
+    var xReturnValue: ([String: (any StubProtocol)?])!
+    var xClosure: (() -> [String: (any StubProtocol)?])?
+
+    func x() -> [String: (any StubProtocol)?] {
+        xCallsCount += 1
+        if let xClosure = xClosure {
+            return xClosure()
+        } else {
+            return xReturnValue
+        }
+    }
+
+    //MARK: - y
+
+    var yCallsCount = 0
+    var yCalled: Bool {
+        return yCallsCount > 0
+    }
+    var yReturnValue: ((any StubProtocol, (any StubProtocol)?))!
+    var yClosure: (() -> (any StubProtocol, (any StubProtocol)?))?
+
+    func y() -> (any StubProtocol, (any StubProtocol)?) {
+        yCallsCount += 1
+        if let yClosure = yClosure {
+            return yClosure()
+        } else {
+            return yReturnValue
+        }
+    }
+
+    //MARK: - z
+
+    var zCallsCount = 0
+    var zCalled: Bool {
+        return zCallsCount > 0
+    }
+    var zReturnValue: (any StubProtocol & CustomStringConvertible)!
+    var zClosure: (() -> any StubProtocol & CustomStringConvertible)?
+
+    func z() -> any StubProtocol & CustomStringConvertible {
+        zCallsCount += 1
+        if let zClosure = zClosure {
+            return zClosure()
+        } else {
+            return zReturnValue
+        }
+    }
+
 }
 class AsyncProtocolMock: AsyncProtocol {
 

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -835,7 +835,7 @@ class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOpt
         return implicitReturnCallsCount > 0
     }
     var implicitReturnReturnValue: String!
-    var implicitReturnClosure: (() -> String?)?
+    var implicitReturnClosure: (() -> String!)?
 
     func implicitReturn() -> String! {
         implicitReturnCallsCount += 1

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -238,6 +238,186 @@ class AnyProtocolMock: AnyProtocol {
         pClosure?(x)
     }
 
+    //MARK: - q
+
+    var qCallsCount = 0
+    var qCalled: Bool {
+        return qCallsCount > 0
+    }
+    var qReturnValue: (any StubProtocol)!
+    var qClosure: (() -> any StubProtocol)?
+
+    func q() -> any StubProtocol {
+        qCallsCount += 1
+        if let qClosure = qClosure {
+            return qClosure()
+        } else {
+            return qReturnValue
+        }
+    }
+
+    //MARK: - r
+
+    var rCallsCount = 0
+    var rCalled: Bool {
+        return rCallsCount > 0
+    }
+    var rReturnValue: ((any StubProtocol)?)
+    var rClosure: (() -> (any StubProtocol)?)?
+
+    func r() -> (any StubProtocol)? {
+        rCallsCount += 1
+        if let rClosure = rClosure {
+            return rClosure()
+        } else {
+            return rReturnValue
+        }
+    }
+
+    //MARK: - s
+
+    var sCallsCount = 0
+    var sCalled: Bool {
+        return sCallsCount > 0
+    }
+    var sReturnValue: (() -> any StubProtocol)!
+    var sClosure: (() -> () -> any StubProtocol)?
+
+    func s() -> () -> any StubProtocol {
+        sCallsCount += 1
+        if let sClosure = sClosure {
+            return sClosure()
+        } else {
+            return sReturnValue
+        }
+    }
+
+    //MARK: - t
+
+    var tCallsCount = 0
+    var tCalled: Bool {
+        return tCallsCount > 0
+    }
+    var tReturnValue: ((() -> (any StubProtocol)?))!
+    var tClosure: (() -> (() -> (any StubProtocol)?))?
+
+    func t() -> (() -> (any StubProtocol)?) {
+        tCallsCount += 1
+        if let tClosure = tClosure {
+            return tClosure()
+        } else {
+            return tReturnValue
+        }
+    }
+
+    //MARK: - u
+
+    var uCallsCount = 0
+    var uCalled: Bool {
+        return uCallsCount > 0
+    }
+    var uReturnValue: ((Int, () -> (any StubProtocol)?))!
+    var uClosure: (() -> (Int, () -> (any StubProtocol)?))?
+
+    func u() -> (Int, () -> (any StubProtocol)?) {
+        uCallsCount += 1
+        if let uClosure = uClosure {
+            return uClosure()
+        } else {
+            return uReturnValue
+        }
+    }
+
+    //MARK: - v
+
+    var vCallsCount = 0
+    var vCalled: Bool {
+        return vCallsCount > 0
+    }
+    var vReturnValue: ((Int, (() -> any StubProtocol)?))!
+    var vClosure: (() -> (Int, (() -> any StubProtocol)?))?
+
+    func v() -> (Int, (() -> any StubProtocol)?) {
+        vCallsCount += 1
+        if let vClosure = vClosure {
+            return vClosure()
+        } else {
+            return vReturnValue
+        }
+    }
+
+    //MARK: - w
+
+    var wCallsCount = 0
+    var wCalled: Bool {
+        return wCallsCount > 0
+    }
+    var wReturnValue: ([(any StubProtocol)?])!
+    var wClosure: (() -> [(any StubProtocol)?])?
+
+    func w() -> [(any StubProtocol)?] {
+        wCallsCount += 1
+        if let wClosure = wClosure {
+            return wClosure()
+        } else {
+            return wReturnValue
+        }
+    }
+
+    //MARK: - x
+
+    var xCallsCount = 0
+    var xCalled: Bool {
+        return xCallsCount > 0
+    }
+    var xReturnValue: ([String: (any StubProtocol)?])!
+    var xClosure: (() -> [String: (any StubProtocol)?])?
+
+    func x() -> [String: (any StubProtocol)?] {
+        xCallsCount += 1
+        if let xClosure = xClosure {
+            return xClosure()
+        } else {
+            return xReturnValue
+        }
+    }
+
+    //MARK: - y
+
+    var yCallsCount = 0
+    var yCalled: Bool {
+        return yCallsCount > 0
+    }
+    var yReturnValue: ((any StubProtocol, (any StubProtocol)?))!
+    var yClosure: (() -> (any StubProtocol, (any StubProtocol)?))?
+
+    func y() -> (any StubProtocol, (any StubProtocol)?) {
+        yCallsCount += 1
+        if let yClosure = yClosure {
+            return yClosure()
+        } else {
+            return yReturnValue
+        }
+    }
+
+    //MARK: - z
+
+    var zCallsCount = 0
+    var zCalled: Bool {
+        return zCallsCount > 0
+    }
+    var zReturnValue: (any StubProtocol & CustomStringConvertible)!
+    var zClosure: (() -> any StubProtocol & CustomStringConvertible)?
+
+    func z() -> any StubProtocol & CustomStringConvertible {
+        zCallsCount += 1
+        if let zClosure = zClosure {
+            return zClosure()
+        } else {
+            return zReturnValue
+        }
+    }
+
 }
 class AsyncProtocolMock: AsyncProtocol {
 

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -858,7 +858,7 @@ class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOpt
         return implicitReturnCallsCount > 0
     }
     var implicitReturnReturnValue: String!
-    var implicitReturnClosure: (() -> String?)?
+    var implicitReturnClosure: (() -> String!)?
 
     func implicitReturn() -> String! {
         implicitReturnCallsCount += 1


### PR DESCRIPTION
# Context
Following merge of support for any keyword for function parameter type: https://github.com/krzysztofzablocki/Sourcery/pull/1169
We could also add support of any keyword for function return type.

# In this PR
I've updated the AutoMockable.stencil to support any keyword for function return type.
As previous PR this is the identified cases for now.
```swift
protocol AnyProtocol {
    func q() -> any StubProtocol
    func r() -> (any StubProtocol)?
    func s() -> () -> any StubProtocol
    func t() -> () -> (any StubProtocol)?
    func u() -> (Int, () -> (any StubProtocol)?)
    func v() -> (Int, (() -> any StubProtocol)?)
    func w() -> [(any StubProtocol)?]
    func x() -> [String: (any StubProtocol)?]
    func y() -> (any StubProtocol, (any StubProtocol)?)
    func z() -> any StubProtocol & CustomStringConvertible
}
```
and the generated output:
```swift
class AnyProtocolMock: AnyProtocol {

    //MARK: - q

    var _qCallsCount = 0
    var _qCalled: Bool {
        return _qCallsCount > 0
    }
    var _qReturnValue: (any StubProtocol)!
    var _qClosure: (() -> any StubProtocol)?

    func q() -> any StubProtocol {
        _qCallsCount += 1
        if let _qClosure = _qClosure {
            return _qClosure()
        } else {
            return _qReturnValue
        }
    }

    //MARK: - r

    var _rCallsCount = 0
    var _rCalled: Bool {
        return _rCallsCount > 0
    }
    var _rReturnValue: ((any StubProtocol)?)
    var _rClosure: (() -> (any StubProtocol)?)?

    func r() -> (any StubProtocol)? {
        _rCallsCount += 1
        if let _rClosure = _rClosure {
            return _rClosure()
        } else {
            return _rReturnValue
        }
    }

    //MARK: - s

    var _sCallsCount = 0
    var _sCalled: Bool {
        return _sCallsCount > 0
    }
    var _sReturnValue: (() -> any StubProtocol)!
    var _sClosure: (() -> () -> any StubProtocol)?

    func s() -> () -> any StubProtocol {
        _sCallsCount += 1
        if let _sClosure = _sClosure {
            return _sClosure()
        } else {
            return _sReturnValue
        }
    }

    //MARK: - t

    var _tCallsCount = 0
    var _tCalled: Bool {
        return _tCallsCount > 0
    }
    var _tReturnValue: ((() -> (any StubProtocol)?))!
    var _tClosure: (() -> (() -> (any StubProtocol)?))?

    func t() -> (() -> (any StubProtocol)?) {
        _tCallsCount += 1
        if let _tClosure = _tClosure {
            return _tClosure()
        } else {
            return _tReturnValue
        }
    }

    //MARK: - u

    var _uCallsCount = 0
    var _uCalled: Bool {
        return _uCallsCount > 0
    }
    var _uReturnValue: ((Int, () -> (any StubProtocol)?))!
    var _uClosure: (() -> (Int, () -> (any StubProtocol)?))?

    func u() -> (Int, () -> (any StubProtocol)?) {
        _uCallsCount += 1
        if let _uClosure = _uClosure {
            return _uClosure()
        } else {
            return _uReturnValue
        }
    }

    //MARK: - v

    var _vCallsCount = 0
    var _vCalled: Bool {
        return _vCallsCount > 0
    }
    var _vReturnValue: ((Int, (() -> any StubProtocol)?))!
    var _vClosure: (() -> (Int, (() -> any StubProtocol)?))?

    func v() -> (Int, (() -> any StubProtocol)?) {
        _vCallsCount += 1
        if let _vClosure = _vClosure {
            return _vClosure()
        } else {
            return _vReturnValue
        }
    }

    //MARK: - w

    var _wCallsCount = 0
    var _wCalled: Bool {
        return _wCallsCount > 0
    }
    var _wReturnValue: ([(any StubProtocol)?])!
    var _wClosure: (() -> [(any StubProtocol)?])?

    func w() -> [(any StubProtocol)?] {
        _wCallsCount += 1
        if let _wClosure = _wClosure {
            return _wClosure()
        } else {
            return _wReturnValue
        }
    }

    //MARK: - x

    var _xCallsCount = 0
    var _xCalled: Bool {
        return _xCallsCount > 0
    }
    var _xReturnValue: ([String : (any StubProtocol)?])!
    var _xClosure: (() -> [String : (any StubProtocol)?])?

    func x() -> [String : (any StubProtocol)?] {
        _xCallsCount += 1
        if let _xClosure = _xClosure {
            return _xClosure()
        } else {
            return _xReturnValue
        }
    }

    //MARK: - y

    var _yCallsCount = 0
    var _yCalled: Bool {
        return _yCallsCount > 0
    }
    var _yReturnValue: ((any StubProtocol, (any StubProtocol)?))!
    var _yClosure: (() -> (any StubProtocol, (any StubProtocol)?))?

    func y() -> (any StubProtocol, (any StubProtocol)?) {
        _yCallsCount += 1
        if let _yClosure = _yClosure {
            return _yClosure()
        } else {
            return _yReturnValue
        }
    }

    //MARK: - z

    var _zCallsCount = 0
    var _zCalled: Bool {
        return _zCallsCount > 0
    }
    var _zReturnValue: (any StubProtocol & CustomStringConvertible)!
    var _zClosure: (() -> any StubProtocol & CustomStringConvertible)?

    func z() -> any StubProtocol & CustomStringConvertible {
        _zCallsCount += 1
        if let _zClosure = _zClosure {
            return _zClosure()
        } else {
            return _zReturnValue
        }
    }

}
```
Let me know if you see more cases to add.