### PR TITLE
Add dynamic method modifier support

### DIFF
--- a/SourceryRuntime/Sources/AST/Attribute.swift
+++ b/SourceryRuntime/Sources/AST/Attribute.swift
@@ -56,6 +56,8 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case autoclosure
         case convention
         case mutating
+        case nonisolated
+        case isolated
         case escaping
         case final
         case open
@@ -69,6 +71,7 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case privateSetter = "setter_access.private"
         case fileprivateSetter = "setter_access.fileprivate"
         case optional
+        case dynamic
 
         public init?(identifier: String) {
             let identifier = identifier.trimmingPrefix("source.decl.attribute.")

--- a/SourceryRuntime/Sources/AST/Method.swift
+++ b/SourceryRuntime/Sources/AST/Method.swift
@@ -96,25 +96,25 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     // sourcery: skipEquality, skipDescription
     /// Whether method is a convenience initializer
     public var isConvenienceInitializer: Bool {
-        modifiers.contains { $0.name == "convenience" }
+        modifiers.contains { $0.name == Attribute.Identifier.convenience.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is required
     public var isRequired: Bool {
-        modifiers.contains { $0.name == "required" }
+        modifiers.contains { $0.name == Attribute.Identifier.required.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is final
     public var isFinal: Bool {
-        modifiers.contains { $0.name == "final" }
+        modifiers.contains { $0.name == Attribute.Identifier.final.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is mutating
     public var isMutating: Bool {
-        modifiers.contains { $0.name == "mutating" }
+        modifiers.contains { $0.name == Attribute.Identifier.mutating.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
@@ -126,13 +126,19 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     // sourcery: skipEquality, skipDescription
     /// Whether method is optional (in an Objective-C protocol)
     public var isOptional: Bool {
-        modifiers.contains { $0.name == "optional" }
+        modifiers.contains { $0.name == Attribute.Identifier.optional.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is nonisolated (this modifier only applies to actor methods)
     public var isNonisolated: Bool {
-        modifiers.contains { $0.name == "nonisolated" }
+        modifiers.contains { $0.name == Attribute.Identifier.nonisolated.rawValue }
+    }
+
+    // sourcery: skipEquality, skipDescription
+    /// Whether method is dynamic
+    public var isDynamic: Bool {
+        modifiers.contains { $0.name == Attribute.Identifier.dynamic.rawValue }
     }
 
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2

--- a/SourceryRuntime/Sources/AST/Method_Linux.swift
+++ b/SourceryRuntime/Sources/AST/Method_Linux.swift
@@ -42,6 +42,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 return isOptionalReturnType
             case "actualReturnTypeName":
                 return actualReturnTypeName
+            case "isDynamic":
+                return isDynamic
             default:
                 fatalError("unable to lookup: \(member) in \(self)")
         }
@@ -135,25 +137,25 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     // sourcery: skipEquality, skipDescription
     /// Whether method is a convenience initializer
     public var isConvenienceInitializer: Bool {
-        modifiers.contains { $0.name == "convenience" }
+        modifiers.contains { $0.name == Attribute.Identifier.convenience.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is required
     public var isRequired: Bool {
-        modifiers.contains { $0.name == "required" }
+        modifiers.contains { $0.name == Attribute.Identifier.required.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is final
     public var isFinal: Bool {
-        modifiers.contains { $0.name == "final" }
+        modifiers.contains { $0.name == Attribute.Identifier.final.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is mutating
     public var isMutating: Bool {
-        modifiers.contains { $0.name == "mutating" }
+        modifiers.contains { $0.name == Attribute.Identifier.mutating.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
@@ -165,13 +167,19 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     // sourcery: skipEquality, skipDescription
     /// Whether method is optional (in an Objective-C protocol)
     public var isOptional: Bool {
-        modifiers.contains { $0.name == "optional" }
+        modifiers.contains { $0.name == Attribute.Identifier.optional.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is nonisolated (this modifier only applies to actor methods)
     public var isNonisolated: Bool {
-        modifiers.contains { $0.name == "nonisolated" }
+        modifiers.contains { $0.name == Attribute.Identifier.nonisolated.rawValue }
+    }
+
+    // sourcery: skipEquality, skipDescription
+    /// Whether method is dynamic
+    public var isDynamic: Bool {
+        modifiers.contains { $0.name == Attribute.Identifier.dynamic.rawValue }
     }
 
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2

--- a/SourceryRuntime/Sources/AST/Variable.swift
+++ b/SourceryRuntime/Sources/AST/Variable.swift
@@ -70,12 +70,17 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
 
     /// Whether variable is final or not
     public var isFinal: Bool {
-        return modifiers.contains { $0.name == "final" }
+        return modifiers.contains { $0.name == Attribute.Identifier.final.rawValue }
     }
 
     /// Whether variable is lazy or not
     public var isLazy: Bool {
-        return modifiers.contains { $0.name == "lazy" }
+        return modifiers.contains { $0.name == Attribute.Identifier.lazy.rawValue }
+    }
+
+    /// Whether variable is dynamic or not
+    public var isDynamic: Bool {
+        modifiers.contains { $0.name == Attribute.Identifier.dynamic.rawValue }
     }
 
     /// Reference to type name where the variable is defined,
@@ -145,6 +150,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         string += "modifiers = \(String(describing: self.modifiers)), "
         string += "isFinal = \(String(describing: self.isFinal)), "
         string += "isLazy = \(String(describing: self.isLazy)), "
+        string += "isDynamic = \(String(describing: self.isDynamic)), "
         string += "definedInTypeName = \(String(describing: self.definedInTypeName)), "
         string += "actualDefinedInTypeName = \(String(describing: self.actualDefinedInTypeName))"
         return string

--- a/SourceryRuntime/Sources/AST/Variable_Linux.swift
+++ b/SourceryRuntime/Sources/AST/Variable_Linux.swift
@@ -40,6 +40,8 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             return isArray
         case "isDictionary":
             return isDictionary
+        case "isDynamic":
+            return isDynamic
         default:
             fatalError("unable to lookup: \(member) in \(self)")
         }
@@ -102,12 +104,17 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
 
     /// Whether variable is final or not
     public var isFinal: Bool {
-        return modifiers.contains { $0.name == "final" }
+        return modifiers.contains { $0.name == Attribute.Identifier.final.rawValue }
     }
 
     /// Whether variable is lazy or not
     public var isLazy: Bool {
-        return modifiers.contains { $0.name == "lazy" }
+        return modifiers.contains { $0.name == Attribute.Identifier.lazy.rawValue }
+    }
+
+    /// Whether variable is dynamic or not
+    public var isDynamic: Bool {
+        modifiers.contains { $0.name == Attribute.Identifier.dynamic.rawValue }
     }
 
     /// Reference to type name where the variable is defined,
@@ -177,6 +184,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         string += "modifiers = \(String(describing: self.modifiers)), "
         string += "isFinal = \(String(describing: self.isFinal)), "
         string += "isLazy = \(String(describing: self.isLazy)), "
+        string += "isDynamic = \(String(describing: self.isDynamic)), "
         string += "definedInTypeName = \(String(describing: self.definedInTypeName)), "
         string += "actualDefinedInTypeName = \(String(describing: self.actualDefinedInTypeName))"
         return string

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -424,6 +424,8 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case autoclosure
         case convention
         case mutating
+        case nonisolated
+        case isolated
         case escaping
         case final
         case open
@@ -437,6 +439,7 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case privateSetter = "setter_access.private"
         case fileprivateSetter = "setter_access.fileprivate"
         case optional
+        case dynamic
 
         public init?(identifier: String) {
             let identifier = identifier.trimmingPrefix("source.decl.attribute.")
@@ -3992,25 +3995,25 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     // sourcery: skipEquality, skipDescription
     /// Whether method is a convenience initializer
     public var isConvenienceInitializer: Bool {
-        modifiers.contains { $0.name == "convenience" }
+        modifiers.contains { $0.name == Attribute.Identifier.convenience.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is required
     public var isRequired: Bool {
-        modifiers.contains { $0.name == "required" }
+        modifiers.contains { $0.name == Attribute.Identifier.required.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is final
     public var isFinal: Bool {
-        modifiers.contains { $0.name == "final" }
+        modifiers.contains { $0.name == Attribute.Identifier.final.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is mutating
     public var isMutating: Bool {
-        modifiers.contains { $0.name == "mutating" }
+        modifiers.contains { $0.name == Attribute.Identifier.mutating.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
@@ -4022,13 +4025,19 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     // sourcery: skipEquality, skipDescription
     /// Whether method is optional (in an Objective-C protocol)
     public var isOptional: Bool {
-        modifiers.contains { $0.name == "optional" }
+        modifiers.contains { $0.name == Attribute.Identifier.optional.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is nonisolated (this modifier only applies to actor methods)
     public var isNonisolated: Bool {
-        modifiers.contains { $0.name == "nonisolated" }
+        modifiers.contains { $0.name == Attribute.Identifier.nonisolated.rawValue }
+    }
+
+    // sourcery: skipEquality, skipDescription
+    /// Whether method is dynamic
+    public var isDynamic: Bool {
+        modifiers.contains { $0.name == Attribute.Identifier.dynamic.rawValue }
     }
 
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -7470,12 +7470,17 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
 
     /// Whether variable is final or not
     public var isFinal: Bool {
-        return modifiers.contains { $0.name == "final" }
+        return modifiers.contains { $0.name == Attribute.Identifier.final.rawValue }
     }
 
     /// Whether variable is lazy or not
     public var isLazy: Bool {
-        return modifiers.contains { $0.name == "lazy" }
+        return modifiers.contains { $0.name == Attribute.Identifier.lazy.rawValue }
+    }
+
+    /// Whether variable is dynamic or not
+    public var isDynamic: Bool {
+        modifiers.contains { $0.name == Attribute.Identifier.dynamic.rawValue }
     }
 
     /// Reference to type name where the variable is defined,
@@ -7545,6 +7550,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         string += "modifiers = \\(String(describing: self.modifiers)), "
         string += "isFinal = \\(String(describing: self.isFinal)), "
         string += "isLazy = \\(String(describing: self.isLazy)), "
+        string += "isDynamic = \\(String(describing: self.isDynamic)), "
         string += "definedInTypeName = \\(String(describing: self.definedInTypeName)), "
         string += "actualDefinedInTypeName = \\(String(describing: self.actualDefinedInTypeName))"
         return string

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -3381,7 +3381,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             case "isDynamic":
                 return isDynamic
             default:
-                fatalError("unable to lookup: \\(member) in \(self)")
+                fatalError("unable to lookup: \\(member) in \\(self)")
         }
     }
 

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -7022,6 +7022,8 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             return isArray
         case "isDictionary":
             return isDictionary
+        case "isDynamic":
+            return isDynamic
         default:
             fatalError("unable to lookup: \\(member) in \\(self)")
         }
@@ -7084,12 +7086,17 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
 
     /// Whether variable is final or not
     public var isFinal: Bool {
-        return modifiers.contains { $0.name == "final" }
+        return modifiers.contains { $0.name == Attribute.Identifier.final.rawValue }
     }
 
     /// Whether variable is lazy or not
     public var isLazy: Bool {
-        return modifiers.contains { $0.name == "lazy" }
+        return modifiers.contains { $0.name == Attribute.Identifier.lazy.rawValue }
+    }
+
+    /// Whether variable is dynamic or not
+    public var isDynamic: Bool {
+        modifiers.contains { $0.name == Attribute.Identifier.dynamic.rawValue }
     }
 
     /// Reference to type name where the variable is defined,
@@ -7159,6 +7166,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         string += "modifiers = \\(String(describing: self.modifiers)), "
         string += "isFinal = \\(String(describing: self.isFinal)), "
         string += "isLazy = \\(String(describing: self.isLazy)), "
+        string += "isDynamic = \\(String(describing: self.isDynamic)), "
         string += "definedInTypeName = \\(String(describing: self.definedInTypeName)), "
         string += "actualDefinedInTypeName = \\(String(describing: self.actualDefinedInTypeName))"
         return string

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -3336,10 +3336,6 @@ extension Array where Element == ClosureParameter {
     .init(name: "Method.swift", content:
 """
 import Foundation
-// For DynamicMemberLookup we need to import Stencil,
-// however, this is different from SourceryRuntime.content.generated.swift, because
-// it cannot reference Stencil
-import Stencil
 
 /// :nodoc:
 public typealias SourceryMethod = Method

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -439,6 +439,8 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case autoclosure
         case convention
         case mutating
+        case nonisolated
+        case isolated
         case escaping
         case final
         case open
@@ -452,6 +454,7 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case privateSetter = "setter_access.private"
         case fileprivateSetter = "setter_access.fileprivate"
         case optional
+        case dynamic
 
         public init?(identifier: String) {
             let identifier = identifier.trimmingPrefix("source.decl.attribute.")
@@ -3333,6 +3336,10 @@ extension Array where Element == ClosureParameter {
     .init(name: "Method.swift", content:
 """
 import Foundation
+// For DynamicMemberLookup we need to import Stencil,
+// however, this is different from SourceryRuntime.content.generated.swift, because
+// it cannot reference Stencil
+import Stencil
 
 /// :nodoc:
 public typealias SourceryMethod = Method
@@ -3369,8 +3376,12 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 return attributes
             case "isOptionalReturnType":
                 return isOptionalReturnType
+            case "actualReturnTypeName":
+                return actualReturnTypeName
+            case "isDynamic":
+                return isDynamic
             default:
-                fatalError("unable to lookup: \\(member) in \\(self)")
+                fatalError("unable to lookup: \\(member) in \(self)")
         }
     }
 
@@ -3462,25 +3473,25 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     // sourcery: skipEquality, skipDescription
     /// Whether method is a convenience initializer
     public var isConvenienceInitializer: Bool {
-        modifiers.contains { $0.name == "convenience" }
+        modifiers.contains { $0.name == Attribute.Identifier.convenience.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is required
     public var isRequired: Bool {
-        modifiers.contains { $0.name == "required" }
+        modifiers.contains { $0.name == Attribute.Identifier.required.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is final
     public var isFinal: Bool {
-        modifiers.contains { $0.name == "final" }
+        modifiers.contains { $0.name == Attribute.Identifier.final.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is mutating
     public var isMutating: Bool {
-        modifiers.contains { $0.name == "mutating" }
+        modifiers.contains { $0.name == Attribute.Identifier.mutating.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
@@ -3492,13 +3503,19 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     // sourcery: skipEquality, skipDescription
     /// Whether method is optional (in an Objective-C protocol)
     public var isOptional: Bool {
-        modifiers.contains { $0.name == "optional" }
+        modifiers.contains { $0.name == Attribute.Identifier.optional.rawValue }
     }
 
     // sourcery: skipEquality, skipDescription
     /// Whether method is nonisolated (this modifier only applies to actor methods)
     public var isNonisolated: Bool {
-        modifiers.contains { $0.name == "nonisolated" }
+        modifiers.contains { $0.name == Attribute.Identifier.nonisolated.rawValue }
+    }
+
+    // sourcery: skipEquality, skipDescription
+    /// Whether method is dynamic
+    public var isDynamic: Bool {
+        modifiers.contains { $0.name == Attribute.Identifier.dynamic.rawValue }
     }
 
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2

--- a/SourceryTests/Models/MethodSpec.swift
+++ b/SourceryTests/Models/MethodSpec.swift
@@ -26,6 +26,11 @@ class MethodSpec: QuickSpec {
                 expect(sut?.shortName).to(equal("foo"))
             }
 
+            it("reports isDynamic properly") {
+                expect(Method(name: "foo()", modifiers: [Modifier(name: "dynamic", detail: nil)]).isDynamic).to(beTrue())
+                expect(Method(name: "foo()", modifiers: [Modifier(name: "mutating", detail: nil)]).isDynamic).to(beFalse())
+            }
+
             it("reports definedInTypeName propertly") {
                 expect(Method(name: "foo()", definedInTypeName: TypeName(name: "BarAlias", actualTypeName: TypeName(name: "Bar"))).definedInTypeName).to(equal(TypeName(name: "BarAlias")))
                 expect(Method(name: "foo()", definedInTypeName: TypeName(name: "Foo")).definedInTypeName).to(equal(TypeName(name: "Foo")))

--- a/SourceryTests/Models/VariableSpec.swift
+++ b/SourceryTests/Models/VariableSpec.swift
@@ -28,6 +28,11 @@ class VariableSpec: QuickSpec {
                 expect(sut?.readAccess == AccessLevel.public.rawValue).to(beTrue())
             }
 
+            it("has proper dynamic state") {
+                expect(Variable(name: "variable", typeName: TypeName(name: "Int"), accessLevel: (read: .public, write: .internal), isComputed: true, modifiers: [Modifier(name: "dynamic")]).isDynamic).to(beTrue())
+                expect(Variable(name: "variable", typeName: TypeName(name: "Int"), accessLevel: (read: .public, write: .internal), isComputed: true, modifiers: [Modifier(name: "lazy")]).isDynamic).to(beFalse())
+            }
+
             it("has proper write access") {
                 expect(sut?.writeAccess == AccessLevel.internal.rawValue).to(beTrue())
             }


### PR DESCRIPTION
Resolves #1243 

## Context 

Currently cases like:

```swift
protocol Christmassifiable {
  dynamic func tree()
  dynamic func presents()
  dynamic var isRelevant: Bool { get }
}
```
are not supported, i.e. there's no way to request `method.isDynamic` or `variable.isDynamic` in stencil or swift templates. 

## Technical Details

Accessors are not provided both in `Method.swift` and `Variable.swift`, though they may and are contained in the member collection of modifiers in both cases. By simply exposing accessors, feature becomes supported.

## Notes

 This PR also moves from using raw strings for similar accessors in both `Mehtod.swift` and `Variable.swift` to `Attribute.Identifier` enum values (their `rawValue`).