### PR TITLE
Revert logic in `cacheKey` calculation introduced in #1163

### DIFF
--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -291,7 +291,7 @@ open class SwiftTemplate {
         var contents = code
 
         // For every included file, make sure that the path and modification date are included in the key
-        let files = (includedFiles + buildDir.allPaths).map({ $0.absolute() }).sorted(by: { $0.string < $1.string })
+        let files = includedFiles.map({ $0.absolute() }).sorted(by: { $0.string < $1.string })
         for file in files {
             let hash = (try? file.read().sha256().base64EncodedString()) ?? ""
             contents += "\n// \(file.string)-\(hash)"


### PR DESCRIPTION
## Context

The way cacheKey was calculated before #1163 was that includedFiles collection was empty, whereas after #1163, that collection always contains file paths.
Because of the aforementioned change in the logic of calculating `cacheKey` hash, the following issue occurs:

1. `buildDir` path includes all files in `.build` folder, and thus, `cacheKey` depends on the `build` folder contents
2. `buildDir` contains files like `master.swiftdeps`, `.swiftsourceinfo`, `main.swift.o`, `DWARF/SwiftTemplate`, `build.db`, `context.bin`, which change every time a build is performed (I suppose timestamp is used in these files in one way or another).
3. Due to this change, hash of the key does not match and "previous" cache get deleted instead of being reused


## Solution

Revert this change and advise to use `--cacheDisabled` flag because it would provide exactly the same behaviour as it is now in version 2.0.3.

Resolves #1196