### PR TITLE
Fixed missing attributes in optional closure type name

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -65,7 +65,8 @@ extension TypeName {
         } else if let typeIdentifier = node.as(OptionalTypeSyntax.self) {
             let type = TypeName(typeIdentifier.wrappedType)
             let needsWrapping = type.isClosure || type.isProtocolComposition
-            self.init(name: needsWrapping ? "(\(type.name))" : type.name,
+            self.init(name: needsWrapping ? "(\(type.asSource))" : type.name,
+                      unwrappedTypeName: needsWrapping ? type.asSource : nil,
                       isOptional: true,
                       isImplicitlyUnwrappedOptional: false,
                       tuple: type.tuple,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -66,7 +66,6 @@ extension TypeName {
             let type = TypeName(typeIdentifier.wrappedType)
             let needsWrapping = type.isClosure || type.isProtocolComposition
             self.init(name: needsWrapping ? "(\(type.asSource))" : type.name,
-                      unwrappedTypeName: needsWrapping ? type.asSource : nil,
                       isOptional: true,
                       isImplicitlyUnwrappedOptional: false,
                       tuple: type.tuple,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -78,7 +78,7 @@ extension TypeName {
         } else if let typeIdentifier = node.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
             let type = TypeName(typeIdentifier.wrappedType)
             let needsWrapping = type.isClosure || type.isProtocolComposition
-            self.init(name: needsWrapping ? "(\(type.name))" : type.name,
+            self.init(name: needsWrapping ? "(\(type.asSource))" : type.name,
                       isOptional: false,
                       isImplicitlyUnwrappedOptional: true,
                       tuple: type.tuple,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -64,12 +64,7 @@ extension TypeName {
             self.init(name: name, isProtocolComposition: true)
         } else if let typeIdentifier = node.as(OptionalTypeSyntax.self) {
             let type = TypeName(typeIdentifier.wrappedType)
-            let needsWrapping = [
-                type.isClosure,
-                type.isProtocolComposition,
-                type.isExistential,
-                type.isOpaque,
-            ].contains(true)
+            let needsWrapping = type.isClosure || type.isProtocolComposition
             self.init(name: needsWrapping ? "(\(type.asSource))" : type.name,
                       isOptional: true,
                       isImplicitlyUnwrappedOptional: false,
@@ -82,12 +77,7 @@ extension TypeName {
             )
         } else if let typeIdentifier = node.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
             let type = TypeName(typeIdentifier.wrappedType)
-            let needsWrapping = [
-                type.isClosure,
-                type.isProtocolComposition,
-                type.isExistential,
-                type.isOpaque,
-            ].contains(true)
+            let needsWrapping = type.isClosure || type.isProtocolComposition
             self.init(name: needsWrapping ? "(\(type.asSource))" : type.name,
                       isOptional: false,
                       isImplicitlyUnwrappedOptional: true,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -64,7 +64,12 @@ extension TypeName {
             self.init(name: name, isProtocolComposition: true)
         } else if let typeIdentifier = node.as(OptionalTypeSyntax.self) {
             let type = TypeName(typeIdentifier.wrappedType)
-            let needsWrapping = type.isClosure || type.isProtocolComposition
+            let needsWrapping = [
+                type.isClosure,
+                type.isProtocolComposition,
+                type.isExistential,
+                type.isOpaque,
+            ].contains(true)
             self.init(name: needsWrapping ? "(\(type.asSource))" : type.name,
                       isOptional: true,
                       isImplicitlyUnwrappedOptional: false,
@@ -77,7 +82,12 @@ extension TypeName {
             )
         } else if let typeIdentifier = node.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
             let type = TypeName(typeIdentifier.wrappedType)
-            let needsWrapping = type.isClosure || type.isProtocolComposition
+            let needsWrapping = [
+                type.isClosure,
+                type.isProtocolComposition,
+                type.isExistential,
+                type.isOpaque,
+            ].contains(true)
             self.init(name: needsWrapping ? "(\(type.asSource))" : type.name,
                       isOptional: false,
                       isImplicitlyUnwrappedOptional: true,

--- a/SourceryRuntime/Sources/AST/TypeName/TypeName.swift
+++ b/SourceryRuntime/Sources/AST/TypeName/TypeName.swift
@@ -95,18 +95,6 @@ public final class TypeName: NSObject, SourceryModelWithoutDescription, Lossless
         return name == "Void" || name == "()" || unwrappedTypeName == "Void"
     }
 
-    // sourcery: skipEquality
-    /// Whether type is existential type (`any FooBar`)
-    public var isExistential: Bool {
-        return name.hasPrefix("any")
-    }
-
-    // sourcery: skipEquality
-    /// Whether type is opaque type (`some FooBar`)
-    public var isOpaque: Bool {
-        return name.hasPrefix("some")
-    }
-
     /// Whether type is a tuple
     public var isTuple: Bool {
         actualTypeName?.tuple != nil || tuple != nil

--- a/SourceryRuntime/Sources/AST/TypeName/TypeName.swift
+++ b/SourceryRuntime/Sources/AST/TypeName/TypeName.swift
@@ -95,6 +95,18 @@ public final class TypeName: NSObject, SourceryModelWithoutDescription, Lossless
         return name == "Void" || name == "()" || unwrappedTypeName == "Void"
     }
 
+    // sourcery: skipEquality
+    /// Whether type is existential type (`any FooBar`)
+    public var isExistential: Bool {
+        return name.hasPrefix("any")
+    }
+
+    // sourcery: skipEquality
+    /// Whether type is opaque type (`some FooBar`)
+    public var isOpaque: Bool {
+        return name.hasPrefix("some")
+    }
+
     /// Whether type is a tuple
     public var isTuple: Bool {
         actualTypeName?.tuple != nil || tuple != nil

--- a/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
@@ -172,7 +172,7 @@ class TypeNameSpec: QuickSpec {
 
             context("given optional closure type with attributes") {
                 it("keeps attributes in unwrappedTypeName") {
-                    expect(typeName("(@MainActor @Sendable (Int) -> Void)?").unwrappedTypeName).to(equal("@MainActor @Sendable (Int) -> Void"))
+                    expect(typeName("(@MainActor @Sendable (Int) -> Void)?").unwrappedTypeName).to(equal("(@MainActor @Sendable (Int) -> Void)"))
                 }
                 it("keeps attributes in name") {
                     expect(typeName("(@MainActor @Sendable (Int) -> Void)?").name).to(equal("(@MainActor @Sendable (Int) -> Void)?"))

--- a/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
@@ -169,6 +169,15 @@ class TypeNameSpec: QuickSpec {
                     expect(typeName("@escaping @autoclosure () -> String").description).to(equal("@autoclosure @escaping () -> String"))
                 }
             }
+
+            context("given optional closure type with attributes") {
+                it("keeps attributes in unwrappedTypeName") {
+                    expect(typeName("(@MainActor @Sendable (Int) -> Void)?").unwrappedTypeName).to(equal("@MainActor @Sendable (Int) -> Void"))
+                }
+                it("keeps attributes in name") {
+                    expect(typeName("(@MainActor @Sendable (Int) -> Void)?").name).to(equal("(@MainActor @Sendable (Int) -> Void)?"))
+                }
+            }
         }
     }
 }

--- a/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
@@ -187,6 +187,33 @@ class TypeNameSpec: QuickSpec {
                     expect(typeName("(@MainActor @Sendable (Int) -> Void)!").name).to(equal("(@MainActor @Sendable (Int) -> Void)!"))
                 }
             }
+
+            context("given optional opaque type") {
+                it("unwrappedTypeName keeps brackets") {
+                    expect(typeName("(some FooBar)?").unwrappedTypeName).to(equal("(some FooBar)"))
+                }
+                it("name keeps brackets") {
+                    expect(typeName("(some FooBar)?").name).to(equal("(some FooBar)?"))
+                }
+            }
+
+            context("given implicitly unwrapped optional opaque type") {
+                it("unwrappedTypeName keeps brackets") {
+                    expect(typeName("(some FooBar)!").unwrappedTypeName).to(equal("(some FooBar)"))
+                }
+                it("name keeps brackets") {
+                    expect(typeName("(some FooBar)!").name).to(equal("(some FooBar)!"))
+                }
+            }
+
+            context("given implicitly unwrapped optional existential type") {
+                it("unwrappedTypeName keeps brackets") {
+                    expect(typeName("(any FooBar)!").unwrappedTypeName).to(equal("(any FooBar)"))
+                }
+                it("name keeps brackets") {
+                    expect(typeName("(any FooBar)!").name).to(equal("(any FooBar)!"))
+                }
+            }
         }
     }
 }

--- a/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
@@ -178,6 +178,15 @@ class TypeNameSpec: QuickSpec {
                     expect(typeName("(@MainActor @Sendable (Int) -> Void)?").name).to(equal("(@MainActor @Sendable (Int) -> Void)?"))
                 }
             }
+
+            context("given implicitly unwrapped optional closure type with attributes") {
+                it("keeps attributes in unwrappedTypeName") {
+                    expect(typeName("(@MainActor @Sendable (Int) -> Void)!").unwrappedTypeName).to(equal("(@MainActor @Sendable (Int) -> Void)"))
+                }
+                it("keeps attributes in name") {
+                    expect(typeName("(@MainActor @Sendable (Int) -> Void)!").name).to(equal("(@MainActor @Sendable (Int) -> Void)!"))
+                }
+            }
         }
     }
 }

--- a/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
@@ -187,33 +187,6 @@ class TypeNameSpec: QuickSpec {
                     expect(typeName("(@MainActor @Sendable (Int) -> Void)!").name).to(equal("(@MainActor @Sendable (Int) -> Void)!"))
                 }
             }
-
-            context("given optional opaque type") {
-                it("unwrappedTypeName keeps brackets") {
-                    expect(typeName("(some FooBar)?").unwrappedTypeName).to(equal("(some FooBar)"))
-                }
-                it("name keeps brackets") {
-                    expect(typeName("(some FooBar)?").name).to(equal("(some FooBar)?"))
-                }
-            }
-
-            context("given implicitly unwrapped optional opaque type") {
-                it("unwrappedTypeName keeps brackets") {
-                    expect(typeName("(some FooBar)!").unwrappedTypeName).to(equal("(some FooBar)"))
-                }
-                it("name keeps brackets") {
-                    expect(typeName("(some FooBar)!").name).to(equal("(some FooBar)!"))
-                }
-            }
-
-            context("given implicitly unwrapped optional existential type") {
-                it("unwrappedTypeName keeps brackets") {
-                    expect(typeName("(any FooBar)!").unwrappedTypeName).to(equal("(any FooBar)"))
-                }
-                it("name keeps brackets") {
-                    expect(typeName("(any FooBar)!").name).to(equal("(any FooBar)!"))
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
We've recently encountered an issue where optional closure type with concurrency attributes wasn't properly parsed.

Example:

```
var closure: (@MainActor(unsafe) @Sendable (Int) -> Void)?
```

In Stencil template this type is returned as:

```
variable.typeName.name -> ((Int) -> Void)?
variable.typeName.unwrappedTypeName -> ((Int) -> Void)
```

This PR should fix #1004.