### PR TITLE
Create swift.yml

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ['ubuntu-latest', 'macos-latest']
+    runs-on: ['ubuntu:latest', 'macos:latest']
 
     steps:
     - name: Bundler CLI

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -65,8 +65,8 @@ jobs:
             brew install ack
             export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
       shell: bash
-    - name: Xcode Build
-      uses: devbotsxyz/xcode-build@v1.0.0
+    - name: Xcode Select
+      uses: devbotsxyz/xcode-select@v1.1.0
     - name: Bundle Install
       run:  bundle install
     - name: Swift Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -54,17 +54,6 @@ jobs:
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
       with:
         ruby-version: '3.1'
-    - name: Update Homebrew
-      run:  |
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-      shell: bash
-    - name: Setup Homebrew PATH
-      run:  |
-            (echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> /Users/runner/.bash_profile
-            eval "$(/usr/local/bin/brew shellenv)"
-            brew install ack
-            export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-      shell: bash
     - name: Xcode Select
       uses: devbotsxyz/xcode-select@v1.1.0
     - name: Bundle Install

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   linux_build:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
     - name: Setup Swift
@@ -56,6 +57,12 @@ jobs:
     - name: Update Homebrew
       run:  |
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      shell: bash
+    - name: Setup Homebrew PATH
+      run:  |
+            (echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> /Users/runner/.bash_profile
+            eval "$(/usr/local/bin/brew shellenv)"
+            brew install ack
       shell: bash
     - name: Bundle Install
       run:  bundle install

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -65,13 +65,13 @@ jobs:
             brew install ack
             export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
       shell: bash
+    - name: Xcode Build
+      uses: devbotsxyz/xcode-build@v1.0.0
     - name: Bundle Install
       run:  bundle install
     - name: Swift Build
       run:  swift build -v
     - name: Run tests
       run: swift test -v
-
-
 
  

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,10 +10,8 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
-
-    runs-on: ['ubuntu:latest', 'macos:latest']
-
+  linux_build:
+    runs-on: ubuntu-latest
     steps:
     - name: Bundler CLI
       # You may pin to the exact commit or the version.
@@ -29,15 +27,33 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run:  |
-            if [ "$RUNNER_OS" == "ubuntu-latest" ]; then
-              sudo apt install libffi-dev
-              sudo apt install build-essential
-              sudo apt install libsqlite3-dev
-              sudo apt-get install libncurses5-dev
-              bundle install
-            else
-              bundle install
-            fi
+            sudo apt install libffi-dev
+            sudo apt install build-essential
+            sudo apt install libsqlite3-dev
+            sudo apt-get install libncurses5-dev
+            bundle install
+            swift build -v
+      shell: bash
+    - name: Run tests
+      run: swift test -v
+  macos_build:
+    runs-on: macos-latest
+    steps:
+    - name: Bundler CLI
+      # You may pin to the exact commit or the version.
+      # uses: CultureHQ/actions-bundler@285f68b1d2059b91ca1eb26683263cf1960e7161
+      uses: CultureHQ/actions-bundler@v1.0.0
+    - name: Setup Swift
+      # You may pin to the exact commit or the version.
+      # uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+      uses: swift-actions/setup-swift@v1.23.0
+      with:
+        # Swift version to configure
+        swift-version: 5.8.1 # default is 5.8
+    - uses: actions/checkout@v3
+    - name: Build
+      run:  |
+            bundle install
             swift build -v
       shell: bash
     - name: Run tests

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -56,6 +56,9 @@ jobs:
         ruby-version: '3.1'
     - name: Xcode Select
       uses: devbotsxyz/xcode-select@v1.1.0
+    - name: Export SDKROOT
+      run: export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+      shell: bash
     - name: Bundle Install
       run:  bundle install
     - name: Swift Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,6 +25,10 @@ jobs:
         # Swift version to configure
         swift-version: 5.8 # default is 5.8
     - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      with:
+        ruby-version: '3.1'
     - name: Build
       run:  |
             sudo apt install libffi-dev
@@ -51,6 +55,10 @@ jobs:
         # Swift version to configure
         swift-version: 5.8 # default is 5.8
     - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      with:
+        ruby-version: '3.1'
     - name: Build
       run:  |
             bundle install

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,48 @@
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
+name: Swift
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: [ubuntu-latest, macos-latest]
+
+    steps:
+    - name: Bundler CLI
+      # You may pin to the exact commit or the version.
+      # uses: CultureHQ/actions-bundler@285f68b1d2059b91ca1eb26683263cf1960e7161
+      uses: CultureHQ/actions-bundler@v1.0.0
+    - name: Setup Swift
+      # You may pin to the exact commit or the version.
+      # uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+      uses: swift-actions/setup-swift@v1.23.0
+      with:
+        # Swift version to configure
+        swift-version: 5.8.1 # default is 5.8
+    - uses: actions/checkout@v3
+    - name: Build
+      run:  |
+            if [ "$RUNNER_OS" == "ubuntu-latest" ]; then
+              sudo apt install libffi-dev
+              sudo apt install build-essential
+              sudo apt install libsqlite3-dev
+              sudo apt-get install libncurses5-dev
+              bundle install
+            else
+              bundle install
+            fi
+            swift build -v
+      shell: bash
+    - name: Run tests
+      run: swift test -v
+
+
+
+ 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: [ubuntu-latest, macos-latest]
+    runs-on: [ubuntu:latest, macos:latest]
 
     steps:
     - name: Bundler CLI

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -54,11 +54,10 @@ jobs:
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
       with:
         ruby-version: '3.1'
-    - name: Xcode Select
-      uses: devbotsxyz/xcode-select@v1.1.0
-    - name: Export SDKROOT
-      run: export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-      shell: bash
+    - name: Install Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '14.3.1'
     - name: Bundle Install
       run:  bundle install
     - name: Swift Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,10 +13,6 @@ jobs:
   linux_build:
     runs-on: ubuntu-latest
     steps:
-    - name: Bundler CLI
-      # You may pin to the exact commit or the version.
-      # uses: CultureHQ/actions-bundler@285f68b1d2059b91ca1eb26683263cf1960e7161
-      uses: CultureHQ/actions-bundler@v1.0.0
     - name: Setup Swift
       # You may pin to the exact commit or the version.
       # uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
@@ -43,10 +39,6 @@ jobs:
   macos_build:
     runs-on: macos-latest
     steps:
-    - name: Bundler CLI
-      # You may pin to the exact commit or the version.
-      # uses: CultureHQ/actions-bundler@285f68b1d2059b91ca1eb26683263cf1960e7161
-      uses: CultureHQ/actions-bundler@v1.0.0
     - name: Setup Swift
       # You may pin to the exact commit or the version.
       # uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -55,8 +55,8 @@ jobs:
         ruby-version: '3.1'
     - name: Update Homebrew
       run:  |
-        brew update --preinstall
-        cat "$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/foo.rb" > .github/brew-formulae
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      shell: bash
     - name: Bundle Install
       run:  bundle install
     - name: Swift Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -63,6 +63,7 @@ jobs:
             (echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> /Users/runner/.bash_profile
             eval "$(/usr/local/bin/brew shellenv)"
             brew install ack
+            export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
       shell: bash
     - name: Bundle Install
       run:  bundle install

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,7 +23,7 @@ jobs:
       uses: swift-actions/setup-swift@v1.23.0
       with:
         # Swift version to configure
-        swift-version: 5.8.1 # default is 5.8
+        swift-version: 5.8 # default is 5.8
     - uses: actions/checkout@v3
     - name: Build
       run:  |
@@ -49,7 +49,7 @@ jobs:
       uses: swift-actions/setup-swift@v1.23.0
       with:
         # Swift version to configure
-        swift-version: 5.8.1 # default is 5.8
+        swift-version: 5.8 # default is 5.8
     - uses: actions/checkout@v3
     - name: Build
       run:  |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: [ubuntu:latest, macos:latest]
+    runs-on: ['ubuntu-latest', 'macos-latest']
 
     steps:
     - name: Bundler CLI

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -53,16 +53,9 @@ jobs:
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
       with:
         ruby-version: '3.1'
-    - name: Install CommandLineTools
+    - name: Install Brew along with CLT
       run:  |
-            touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress;
-            PROD=$(softwareupdate -l | \
-            grep "\*.*Command Line" | \
-            head -n 1 | awk -F"*" '{print $2}' | \
-            sed -e 's/^ *//' | \
-            tr -d '\n')
-            softwareupdate -i "$PROD" --verbose
-            rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+            ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     - name: Bundle Install
       run:  bundle install
     - name: Swift Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -42,22 +42,11 @@ jobs:
   macos_build:
     runs-on: macos-latest
     steps:
-    - name: Setup Swift
-      # You may pin to the exact commit or the version.
-      # uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
-      uses: swift-actions/setup-swift@v1.23.0
-      with:
-        # Swift version to configure
-        swift-version: 5.8 # default is 5.8
     - uses: actions/checkout@v3
     - name: Setup Ruby
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
       with:
         ruby-version: '3.1'
-    - name: Install Xcode
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '14.3.1'
     - name: Bundle Install
       run:  bundle install
     - name: Swift Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -53,9 +53,10 @@ jobs:
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
       with:
         ruby-version: '3.1'
-    - name: Install Brew along with CLT
+    - name: Update Homebrew
       run:  |
-            ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        brew update --preinstall
+        cat "$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/foo.rb" > .github/brew-formulae
     - name: Bundle Install
       run:  bundle install
     - name: Swift Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Run tests
       run: swift test -v
   macos_build:
+    if: ${{ false }}
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,15 +25,17 @@ jobs:
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
       with:
         ruby-version: '3.1'
-    - name: Build
+    - name: Install dependencies
       run:  |
             sudo apt install libffi-dev
             sudo apt install build-essential
             sudo apt install libsqlite3-dev
             sudo apt-get install libncurses5-dev
-            bundle install
-            swift build -v
       shell: bash
+    - name: Bundle Install
+      run:  bundle install
+    - name: Swift Build
+      run:  swift build -v
     - name: Run tests
       run: swift test -v
   macos_build:
@@ -47,15 +49,24 @@ jobs:
         # Swift version to configure
         swift-version: 5.8 # default is 5.8
     - uses: actions/checkout@v3
-    - name: Set up Ruby
+    - name: Setup Ruby
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
       with:
         ruby-version: '3.1'
-    - name: Build
+    - name: Install CommandLineTools
       run:  |
-            bundle install
-            swift build -v
-      shell: bash
+            touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress;
+            PROD=$(softwareupdate -l | \
+            grep "\*.*Command Line" | \
+            head -n 1 | awk -F"*" '{print $2}' | \
+            sed -e 's/^ *//' | \
+            tr -d '\n')
+            softwareupdate -i "$PROD" --verbose
+            rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+    - name: Bundle Install
+      run:  bundle install
+    - name: Swift Build
+      run:  swift build -v
     - name: Run tests
       run: swift test -v
 


### PR DESCRIPTION
## Description

This MR adds two GitHub Actions:

1. ubuntu-latest
2. macos-latest

In this MR, `linux` and `macos` actions are disabled, and will be enabled along with #1188 once it would be merged.

## Notes

- macos-latest uses `Xcode` provided by GitHub actions, at this moment the version is `12.4`.
- tests run by macos-latest are failing in this MR due to missing changes from #1188 , where `swift test` works.