### PR TITLE
Add Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Extract DOCKER_TAG using tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+    - name: Use default DOCKER_TAG
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+
+    - name: Set lowercase repository name
+      run: |
+        echo "REPOSITORY_LC=${REPOSITORY,,}" >>${GITHUB_ENV}
+      env:
+        REPOSITORY: '${{ github.repository }}'
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub registry
+      uses: docker/login-action@v1
+      with:
+        username: ${{ github.actor }}
+        password:  ${{ secrets.GITHUB_TOKEN }}
+        registry: ghcr.io
+
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY Tests Tests/
 COPY Package.* ./
 
 RUN swift package update
-ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib -Xlinker -lCFURLSessionInterface -Xlinker -lCFXMLInterface -Xlinker -lcurl -Xlinker -lxml2 -Xswiftc -I. -Xlinker -fuse-ld=lld -Xlinker -L/usr/lib/swift/linux"
+ARG SWIFT_FLAGS="-c release"
 RUN swift build $SWIFT_FLAGS --product sourcery
 RUN mv `swift build $SWIFT_FLAGS --show-bin-path`/sourcery /usr/bin
 RUN sourcery --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+ARG BUILDER_IMAGE=swift:5.9-jammy
+ARG RUNTIME_IMAGE=swift:5.9-jammy-slim
+
+# Builder image
+FROM ${BUILDER_IMAGE} AS builder
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libffi-dev \
+    libncurses5-dev \
+    libsqlite3-dev \
+ && rm -r /var/lib/apt/lists/*
+WORKDIR /workdir/
+COPY Sourcery Sourcery/
+COPY SourceryExecutable SourceryExecutable/
+COPY SourceryFramework SourceryFramework/
+COPY SourceryJS SourceryJS/
+COPY SourceryRuntime SourceryRuntime/
+COPY SourceryStencil SourceryStencil/
+COPY SourcerySwift SourcerySwift/
+COPY SourceryTests SourceryTests/
+COPY SourceryUtils SourceryUtils/
+COPY Plugins Plugins/
+COPY Templates Templates/
+COPY Tests Tests/
+COPY Package.* ./
+
+RUN swift package update
+ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib -Xlinker -lCFURLSessionInterface -Xlinker -lCFXMLInterface -Xlinker -lcurl -Xlinker -lxml2 -Xswiftc -I. -Xlinker -fuse-ld=lld -Xlinker -L/usr/lib/swift/linux"
+RUN swift build $SWIFT_FLAGS --product sourcery
+RUN mv `swift build $SWIFT_FLAGS --show-bin-path`/sourcery /usr/bin
+RUN sourcery --version
+
+# Runtime image
+FROM ${RUNTIME_IMAGE}
+LABEL org.opencontainers.image.source https://github.com/krzysztofzablocki/Sourcery
+RUN apt-get update && apt-get install -y \
+    libcurl4 \
+    libsqlite3-0 \
+    libxml2 \
+ && rm -r /var/lib/apt/lists/*
+COPY --from=builder /usr/bin/sourcery /usr/bin
+
+RUN sourcery --version
+
+CMD ["sourcery"]

--- a/LINUX.md
+++ b/LINUX.md
@@ -13,6 +13,20 @@ All issues related to Linux will be mentioned in #1198
 
 Simply add package dependency of Sourcery as described in the [README](README.md).
 
+## Using Sourcery with Docker
+
+You can build Docker container with Sourcery installed using this command:
+
+```console
+docker build -t sourcery-image .
+```
+
+Then you can run this Docker image passing the arguments you'd like:
+
+```console
+docker run sourcery-image sourcery --help
+```
+
 ## Contributing
 ### Installation of Linux Environment
 


### PR DESCRIPTION
To simplify building on Linux:

```console
docker build -t sourcery-image .
docker run sourcery-image sourcery --help
```

I've kept the resulting Docker image small(-ish) at the expense of probably removing some useful functionality. To have full functionality it may be necessary to skip the builder/runtime image layering and just ship the much larger (5GB vs 347MB) builder image.

I haven't tested this thoroughly but I'll leave it to other contributors can expand this as needed.