### PR TITLE
Set fixed version for StencilSwiftKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -235,7 +235,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/kylef/Commander.git", exact: "0.9.1"),
     // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
     .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
-    .package(url: "https://github.com/art-divin/StencilSwiftKit.git", branch: "stable"),
+    .package(url: "https://github.com/art-divin/StencilSwiftKit.git", exact: "2.10.3"),
     .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.15.0"),
     .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),


### PR DESCRIPTION
## Description

While https://github.com/SwiftGen/StencilSwiftKit/issues/174 is not closed, we need to fix the version of `StencilSwiftKit` and `Stencil`