### PR TITLE
Separate EJSTemplate.swift for swift test and for swift build -c release

### DIFF
--- a/SourceryJS/Sources/EJSTemplate+Tests.swift
+++ b/SourceryJS/Sources/EJSTemplate+Tests.swift
@@ -1,8 +1,26 @@
-#if canImport(ObjectiveC) && !DEBUG
+// swift test runs tests in DEBUG, thus this file will only be compiled for `swift test`
+#if canImport(ObjectiveC) && DEBUG
 import JavaScriptCore
 import PathKit
 
-private extension Foundation.Bundle {
+// (c) https://forums.swift.org/t/swift-5-3-spm-resources-in-tests-uses-wrong-bundle-path/37051/46
+private extension Bundle {
+    static let mypackageResources: Bundle = {
+        #if DEBUG
+            if let moduleName = Bundle(for: BundleFinder.self).bundleIdentifier,
+               let testBundlePath = ProcessInfo.processInfo.environment["XCTestBundlePath"] {
+                if let resourceBundle = Bundle(path: testBundlePath + "/\(moduleName)_\(moduleName).bundle") {
+                    return resourceBundle
+                }
+            }
+        #endif
+        return Bundle.module
+    }()
+
+    private final class BundleFinder {}
+}
+
+public extension Foundation.Bundle {
     /// Returns the resource bundle associated with the current Swift module.
     static var jsModule: Bundle = {
         let bundleName = "Sourcery_SourceryJS"
@@ -24,8 +42,7 @@ private extension Foundation.Bundle {
                 return bundle
             }
         }
-
-        return Bundle(for: EJSTemplate.self)
+        return Bundle.mypackageResources
     }()
 }
 
@@ -45,7 +62,13 @@ open class EJSTemplate {
     #else
     static let bundle = Bundle(for: EJSTemplate.self)
     #endif
-    public static var ejsPath: Path! = bundle.path(forResource: "ejs", ofType: "js").map({ Path($0) })
+    public static var ejsPath: Path? = {
+        let bundle = EJSTemplate.bundle
+        guard let path = bundle.path(forResource: "ejs", ofType: "js") else {
+            return nil
+        }
+        return Path(path)
+    }()
 
     public let sourcePath: Path
     public let templateString: String
@@ -67,17 +90,17 @@ open class EJSTemplate {
         }
     }
 
-    public convenience init(path: Path, ejsPath: Path = EJSTemplate.ejsPath) throws {
+    public convenience init(path: Path, ejsPath: Path) throws {
         try self.init(path: path, templateString: try path.read(), ejsPath: ejsPath)
     }
 
-    public init(path: Path, templateString: String, ejsPath: Path = EJSTemplate.ejsPath) throws {
+    public init(path: Path, templateString: String, ejsPath: Path) throws {
         self.templateString = templateString
         sourcePath = path
         self.ejs = try ejsPath.read(.utf8)
     }
-    
-    public init(templateString: String, ejsPath: Path = EJSTemplate.ejsPath) throws {
+
+    public init(templateString: String, ejsPath: Path) throws {
         self.templateString = templateString
         sourcePath = ""
         self.ejs = try ejsPath.read(.utf8)


### PR DESCRIPTION
Resolves #1202 

## Context

Introduced by #1188.

For `swift test` to work, a different way of searching for `ejs` template on macOS was implemented according to "best practices" due to issues with SPM ([more info here](https://github.com/krzysztofzablocki/Sourcery/pull/1188#issuecomment-1668587358)).
But the problem with this is that when running Sourcery from CLI, it is packaged differently for `release` mode, and so, it cannot find the required resources like for `swift test`.

## Workaround

1. Revert changes for before the migration to `swift test`
2. Create a separate version of implementation that works with `swift test` and put it under `#if DEBUG` because `swift test` runs tests in DEBUG, and Sourcery CLI is distributed with `-c release` compilation mode.

## Notes

There are missing integration tests because otherwise I would not merge that MR. So, I have added this use case to explore into TODO - #1198 .