### PR TITLE
Bump SPM version to support Swift 5.9

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,12 +19,21 @@
       }
     },
     {
-      "identity" : "komondor",
+      "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/shibapm/Komondor.git",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
       "state" : {
-        "revision" : "90b087b1e39069684b1ff4bf915c2aae594f2d60",
-        "version" : "1.1.3"
+        "revision" : "f809deb30dc5c9d9b78c872e553261a61177721a",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "02b7a39a99c4da27abe03cab2053a9034379639f",
+        "version" : "2.0.0"
       }
     },
     {
@@ -34,15 +43,6 @@
       "state" : {
         "revision" : "e491a6731307bb23783bf664d003be9b2fa59ab5",
         "version" : "9.0.0"
-      }
-    },
-    {
-      "identity" : "packageconfig",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/shibapm/PackageConfig.git",
-      "state" : {
-        "revision" : "58523193c26fb821ed1720dcd8a21009055c7cdb",
-        "version" : "1.1.3"
       }
     },
     {
@@ -64,15 +64,6 @@
       }
     },
     {
-      "identity" : "shellout",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/ShellOut.git",
-      "state" : {
-        "revision" : "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
-        "version" : "2.3.0"
-      }
-    },
-    {
       "identity" : "spectre",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kylef/Spectre.git",
@@ -84,19 +75,19 @@
     {
       "identity" : "stencil",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StencilProject/Stencil.git",
+      "location" : "https://github.com/art-divin/Stencil.git",
       "state" : {
-        "revision" : "4f222ac85d673f35df29962fc4c36ccfdaf9da5b",
-        "version" : "0.15.1"
+        "revision" : "ea58733eb66b063f37288d009959d47c09f520c7",
+        "version" : "0.15.2"
       }
     },
     {
       "identity" : "stencilswiftkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftGen/StencilSwiftKit.git",
+      "location" : "https://github.com/art-divin/StencilSwiftKit.git",
       "state" : {
-        "revision" : "20e2de5322c83df005939d9d9300fab130b49f97",
-        "version" : "2.10.1"
+        "revision" : "60bd09805246f788154aefd74dfbbba512408c84",
+        "version" : "2.10.3"
       }
     },
     {
@@ -104,8 +95,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "e394bf350e38cb100b6bc4172834770ede1b7232",
-        "version" : "1.0.3"
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "805deae27a7506dcad043604c00a9dc52d465dcb",
+        "version" : "0.7.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "35a7df2d9d71c401a47de9be2e3de629a01370c2",
+        "version" : "0.4.1"
       }
     },
     {
@@ -122,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "75ec60b8b4cc0f085c3ac414f3dca5625fa3588e",
-        "version" : "2.2.4"
+        "revision" : "33a20e650c33f6d72d822d558333f2085effa3dc",
+        "version" : "2.5.0"
       }
     },
     {
@@ -131,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-driver.git",
       "state" : {
-        "branch" : "release/5.8",
-        "revision" : "7cfe0c0b6e6297efe88a3ce34e6138ee7eda969e"
+        "branch" : "release/5.9",
+        "revision" : "1b2b851ae4718caffa5f18fd1861bc0ddd1791a3"
       }
     },
     {
@@ -140,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-llbuild.git",
       "state" : {
-        "branch" : "release/5.8",
-        "revision" : "168f9dc3798def1ecdd7d40049f6e1841bf761d0"
+        "branch" : "release/5.9",
+        "revision" : "d73a305d6e5a82e4bf3bf1727da3d1376e87efab"
       }
     },
     {
@@ -149,7 +158,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-package-manager",
       "state" : {
-        "revision" : "fa3db13e0bd00e33c187c63c80673b3ac7c82f55"
+        "revision" : "848ddac99ee588a4a6cd1ec22beae8822c819671"
       }
     },
     {
@@ -175,8 +184,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-tools-support-core.git",
       "state" : {
-        "branch" : "release/5.8",
-        "revision" : "ac4871e01ef338cb95b5d28328cab0ec1dfae935"
+        "branch" : "release/5.9",
+        "revision" : "5665fc7641ce1a971ad06faaa476862b222ef44b"
       }
     },
     {
@@ -184,8 +193,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/xcodeproj",
       "state" : {
-        "revision" : "446f3a0db73e141c7f57e26fcdb043096b1db52c",
-        "version" : "8.3.1"
+        "revision" : "3797181813ee963fe305d939232bc576d23ddbb0",
+        "version" : "8.15.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -240,7 +240,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
     .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
-    .package(url: "https://github.com/apple/swift-package-manager", revision: "fa3db13e0bd00e33c187c63c80673b3ac7c82f55"),
+    .package(url: "https://github.com/apple/swift-package-manager", revision: "848ddac99ee588a4a6cd1ec22beae8822c819671"),
 ]
 
 #if !canImport(ObjectiveC)


### PR DESCRIPTION
In order to read Packages when Swift 5.9 is installed we need SPM bundled that supports Swift 5.9.

Note: I'm going to work on a fix to make it more agnostic from the installed Swift version, and less heavy due to not having to bundle SPM with Sourcery. 

Until that time it would be great if we can ship this asap as this is blocking my team at the moment.