### PR TITLE
Update SwiftStencilKit & Stencil

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/art-divin/Stencil.git",
       "state" : {
-        "revision" : "ea58733eb66b063f37288d009959d47c09f520c7",
-        "version" : "0.15.2"
+        "revision" : "03a1dca8923bef5a34c08f5a560fb420326f7244",
+        "version" : "0.15.3"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/art-divin/StencilSwiftKit.git",
       "state" : {
-        "revision" : "60bd09805246f788154aefd74dfbbba512408c84",
-        "version" : "2.10.3"
+        "revision" : "6b07f85def6984e7015d65502d41b91f3f8db6d5",
+        "version" : "2.10.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -4,19 +4,19 @@ import PackageDescription
 import Foundation
 
 var sourceryLibDependencies: [Target.Dependency] = [
-                "SourceryFramework",
-                "SourceryRuntime",
-                "SourceryStencil",
-                "SourceryJS",
-                "SourcerySwift",
-                "Commander",
-                "PathKit",
-                "Yams",
-                "StencilSwiftKit",
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
-                "XcodeProj",
-                .product(name: "SwiftPM-auto", package: "swift-package-manager"),
-            ]
+    "SourceryFramework",
+    "SourceryRuntime",
+    "SourceryStencil",
+    "SourceryJS",
+    "SourcerySwift",
+    "Commander",
+    "PathKit",
+    "Yams",
+    "StencilSwiftKit",
+    .product(name: "SwiftSyntax", package: "swift-syntax"),
+    "XcodeProj",
+    .product(name: "SwiftPM-auto", package: "swift-package-manager"),
+]
 
 // Note: when Swift Linux doesn't bug out on [String: String], add a test back for it
 // See https://github.com/krzysztofzablocki/Sourcery/pull/1208#issuecomment-1752185381
@@ -65,171 +65,171 @@ let sourceryLibTestsResources: [Resource] = [
 #endif
 
 var targets: [Target] = [
-        .executableTarget(
-            name: "SourceryExecutable",
-            dependencies: ["SourceryLib"],
-            path: "SourceryExecutable",
-            exclude: [
-                "Info.plist"
-            ]
-        ),
-        .target(
-            // Xcode doesn't like when a target has the same name as a product but in different case.
-            name: "SourceryLib",
-            dependencies: sourceryLibDependencies,
-            path: "Sourcery",
-            exclude: [
-                "Templates",
-            ]
-        ),
-        .target(
-            name: "SourceryRuntime",
-            dependencies: [
-                "StencilSwiftKit"
-            ],
-            path: "SourceryRuntime",
-            exclude: [
-                "Supporting Files/Info.plist"
-            ]
-        ),
-        .target(
-            name: "SourceryFramework",
-            dependencies: [
-              "PathKit",
-              .product(name: "SwiftSyntax", package: "swift-syntax"),
-              .product(name: "SwiftParser", package: "swift-syntax"),
-              "SourceryUtils",
-              "SourceryRuntime"
-            ],
-            path: "SourceryFramework",
-            exclude: [
-                "Info.plist"
-            ]
-        ),
-        .target(
-            name: "SourceryStencil",
-            dependencies: [
-              "PathKit",
-              "SourceryRuntime",
-              "StencilSwiftKit",
-            ],
-            path: "SourceryStencil",
-            exclude: [
-                "Info.plist"
-            ]
-        ),
-        .target(
-            name: "SourceryJS",
-            dependencies: [
-                "PathKit"
-            ],
-            path: "SourceryJS",
-            exclude: [
-                "Info.plist"
-            ],
-            resources: [
-                .copy("Resources/ejs.js")
-            ]
-        ),
-        .target(
-            name: "SourcerySwift",
-            dependencies: [
-              "PathKit",
-              "SourceryRuntime",
-              "SourceryUtils"
-            ],
-            path: "SourcerySwift",
-            exclude: [
-                "Info.plist"
-            ]
-        ),
-        .target(
-            name: "CodableContext",
-            path: "Templates/Tests",
-            exclude: [
-                "Context/AutoCases.swift",
-                "Context/AutoEquatable.swift",
-                "Context/AutoHashable.swift",
-                "Context/AutoLenses.swift",
-                "Context/AutoMockable.swift",
-                "Context/LinuxMain.swift",
-                "Generated/AutoCases.generated.swift",
-                "Generated/AutoEquatable.generated.swift",
-                "Generated/AutoHashable.generated.swift",
-                "Generated/AutoLenses.generated.swift",
-                "Generated/AutoMockable.generated.swift",
-                "Generated/LinuxMain.generated.swift",
-                "Expected",
-                "Info.plist",
-                "TemplatesTests.swift"
-            ],
-            sources: [
-                "Context/AutoCodable.swift",
-                "Generated/AutoCodable.generated.swift"
-            ]
-        ),
-        .testTarget(
-            name: "SourceryLibTests",
-            dependencies: [
-                "SourceryLib",
-                "Quick",
-                "Nimble"
-            ],
-            exclude: [
-                "Info.plist"
-            ],
-            resources: sourceryLibTestsResources,
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]
-        ),
-        .testTarget(
-            name: "CodableContextTests",
-            dependencies: [
-                "CodableContext",
-                "Quick",
-                "Nimble"
-            ],
-            path: "Templates/CodableContextTests",
-            exclude: [
-                "Info.plist"
-            ],
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]
-        ),
-        .testTarget(
-            name: "TemplatesTests",
-            dependencies: [
-                "Quick",
-                "Nimble",
-                "PathKit"
-            ],
-            path: "Templates",
-            exclude: [
-                "CodableContext",
-                "CodableContextTests",
-                "Tests/Generated",
-                "Tests/Info.plist"
-            ],
-            sources: [
-                // LinuxMain is not compiled as part of the target
-                // since there is no way to run script before compilation begins.
-                "Tests/TemplatesTests.swift"
-            ],
-            resources: templatesTestsResourcesCopy,
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]
-        ),
-        .plugin(
-            name: "SourceryCommandPlugin",
-            capability: .command(
-                intent: .custom(
-                    verb: "sourcery-command",
-                    description: "Sourcery command plugin for code generation"
-                ),
-                permissions: [
-                    .writeToPackageDirectory(reason: "Need permission to write generated files to package directory")
-                ]
+    .executableTarget(
+        name: "SourceryExecutable",
+        dependencies: ["SourceryLib"],
+        path: "SourceryExecutable",
+        exclude: [
+            "Info.plist"
+        ]
+    ),
+    .target(
+        // Xcode doesn't like when a target has the same name as a product but in different case.
+        name: "SourceryLib",
+        dependencies: sourceryLibDependencies,
+        path: "Sourcery",
+        exclude: [
+            "Templates",
+        ]
+    ),
+    .target(
+        name: "SourceryRuntime",
+        dependencies: [
+            "StencilSwiftKit"
+        ],
+        path: "SourceryRuntime",
+        exclude: [
+            "Supporting Files/Info.plist"
+        ]
+    ),
+    .target(
+        name: "SourceryFramework",
+        dependencies: [
+            "PathKit",
+            .product(name: "SwiftSyntax", package: "swift-syntax"),
+            .product(name: "SwiftParser", package: "swift-syntax"),
+            "SourceryUtils",
+            "SourceryRuntime"
+        ],
+        path: "SourceryFramework",
+        exclude: [
+            "Info.plist"
+        ]
+    ),
+    .target(
+        name: "SourceryStencil",
+        dependencies: [
+            "PathKit",
+            "SourceryRuntime",
+            "StencilSwiftKit",
+        ],
+        path: "SourceryStencil",
+        exclude: [
+            "Info.plist"
+        ]
+    ),
+    .target(
+        name: "SourceryJS",
+        dependencies: [
+            "PathKit"
+        ],
+        path: "SourceryJS",
+        exclude: [
+            "Info.plist"
+        ],
+        resources: [
+            .copy("Resources/ejs.js")
+        ]
+    ),
+    .target(
+        name: "SourcerySwift",
+        dependencies: [
+            "PathKit",
+            "SourceryRuntime",
+            "SourceryUtils"
+        ],
+        path: "SourcerySwift",
+        exclude: [
+            "Info.plist"
+        ]
+    ),
+    .target(
+        name: "CodableContext",
+        path: "Templates/Tests",
+        exclude: [
+            "Context/AutoCases.swift",
+            "Context/AutoEquatable.swift",
+            "Context/AutoHashable.swift",
+            "Context/AutoLenses.swift",
+            "Context/AutoMockable.swift",
+            "Context/LinuxMain.swift",
+            "Generated/AutoCases.generated.swift",
+            "Generated/AutoEquatable.generated.swift",
+            "Generated/AutoHashable.generated.swift",
+            "Generated/AutoLenses.generated.swift",
+            "Generated/AutoMockable.generated.swift",
+            "Generated/LinuxMain.generated.swift",
+            "Expected",
+            "Info.plist",
+            "TemplatesTests.swift"
+        ],
+        sources: [
+            "Context/AutoCodable.swift",
+            "Generated/AutoCodable.generated.swift"
+        ]
+    ),
+    .testTarget(
+        name: "SourceryLibTests",
+        dependencies: [
+            "SourceryLib",
+            "Quick",
+            "Nimble"
+        ],
+        exclude: [
+            "Info.plist"
+        ],
+        resources: sourceryLibTestsResources,
+        swiftSettings: [.unsafeFlags(["-enable-testing"])]
+    ),
+    .testTarget(
+        name: "CodableContextTests",
+        dependencies: [
+            "CodableContext",
+            "Quick",
+            "Nimble"
+        ],
+        path: "Templates/CodableContextTests",
+        exclude: [
+            "Info.plist"
+        ],
+        swiftSettings: [.unsafeFlags(["-enable-testing"])]
+    ),
+    .testTarget(
+        name: "TemplatesTests",
+        dependencies: [
+            "Quick",
+            "Nimble",
+            "PathKit"
+        ],
+        path: "Templates",
+        exclude: [
+            "CodableContext",
+            "CodableContextTests",
+            "Tests/Generated",
+            "Tests/Info.plist"
+        ],
+        sources: [
+            // LinuxMain is not compiled as part of the target
+            // since there is no way to run script before compilation begins.
+            "Tests/TemplatesTests.swift"
+        ],
+        resources: templatesTestsResourcesCopy,
+        swiftSettings: [.unsafeFlags(["-enable-testing"])]
+    ),
+    .plugin(
+        name: "SourceryCommandPlugin",
+        capability: .command(
+            intent: .custom(
+                verb: "sourcery-command",
+                description: "Sourcery command plugin for code generation"
             ),
-            dependencies: ["SourceryExecutable"]
-        )
-    ]
+            permissions: [
+                .writeToPackageDirectory(reason: "Need permission to write generated files to package directory")
+            ]
+        ),
+        dependencies: ["SourceryExecutable"]
+    )
+]
 
 #if canImport(ObjectiveC)
 let sourceryUtilsDependencies: [Target.Dependency] = ["PathKit"]
@@ -242,13 +242,13 @@ let sourceryUtilsDependencies: [Target.Dependency] = [
 #endif
 targets.append(
     .target(
-            name: "SourceryUtils",
-            dependencies: sourceryUtilsDependencies,
-            path: "SourceryUtils",
-            exclude: [
-                "Supporting Files/Info.plist"
-            ]
-        )
+        name: "SourceryUtils",
+        dependencies: sourceryUtilsDependencies,
+        path: "SourceryUtils",
+        exclude: [
+            "Supporting Files/Info.plist"
+        ]
+    )
 )
 
 var dependencies: [Package.Dependency] = [
@@ -256,7 +256,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/kylef/Commander.git", exact: "0.9.1"),
     // PathKit needs to be exact to avoid a SwiftPM bug where dependency resolution takes a very long time.
     .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
-    .package(url: "https://github.com/art-divin/StencilSwiftKit.git", exact: "2.10.3"),
+    .package(url: "https://github.com/art-divin/StencilSwiftKit.git", exact: "2.10.4"),
     .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.16.0"),
     .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
@@ -271,7 +271,7 @@ dependencies.append(.package(url: "https://github.com/apple/swift-crypto", from:
 let package = Package(
     name: "Sourcery",
     platforms: [
-       .macOS(.v12),
+        .macOS(.v12),
     ],
     products: [
         // SPM won't generate .swiftmodule for a target directly used by a product,


### PR DESCRIPTION
## Context

https://github.com/art-divin/Stencil/pull/1 introduces new way of caching of the loaded templates in Stencil.

## Details

Since Sourcery is now depending on forks of `StencilSwiftKit` which uses a fork of `Stencil` due to the fact that releases on the official repositories have not been done for a while, this PR bumps the version for `StencilSwiftKit` which includes the mentioned improvement. 
