### PR TITLE
Use sortedKeys option for JSON encoder

### DIFF
--- a/Templates/CodableContextTests/CodableContextTests.swift
+++ b/Templates/CodableContextTests/CodableContextTests.swift
@@ -8,7 +8,7 @@ class CodableContextTests: QuickSpec {
 #if canImport(ObjectiveC)
         let encoder: JSONEncoder = {
             let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             return encoder
         }()
 
@@ -22,14 +22,13 @@ class CodableContextTests: QuickSpec {
                     let value = AssociatedValuesEnum.someCase(id: 0, name: "a")
 
                     let encoded = try! encoder.encode(value)
-                    expect(String(data: encoded, encoding: .utf8)).to(equal(
-"""
-{
-  "type" : "someCase",
-  "id" : 0,
-  "name" : "a"
-}
-"""
+                    expect(String(data: encoded, encoding: .utf8)).to(equal("""
+                    {
+                      "id" : 0,
+                      "name" : "a",
+                      "type" : "someCase"
+                    }
+                    """
                     ))
 
                     let decoded = try! decoder.decode(AssociatedValuesEnum.self, from: encoded)


### PR DESCRIPTION
A test case in `CodableContextTests` produced a failure here on Xcode 15.0.1, emitting a JSON document with different order of keys. Using the `.sortedKeys` option on `JSONEncoder` should help getting the same result on all machines.