### PR TITLE
Fixed incorrect parsing of consequently declared "@" symbols

### DIFF
--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -221,7 +221,7 @@ public struct AnnotationsParser {
                     var annotations = Annotations()
                     let isComment = content.hasPrefix("//") || content.hasPrefix("/*") || content.hasPrefix("*")
                     let isDocumentationComment = content.hasPrefix("///") || content.hasPrefix("/**")
-                    let isPropertyWrapper = content.isMacros
+                    let isPropertyWrapper = content.isPropertyWrapper
                     let isMacros = content.hasPrefix("#")
                     var type = Line.LineType.other
                     if isDocumentationComment {
@@ -438,7 +438,7 @@ private extension String {
     /// @MyAttribute(some     thing) // true
     /// @MyAttribute(some     thing) var paosdjapsodji = 1 // false
     /// @objc let asdasd // false
-    var isMacros: Bool {
+    var isPropertyWrapper: Bool {
         guard hasPrefix("@") else { return false }
         guard contains(")") || !contains(" ") else { return false }
         return true

--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -107,11 +107,17 @@ public struct AnnotationsParser {
         var annotations = inlineFrom(line: (lineNumber, column), stop: &stop)
         guard !stop else { return annotations }
 
-        for line in lines[0..<lineNumber-1].reversed() {
+        let reversedArray = lines[0..<lineNumber-1].reversed()
+        for line in reversedArray {
             line.annotations.forEach { annotation in
                 AnnotationsParser.append(key: annotation.key, value: annotation.value, to: &annotations)
             }
-            if line.type != .comment && line.type != .documentationComment && line.type != .macros && line.type != .propertyWrapper {
+
+            if line.type != .comment 
+                && line.type != .documentationComment
+                && line.type != .macros
+                && line.type != .propertyWrapper
+            {
                 break
             }
         }
@@ -215,7 +221,7 @@ public struct AnnotationsParser {
                     var annotations = Annotations()
                     let isComment = content.hasPrefix("//") || content.hasPrefix("/*") || content.hasPrefix("*")
                     let isDocumentationComment = content.hasPrefix("///") || content.hasPrefix("/**")
-                    let isPropertyWrapper = content.hasPrefix("@")
+                    let isPropertyWrapper = content.isMacros
                     let isMacros = content.hasPrefix("#")
                     var type = Line.LineType.other
                     if isDocumentationComment {
@@ -423,4 +429,18 @@ public struct AnnotationsParser {
         }
     }
 
+}
+
+// Parses string to see if it is a macros or not
+private extension String {
+    /// @objc // true
+    /// @objc var paosdjapsodji = 1 // false
+    /// @MyAttribute(some     thing) // true
+    /// @MyAttribute(some     thing) var paosdjapsodji = 1 // false
+    /// @objc let asdasd // false
+    var isMacros: Bool {
+        guard hasPrefix("@") else { return false }
+        guard contains(")") || !contains(" ") else { return false }
+        return true
+    }
 }


### PR DESCRIPTION
Resolves #1236 

## Context

In the issue #1236 it was investigated that commit https://github.com/krzysztofzablocki/Sourcery/commit/e64a3ab4839417204190191b11b9ce4d165b09bb introduced a bug, where consequently declared variables with `@` annotations, like:

```swift
// sourcery: Annotation
@objc var ...
@objc let ...
var ...
```

would share annotations.

## Technical details

Issue was in the way property wrapper was detected. Before, only prefix `@` would suffice to consider the whole line as a property wrapper.
Now a new extension on `String` type was introduced which checks if the whole line is property wrapper or not.