### PR TITLE
Introduce package access level

### DIFF
--- a/SourceryRuntime/Sources/AST/AccessLevel.swift
+++ b/SourceryRuntime/Sources/AST/AccessLevel.swift
@@ -7,6 +7,7 @@ import Foundation
 
 /// :nodoc:
 public enum AccessLevel: String {
+    case `package` = "package"
     case `internal` = "internal"
     case `private` = "private"
     case `fileprivate` = "fileprivate"

--- a/SourceryRuntime/Sources/AST/Attribute.swift
+++ b/SourceryRuntime/Sources/AST/Attribute.swift
@@ -62,6 +62,7 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
         case final
         case open
         case lazy
+        case `package` = "package"
         case `public` = "public"
         case `internal` = "internal"
         case `private` = "private"

--- a/SourceryTests/Models/ClassSpec.swift
+++ b/SourceryTests/Models/ClassSpec.swift
@@ -24,6 +24,10 @@ class ClassSpec: QuickSpec {
                 expect(sut?.kind).to(equal("class"))
             }
 
+            it("supports package access level") {
+                expect(Class(name: "Foo", accessLevel: .package).accessLevel == AccessLevel.package.rawValue).to(beTrue())
+                expect(Class(name: "Foo", accessLevel: .internal).accessLevel == AccessLevel.package.rawValue).to(beFalse())
+            }
         }
     }
 }

--- a/SourceryTests/Models/MethodSpec.swift
+++ b/SourceryTests/Models/MethodSpec.swift
@@ -60,6 +60,11 @@ class MethodSpec: QuickSpec {
                 expect(Method(name: "foo()").isGeneric).to(beFalse())
             }
 
+            it("has correct access level") {
+                expect(Method(name: "foo<T>()", accessLevel: .package).accessLevel == AccessLevel.package.rawValue).to(beTrue())
+                expect(Method(name: "foo<T>()", accessLevel: .open).accessLevel == AccessLevel.package.rawValue).to(beFalse())
+            }
+
             describe("When testing equality") {
 
                 context("given same items") {

--- a/SourceryTests/Models/ProtocolSpec.swift
+++ b/SourceryTests/Models/ProtocolSpec.swift
@@ -24,6 +24,10 @@ class ProtocolSpec: QuickSpec {
                 expect(sut?.kind).to(equal("protocol"))
             }
 
+            it("supports package access level") {
+                expect(Protocol(name: "Foo", accessLevel: .package).accessLevel == AccessLevel.package.rawValue).to(beTrue())
+                expect(Protocol(name: "Foo", accessLevel: .internal).accessLevel == AccessLevel.package.rawValue).to(beFalse())
+            }
         }
     }
 }

--- a/SourceryTests/Models/VariableSpec.swift
+++ b/SourceryTests/Models/VariableSpec.swift
@@ -26,6 +26,7 @@ class VariableSpec: QuickSpec {
 
             it("has proper read access") {
                 expect(sut?.readAccess == AccessLevel.public.rawValue).to(beTrue())
+                expect(Variable(name: "variable", typeName: TypeName(name: "Int"), accessLevel: (read: .package, write: .public), isComputed: true).readAccess == AccessLevel.package.rawValue).to(beTrue())
             }
 
             it("has proper dynamic state") {
@@ -35,6 +36,7 @@ class VariableSpec: QuickSpec {
 
             it("has proper write access") {
                 expect(sut?.writeAccess == AccessLevel.internal.rawValue).to(beTrue())
+                expect(Variable(name: "variable", typeName: TypeName(name: "Int"), accessLevel: (read: .public, write: .package), isComputed: true).writeAccess == AccessLevel.package.rawValue).to(beTrue())
             }
 
             describe("When testing equality") {


### PR DESCRIPTION
Resolves #1234

## Context

Currently `package` access level is not supported in `AccessLevel` enum.