### PR TITLE
Support for variadic types as method arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     ([#1224](https://github.com/krzysztofzablocki/Sourcery/pull/1224)
 - Fix unit tests on Linux ([#1225](https://github.com/krzysztofzablocki/Sourcery/pull/1225))
 - Updated XcodeProj to 8.16.0 ([#1228](https://github.com/krzysztofzablocki/Sourcery/pull/1228))
+- Support for variadic arguments as method parameters ([#1222](https://github.com/krzysztofzablocki/Sourcery/issues/1222))
 
 ## 2.1.2
 ## Changes

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,24 +19,6 @@
       }
     },
     {
-      "identity" : "cwlcatchexception",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
-      "state" : {
-        "revision" : "f809deb30dc5c9d9b78c872e553261a61177721a",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "cwlpreconditiontesting",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-      "state" : {
-        "revision" : "02b7a39a99c4da27abe03cab2053a9034379639f",
-        "version" : "2.0.0"
-      }
-    },
-    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",

--- a/SourceryRuntime/Sources/AST/MethodParameter_Linux.swift
+++ b/SourceryRuntime/Sources/AST/MethodParameter_Linux.swift
@@ -19,6 +19,8 @@ public class MethodParameter: NSObject, SourceryModel, Typed, Annotated, Diffabl
                 return isClosure
             case "typeAttributes":
                 return typeAttributes
+            case "isVariadic":
+                return isVariadic
             default:
                 fatalError("unable to lookup: \(member) in \(self)")
         }

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -54,7 +54,7 @@ import {{ import }}
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -77,11 +77,11 @@ import {{ import }}
         {% endfor -%}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName %}{{ ')' if param.isClosure }})?{% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{{ ')' if param.isClosure }})?{% endfor %}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName %}{% else %}{% call existentialClosureVariableTypeName param.typeName %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName %}{% else %}{% call existentialClosureVariableTypeName param.typeName %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
@@ -221,7 +221,7 @@ import {{ import }}
         {{ typeName }}
     {%- endif -%}
 {%- endmacro %}
-{% macro existentialClosureVariableTypeName typeName -%}
+{% macro existentialClosureVariableTypeName typeName isVariadic -%}
     {%- if typeName|contains:"any " and typeName|contains:"!" -%}
         {{ typeName | replace:"any","(any" | replace:"!",")?" }}
     {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
@@ -234,6 +234,8 @@ import {{ import }}
         {{ typeName | replace:"some","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"some " and typeName|contains:"?" -%}
         {{ typeName | replace:"some","(any" | replace:"?",")?" }}
+    {%- elif isVariadic -%}
+        {{ typeName }}...
     {%- else -%}
         {{ typeName|replace:"some ","any " }}
     {%- endif -%}

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -238,7 +238,7 @@ import {{ import }}
         {{ typeName|replace:"some ","any " }}
     {%- endif -%}
 {%- endmacro %}
-{% macro existentialParameterTypeName typeName -%}
+{% macro existentialParameterTypeName typeName isVariadic -%}
     {%- if typeName|contains:"any " and typeName|contains:"?," and typeName|contains:">?" -%}
         {{ typeName | replace:"any","(any" | replace:"?,",")?," }}
     {%- elif typeName|contains:"any " and typeName|contains:"!" -%}
@@ -253,11 +253,13 @@ import {{ import }}
         {{ typeName | replace:"some","(some" | replace:"?",")?" }}
     {%- elif typeName|contains:"some " and typeName.isOptional -%}
         {{ typeName | replace:"some","(some" | replace:"?",")?" }}
+    {%- elif isVariadic -%}
+        {{ typeName }}...
     {%- else -%}
         {{ typeName }}
     {%- endif -%}
 {%- endmacro %}
-{% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {{ param.name }}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% call existentialParameterTypeName param.typeName %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}
+{% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {{ param.name }}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% call existentialParameterTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}
 
 {% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
 {% call accessLevel type.accessLevel %}class {{ type.name }}Mock: {{ type.name }} {

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -210,3 +210,8 @@ protocol HouseProtocol: AutoMockable {
     var f3Publisher: GenericType<Never, Never, any PersonProtocol>? { get }
     var f4Publisher: GenericType<any PersonProtocol, any PersonProtocol, any PersonProtocol>? { get }
 }
+
+// sourcery: AutoMockable
+protocol ExampleVararg {
+    func string(key: String, args: CVarArg...) -> String
+}

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -210,3 +210,8 @@ protocol HouseProtocol: AutoMockable {
     var f3Publisher: GenericType<Never, Never, any PersonProtocol>? { get }
     var f4Publisher: GenericType<any PersonProtocol, any PersonProtocol, any PersonProtocol>? { get }
 }
+
+// sourcery: AutoMockable
+protocol ExampleVararg {
+    func string(key: String, args: CVarArg...) -> String
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.1.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -661,6 +661,34 @@ class CurrencyPresenterMock: CurrencyPresenter {
         showSourceCurrencyReceivedCurrency = currency
         showSourceCurrencyReceivedInvocations.append(currency)
         showSourceCurrencyClosure?(currency)
+    }
+
+}
+class ExampleVarargMock: ExampleVararg {
+
+
+
+
+    //MARK: - string
+
+    var stringKeyArgsCallsCount = 0
+    var stringKeyArgsCalled: Bool {
+        return stringKeyArgsCallsCount > 0
+    }
+    var stringKeyArgsReceivedArguments: (key: String, args: CVarArg...)?
+    var stringKeyArgsReceivedInvocations: [(key: String, args: CVarArg...)] = []
+    var stringKeyArgsReturnValue: String!
+    var stringKeyArgsClosure: ((String, CVarArg...) -> String)?
+
+    func string(key: String, args: CVarArg...) -> String {
+        stringKeyArgsCallsCount += 1
+        stringKeyArgsReceivedArguments = (key: key, args: args)
+        stringKeyArgsReceivedInvocations.append((key: key, args: args))
+        if let stringKeyArgsClosure = stringKeyArgsClosure {
+            return stringKeyArgsClosure(key, args)
+        } else {
+            return stringKeyArgsReturnValue
+        }
     }
 
 }


### PR DESCRIPTION
Resolves #1222 

## Context

Currently it is not possible to mock a method which has a VarArg argument type. Neither it is possible to mock a method or variable, whose return type contains a closure with a VarArg argument.

For example, the following code would not consider `...` after the type:

```swift
func string(key: String, args: CVarArg...) -> String
```

## Solution

Check if the MethodParameter is `variadic`, and if so, append `...` after the `TypeName.name`.