### PR TITLE
Update xcodeproj dependency

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
       uses: swift-actions/setup-swift@v1.23.0
       with:
         # Swift version to configure
-        swift-version: 5.8 # default is 5.8
+        swift-version: 5.9 # default is 5.8
     - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -17,13 +17,19 @@ jobs:
   linux_build:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Swift
-      # You may pin to the exact commit or the version.
-      # uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
-      uses: swift-actions/setup-swift@v1.23.0
+    # - name: Setup Swift
+    #   # You may pin to the exact commit or the version.
+    #   # uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+    #   uses: swift-actions/setup-swift@v1.23.0
+    #   with:
+    #     # Swift version to configure
+    #     swift-version: 5.9 # default is 5.8
+    - name: Setup Swift environment for macOS, Linux and Windows
+      uses: SwiftyLab/setup-swift@v1.4.1
       with:
-        # Swift version to configure
-        swift-version: 5.9 # default is 5.8
+        swift-version: "5.9"
+    - name: Get swift version
+      run: swift --version
     - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1

--- a/Package.swift
+++ b/Package.swift
@@ -237,7 +237,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
     .package(url: "https://github.com/art-divin/StencilSwiftKit.git", branch: "stable"),
     .package(url: "https://github.com/art-divin/Stencil.git", branch: "master"),
-    .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.3.1"),
+    .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.15.0"),
     .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
     .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -236,7 +236,6 @@ var dependencies: [Package.Dependency] = [
     // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
     .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
     .package(url: "https://github.com/art-divin/StencilSwiftKit.git", branch: "stable"),
-    .package(url: "https://github.com/art-divin/Stencil.git", branch: "master"),
     .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.15.0"),
     .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),


### PR DESCRIPTION
## Description

This PR updates `XcodeProj` to 8.15.0; however, this does not resolve issue with `XCLocalSwiftPackageReference ` mentioned in https://github.com/krzysztofzablocki/Sourcery/issues/1206. At this point, it seems that `XCLocalSwiftPackageReference` is unsupported by `XcodeProj` at all, there are 0 references to be found anywhere using search on GitHub.

## Notes

This PR also updates `swift` version to `5.9` for Linux action. 