### PR TITLE
EJSTemplates: make `typealias`es accessible from templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Sourcery CHANGELOG
+## Master
+## Changes
+- Add support for `typealias`es in EJS templates. ([#1208](https://github.com/krzysztofzablocki/Sourcery/pull/1208))
 
 ## 2.1.2
 ## Changes

--- a/SourceryRuntime/Sources/AST/Type.swift
+++ b/SourceryRuntime/Sources/AST/Type.swift
@@ -36,7 +36,6 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
     }
 
     // All local typealiases
-    // sourcery: skipJSExport
     /// :nodoc:
     public var typealiases: [String: Typealias] {
         didSet {

--- a/SourceryRuntime/Sources/AST/Type_Linux.swift
+++ b/SourceryRuntime/Sources/AST/Type_Linux.swift
@@ -75,7 +75,6 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
     }
 
     // All local typealiases
-    // sourcery: skipJSExport
     /// :nodoc:
     public var typealiases: [String: Typealias] {
         didSet {

--- a/SourceryRuntime/Sources/Generated/JSExport.generated.swift
+++ b/SourceryRuntime/Sources/Generated/JSExport.generated.swift
@@ -10,6 +10,7 @@ import JavaScriptCore
     var module: String? { get }
     var imports: [Import] { get }
     var allImports: [Import] { get }
+    var typealiases: [String: Typealias] { get }
     var accessLevel: String { get }
     var name: String { get }
     var isUnknownExtension: Bool { get }
@@ -106,6 +107,7 @@ extension BytesRange: BytesRangeAutoJSExport {}
     var module: String? { get }
     var imports: [Import] { get }
     var allImports: [Import] { get }
+    var typealiases: [String: Typealias] { get }
     var accessLevel: String { get }
     var name: String { get }
     var isUnknownExtension: Bool { get }
@@ -206,6 +208,7 @@ extension DictionaryType: DictionaryTypeAutoJSExport {}
     var module: String? { get }
     var imports: [Import] { get }
     var allImports: [Import] { get }
+    var typealiases: [String: Typealias] { get }
     var accessLevel: String { get }
     var name: String { get }
     var isUnknownExtension: Bool { get }
@@ -366,6 +369,7 @@ extension Modifier: ModifierAutoJSExport {}
     var module: String? { get }
     var imports: [Import] { get }
     var allImports: [Import] { get }
+    var typealiases: [String: Typealias] { get }
     var accessLevel: String { get }
     var name: String { get }
     var isUnknownExtension: Bool { get }
@@ -415,6 +419,7 @@ extension Protocol: ProtocolAutoJSExport {}
     var module: String? { get }
     var imports: [Import] { get }
     var allImports: [Import] { get }
+    var typealiases: [String: Typealias] { get }
     var accessLevel: String { get }
     var name: String { get }
     var isUnknownExtension: Bool { get }
@@ -464,6 +469,7 @@ extension ProtocolComposition: ProtocolCompositionAutoJSExport {}
     var module: String? { get }
     var imports: [Import] { get }
     var allImports: [Import] { get }
+    var typealiases: [String: Typealias] { get }
     var accessLevel: String { get }
     var name: String { get }
     var isUnknownExtension: Bool { get }
@@ -563,6 +569,7 @@ extension TupleType: TupleTypeAutoJSExport {}
     var module: String? { get }
     var imports: [Import] { get }
     var allImports: [Import] { get }
+    var typealiases: [String: Typealias] { get }
     var kind: String { get }
     var accessLevel: String { get }
     var name: String { get }

--- a/SourceryTests/Generating/JavaScriptTemplateSpecs.swift
+++ b/SourceryTests/Generating/JavaScriptTemplateSpecs.swift
@@ -41,6 +41,17 @@ class JavaScriptTemplateTests: QuickSpec {
                 print("expected:\n\(expectedResult)\n\ngot:\n\(result)")
                 expect(result).to(equal(expectedResult))
             }
+            
+            it("provides typealias information") {
+                let templatePath = Stubs.jsTemplates + Path("Typealiases.ejs")
+                let expectedResult = try? (Stubs.resultDirectory + Path("Typealiases.swift")).read(.utf8)
+                
+                expect { try Sourcery(cacheDisabled: true).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output, baseIndentation: 0) }.toNot(throwError())
+
+                let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                print("expected:\n\(expectedResult)\n\ngot:\n\(result)")
+                expect(result).to(equal(expectedResult))
+            }
 
             it("handles includes") {
                 let templatePath = Stubs.jsTemplates + Path("Includes.ejs")

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -1324,7 +1324,7 @@ class SourcerySpecTests: QuickSpec {
                     expect {
                         let paths = sourceFilesPaths
                         expect(paths.contains(outputDir + "PerFileGeneration.generated.swift")).to(beTrue())
-                        expect(paths.contains(outputDir + "Generated/Foo.generated.swift")).to(beTrue())
+                        expect(paths.contains(outputDir + "Generated/FooBarBaz.generated.swift")).to(beTrue())
                     }.toNot(throwError())
                 }
             }

--- a/SourceryTests/Stub/JavaScriptTemplates/Typealiases.ejs
+++ b/SourceryTests/Stub/JavaScriptTemplates/Typealiases.ejs
@@ -1,0 +1,6 @@
+<%_ for (type of types.all) { -%>
+// Typealiases in <%= type.name %>
+<%_ for (const [aliasName, aliasValue] of Object.entries(type.typealiases)) { -%>
+// - name '<%= aliasName %>', type '<%= aliasValue.typeName.name %>'
+<% }
+} -%>

--- a/SourceryTests/Stub/Result/Basic+Other+SourceryTemplates.swift
+++ b/SourceryTests/Stub/Result/Basic+Other+SourceryTemplates.swift
@@ -1,19 +1,19 @@
 // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-extension Bar: Equatable {}
+extension BarBaz: Equatable {}
 
-// Bar has Annotations
+// BarBaz has Annotations
 
-func == (lhs: Bar, rhs: Bar) -> Bool {
+func == (lhs: BarBaz, rhs: BarBaz) -> Bool {
     if lhs.parent != rhs.parent { return false }
     if lhs.otherVariable != rhs.otherVariable { return false }
 
     return true
 }
 
-extension Foo: Equatable {}
+extension FooBarBaz: Equatable {}
 
-func == (lhs: Foo, rhs: Foo) -> Bool {
+func == (lhs: FooBarBaz, rhs: FooBarBaz) -> Bool {
     if lhs.name != rhs.name { return false }
     if lhs.value != rhs.value { return false }
 

--- a/SourceryTests/Stub/Result/Basic+Other+SourceryTemplates_Linux.swift
+++ b/SourceryTests/Stub/Result/Basic+Other+SourceryTemplates_Linux.swift
@@ -1,19 +1,19 @@
 // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-extension Bar: Equatable {}
+extension BarBaz: Equatable {}
 
-// Bar has Annotations
+// BarBaz has Annotations
 
-func == (lhs: Bar, rhs: Bar) -> Bool {
+func == (lhs: BarBaz, rhs: BarBaz) -> Bool {
     if lhs.parent != rhs.parent { return false }
     if lhs.otherVariable != rhs.otherVariable { return false }
 
     return true
 }
 
-extension Foo: Equatable {}
+extension FooBarBaz: Equatable {}
 
-func == (lhs: Foo, rhs: Foo) -> Bool {
+func == (lhs: FooBarBaz, rhs: FooBarBaz) -> Bool {
     if lhs.name != rhs.name { return false }
     if lhs.value != rhs.value { return false }
 

--- a/SourceryTests/Stub/Result/Basic+Other.swift
+++ b/SourceryTests/Stub/Result/Basic+Other.swift
@@ -1,19 +1,19 @@
 // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-extension Bar: Equatable {}
+extension BarBaz: Equatable {}
 
-// Bar has Annotations
+// BarBaz has Annotations
 
-func == (lhs: Bar, rhs: Bar) -> Bool {
+func == (lhs: BarBaz, rhs: BarBaz) -> Bool {
     if lhs.parent != rhs.parent { return false }
     if lhs.otherVariable != rhs.otherVariable { return false }
 
     return true
 }
 
-extension Foo: Equatable {}
+extension FooBarBaz: Equatable {}
 
-func == (lhs: Foo, rhs: Foo) -> Bool {
+func == (lhs: FooBarBaz, rhs: FooBarBaz) -> Bool {
     if lhs.name != rhs.name { return false }
     if lhs.value != rhs.value { return false }
 

--- a/SourceryTests/Stub/Result/Basic.swift
+++ b/SourceryTests/Stub/Result/Basic.swift
@@ -1,19 +1,19 @@
 // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-extension Bar: Equatable {}
+extension BarBaz: Equatable {}
 
-// Bar has Annotations
+// BarBaz has Annotations
 
-func == (lhs: Bar, rhs: Bar) -> Bool {
+func == (lhs: BarBaz, rhs: BarBaz) -> Bool {
     if lhs.parent != rhs.parent { return false }
     if lhs.otherVariable != rhs.otherVariable { return false }
 
     return true
 }
 
-extension Foo: Equatable {}
+extension FooBarBaz: Equatable {}
 
-func == (lhs: Foo, rhs: Foo) -> Bool {
+func == (lhs: FooBarBaz, rhs: FooBarBaz) -> Bool {
     if lhs.name != rhs.name { return false }
     if lhs.value != rhs.value { return false }
 

--- a/SourceryTests/Stub/Result/BasicFooExcluded.swift
+++ b/SourceryTests/Stub/Result/BasicFooExcluded.swift
@@ -1,10 +1,10 @@
 // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-extension Bar: Equatable {}
+extension BarBaz: Equatable {}
 
-// Bar has Annotations
+// BarBaz has Annotations
 
-func == (lhs: Bar, rhs: Bar) -> Bool {
+func == (lhs: BarBaz, rhs: BarBaz) -> Bool {
     if lhs.parent != rhs.parent { return false }
     if lhs.otherVariable != rhs.otherVariable { return false }
 

--- a/SourceryTests/Stub/Result/FooBar.swift
+++ b/SourceryTests/Stub/Result/FooBar.swift
@@ -4,8 +4,8 @@
 struct AnyFooBar: FooBar {
 
     // MARK: HasFoo properties
-    var foo: Foo
+    var foo: FooBarBaz
 
     // MARK: HasBar properties
-    var bar: Bar
+    var bar: BarBaz
 }

--- a/SourceryTests/Stub/Result/Function.swift
+++ b/SourceryTests/Stub/Result/Function.swift
@@ -1,5 +1,5 @@
 // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-func wrappedPerformFoo(value: Foo) {
+func wrappedPerformFoo(value: FooBarBaz) {
     performFoo(value: value)
 }

--- a/SourceryTests/Stub/Result/Typealiases.swift
+++ b/SourceryTests/Stub/Result/Typealiases.swift
@@ -1,0 +1,7 @@
+// Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+// Typealiases in Bar
+// - name 'List', type '[Foo]'
+// Typealiases in Foo
+// - name 'Name', type 'String'
+// Typealiases in FooSubclass

--- a/SourceryTests/Stub/Result/Typealiases.swift
+++ b/SourceryTests/Stub/Result/Typealiases.swift
@@ -1,7 +1,7 @@
 // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-// Typealiases in Bar
-// - name 'List', type '[Foo]'
-// Typealiases in Foo
+// Typealiases in BarBaz
+// - name 'List', type '[FooBarBaz]'
+// Typealiases in FooBarBaz
 // - name 'Name', type 'String'
 // Typealiases in FooSubclass

--- a/SourceryTests/Stub/Source/Bar.swift
+++ b/SourceryTests/Stub/Source/Bar.swift
@@ -6,6 +6,7 @@ import Foundation
 // sourcery: showComment
 /// other documentation
 class Bar: Foo, AutoEquatable {
+    typealias List = [Foo]
     var parent: Foo? = nil
     var otherVariable: Int = 0
 }

--- a/SourceryTests/Stub/Source/Bar.swift
+++ b/SourceryTests/Stub/Source/Bar.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-// sourcery: this will not appear under Bar
+// sourcery: this will not appear under FooBarBaz
 
 /// Documentation for bar
 // sourcery: showComment
 /// other documentation
-class Bar: Foo, AutoEquatable {
-    typealias List = [Foo]
-    var parent: Foo? = nil
+class BarBaz: FooBarBaz, AutoEquatable {
+    typealias List = [FooBarBaz]
+    var parent: FooBarBaz? = nil
     var otherVariable: Int = 0
 }

--- a/SourceryTests/Stub/Source/Foo.swift
+++ b/SourceryTests/Stub/Source/Foo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class Foo {
+class FooBarBaz {
 	// Note: when Swift Linux doesn't bug out on [String: String], add a test back for it
 	// See https://github.com/krzysztofzablocki/Sourcery/pull/1208#issuecomment-1752185381
     typealias Name = String
@@ -11,10 +11,10 @@ class Foo {
 
 protocol AutoEquatable {}
 
-class FooSubclass: Foo, AutoEquatable {
+class FooSubclass: FooBarBaz, AutoEquatable {
     var other: String = ""
 }
 
-func performFoo(value: Foo) {
+func performFoo(value: FooBarBaz) {
 
 }

--- a/SourceryTests/Stub/Source/Foo.swift
+++ b/SourceryTests/Stub/Source/Foo.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 class Foo {
+	// Note: when Swift Linux doesn't bug out on [String: String], add a test back for it
+	// See https://github.com/krzysztofzablocki/Sourcery/pull/1208#issuecomment-1752185381
+    typealias Name = String
+
     var name: String = ""
     var value: Int = 0
 }

--- a/SourceryTests/Stub/Source/FooBar.swift
+++ b/SourceryTests/Stub/Source/FooBar.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 protocol HasFoo {
-    var foo: Foo { get }
+    var foo: FooBarBaz { get }
 }
 protocol HasBar {
-    var bar: Bar { get }
+    var bar: BarBaz { get }
 }
 
 // sourcery: AutoStruct


### PR DESCRIPTION
Currently marked with `skipJSExport`, so not visible from those templates. Not sure why 🤷 

Same as with the [recent protocols PR](https://github.com/krzysztofzablocki/Sourcery/pull/1192), added some tests for it as well.