### PR TITLE
Added isAsync and throws to Subscript

### DIFF
--- a/SourceryRuntime/Sources/AST/Subscript.swift
+++ b/SourceryRuntime/Sources/AST/Subscript.swift
@@ -50,6 +50,12 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     /// For immutable variables this value is empty string
     public var writeAccess: String
 
+    /// Whether subscript is async
+    public let isAsync: Bool
+
+    /// Whether subscript throws
+    public let `throws`: Bool
+
     /// Whether variable is mutable or not
     public var isMutable: Bool {
         return writeAccess != AccessLevel.none.rawValue
@@ -96,10 +102,11 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     /// :nodoc:
     public var __parserData: Any?
 
-    /// :nodoc:
     public init(parameters: [MethodParameter] = [],
                 returnTypeName: TypeName,
                 accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
+                isAsync: Bool = false,
+                `throws`: Bool = false,
                 genericParameters: [GenericParameter] = [],
                 genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
@@ -112,6 +119,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         self.returnTypeName = returnTypeName
         self.readAccess = accessLevel.read.rawValue
         self.writeAccess = accessLevel.write.rawValue
+        self.isAsync = isAsync
+        self.throws = `throws`
         self.genericParameters = genericParameters
         self.genericRequirements = genericRequirements
         self.attributes = attributes
@@ -130,6 +139,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         string += "isFinal = \(String(describing: self.isFinal)), "
         string += "readAccess = \(String(describing: self.readAccess)), "
         string += "writeAccess = \(String(describing: self.writeAccess)), "
+        string += "isAsync = \(String(describing: self.isAsync)), "
+        string += "`throws` = \(String(describing: self.throws)), "
         string += "isMutable = \(String(describing: self.isMutable)), "
         string += "annotations = \(String(describing: self.annotations)), "
         string += "documentation = \(String(describing: self.documentation)), "
@@ -153,6 +164,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
+        results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
+        results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.throws, expected: castObject.throws))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "documentation").trackDifference(actual: self.documentation, expected: castObject.documentation))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
@@ -169,6 +182,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         hasher.combine(self.returnTypeName)
         hasher.combine(self.readAccess)
         hasher.combine(self.writeAccess)
+        hasher.combine(self.isAsync)
+        hasher.combine(self.throws)
         hasher.combine(self.annotations)
         hasher.combine(self.documentation)
         hasher.combine(self.definedInTypeName)
@@ -186,6 +201,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         if self.returnTypeName != rhs.returnTypeName { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
+        if self.isAsync != rhs.isAsync { return false }
+        if self.throws != rhs.throws { return false }
         if self.annotations != rhs.annotations { return false }
         if self.documentation != rhs.documentation { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
@@ -200,52 +217,54 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
 
         /// :nodoc:
         required public init?(coder aDecoder: NSCoder) {
-            guard let parameters: [MethodParameter] = aDecoder.decode(forKey: "parameters") else { 
+            guard let parameters: [MethodParameter] = aDecoder.decode(forKey: "parameters") else {
                 withVaList(["parameters"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
                 fatalError()
              }; self.parameters = parameters
-            guard let returnTypeName: TypeName = aDecoder.decode(forKey: "returnTypeName") else { 
+            guard let returnTypeName: TypeName = aDecoder.decode(forKey: "returnTypeName") else {
                 withVaList(["returnTypeName"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
                 fatalError()
              }; self.returnTypeName = returnTypeName
             self.returnType = aDecoder.decode(forKey: "returnType")
-            guard let readAccess: String = aDecoder.decode(forKey: "readAccess") else { 
+            guard let readAccess: String = aDecoder.decode(forKey: "readAccess") else {
                 withVaList(["readAccess"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
                 fatalError()
              }; self.readAccess = readAccess
-            guard let writeAccess: String = aDecoder.decode(forKey: "writeAccess") else { 
+            guard let writeAccess: String = aDecoder.decode(forKey: "writeAccess") else {
                 withVaList(["writeAccess"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
                 fatalError()
              }; self.writeAccess = writeAccess
-            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
+            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else {
                 withVaList(["annotations"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
                 fatalError()
              }; self.annotations = annotations
-            guard let documentation: Documentation = aDecoder.decode(forKey: "documentation") else { 
+            guard let documentation: Documentation = aDecoder.decode(forKey: "documentation") else {
                 withVaList(["documentation"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
                 fatalError()
              }; self.documentation = documentation
+            self.isAsync = aDecoder.decode(forKey: "isAsync")
+            self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.definedInTypeName = aDecoder.decode(forKey: "definedInTypeName")
             self.definedInType = aDecoder.decode(forKey: "definedInType")
-            guard let attributes: AttributeList = aDecoder.decode(forKey: "attributes") else { 
+            guard let attributes: AttributeList = aDecoder.decode(forKey: "attributes") else {
                 withVaList(["attributes"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
                 fatalError()
              }; self.attributes = attributes
-            guard let modifiers: [SourceryModifier] = aDecoder.decode(forKey: "modifiers") else { 
+            guard let modifiers: [SourceryModifier] = aDecoder.decode(forKey: "modifiers") else {
                 withVaList(["modifiers"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
@@ -272,6 +291,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             aCoder.encode(self.returnType, forKey: "returnType")
             aCoder.encode(self.readAccess, forKey: "readAccess")
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
+            aCoder.encode(self.isAsync, forKey: "isAsync")
+            aCoder.encode(self.`throws`, forKey: "`throws`")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.definedInTypeName, forKey: "definedInTypeName")

--- a/SourceryRuntime/Sources/AST/Subscript_Linux.swift
+++ b/SourceryRuntime/Sources/AST/Subscript_Linux.swift
@@ -30,6 +30,10 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
                 return readAccess
             case "writeAccess":
                 return writeAccess
+            case "isAsync":
+                return isAsync
+            case "throws":
+                return `throws`
             case "isMutable":
                 return isMutable
             case "annotations":
@@ -100,6 +104,12 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     /// For immutable variables this value is empty string
     public var writeAccess: String
 
+    /// Whether subscript is async
+    public let isAsync: Bool
+
+    /// Whether subscript throws
+    public let `throws`: Bool
+
     /// Whether variable is mutable or not
     public var isMutable: Bool {
         return writeAccess != AccessLevel.none.rawValue
@@ -150,6 +160,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     public init(parameters: [MethodParameter] = [],
                 returnTypeName: TypeName,
                 accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
+                isAsync: Bool = false,
+                `throws`: Bool = false,
                 genericParameters: [GenericParameter] = [],
                 genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
@@ -162,6 +174,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         self.returnTypeName = returnTypeName
         self.readAccess = accessLevel.read.rawValue
         self.writeAccess = accessLevel.write.rawValue
+        self.isAsync = isAsync
+        self.throws = `throws`
         self.genericParameters = genericParameters
         self.genericRequirements = genericRequirements
         self.attributes = attributes
@@ -180,6 +194,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         string += "isFinal = \(String(describing: self.isFinal)), "
         string += "readAccess = \(String(describing: self.readAccess)), "
         string += "writeAccess = \(String(describing: self.writeAccess)), "
+        string += "isAsync = \(String(describing: self.isAsync)), "
+        string += "`throws` = \(String(describing: self.throws)), "
         string += "isMutable = \(String(describing: self.isMutable)), "
         string += "annotations = \(String(describing: self.annotations)), "
         string += "documentation = \(String(describing: self.documentation)), "
@@ -203,6 +219,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
+        results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
+        results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.throws, expected: castObject.throws))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "documentation").trackDifference(actual: self.documentation, expected: castObject.documentation))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
@@ -219,6 +237,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         hasher.combine(self.returnTypeName)
         hasher.combine(self.readAccess)
         hasher.combine(self.writeAccess)
+        hasher.combine(self.isAsync)
+        hasher.combine(self.throws)
         hasher.combine(self.annotations)
         hasher.combine(self.documentation)
         hasher.combine(self.definedInTypeName)
@@ -236,6 +256,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         if self.returnTypeName != rhs.returnTypeName { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
+        if self.isAsync != rhs.isAsync { return false }
+        if self.throws != rhs.throws { return false }
         if self.annotations != rhs.annotations { return false }
         if self.documentation != rhs.documentation { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
@@ -287,6 +309,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
                 }
                 fatalError()
              }; self.documentation = documentation
+            self.isAsync = aDecoder.decode(forKey: "isAsync")
+            self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.definedInTypeName = aDecoder.decode(forKey: "definedInTypeName")
             self.definedInType = aDecoder.decode(forKey: "definedInType")
             guard let attributes: AttributeList = aDecoder.decode(forKey: "attributes") else {
@@ -322,6 +346,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             aCoder.encode(self.returnType, forKey: "returnType")
             aCoder.encode(self.readAccess, forKey: "readAccess")
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
+            aCoder.encode(self.isAsync, forKey: "isAsync")
+            aCoder.encode(self.`throws`, forKey: "`throws`")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.definedInTypeName, forKey: "definedInTypeName")

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -5385,6 +5385,12 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     /// For immutable variables this value is empty string
     public var writeAccess: String
 
+    /// Whether subscript is async
+    public let isAsync: Bool
+
+    /// Whether subscript throws
+    public let `throws`: Bool
+
     /// Whether variable is mutable or not
     public var isMutable: Bool {
         return writeAccess != AccessLevel.none.rawValue
@@ -5435,6 +5441,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     public init(parameters: [MethodParameter] = [],
                 returnTypeName: TypeName,
                 accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
+                isAsync: Bool = false,
+                `throws`: Bool = false,
                 genericParameters: [GenericParameter] = [],
                 genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
@@ -5447,6 +5455,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         self.returnTypeName = returnTypeName
         self.readAccess = accessLevel.read.rawValue
         self.writeAccess = accessLevel.write.rawValue
+        self.isAsync = isAsync
+        self.throws = `throws`
         self.genericParameters = genericParameters
         self.genericRequirements = genericRequirements
         self.attributes = attributes
@@ -5465,6 +5475,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         string += "isFinal = \(String(describing: self.isFinal)), "
         string += "readAccess = \(String(describing: self.readAccess)), "
         string += "writeAccess = \(String(describing: self.writeAccess)), "
+        string += "isAsync = \(String(describing: self.isAsync)), "
+        string += "`throws` = \(String(describing: self.throws)), "
         string += "isMutable = \(String(describing: self.isMutable)), "
         string += "annotations = \(String(describing: self.annotations)), "
         string += "documentation = \(String(describing: self.documentation)), "
@@ -5488,6 +5500,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
+        results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
+        results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.throws, expected: castObject.throws))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "documentation").trackDifference(actual: self.documentation, expected: castObject.documentation))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
@@ -5504,6 +5518,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         hasher.combine(self.returnTypeName)
         hasher.combine(self.readAccess)
         hasher.combine(self.writeAccess)
+        hasher.combine(self.isAsync)
+        hasher.combine(self.throws)
         hasher.combine(self.annotations)
         hasher.combine(self.documentation)
         hasher.combine(self.definedInTypeName)
@@ -5521,6 +5537,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         if self.returnTypeName != rhs.returnTypeName { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
+        if self.isAsync != rhs.isAsync { return false }
+        if self.throws != rhs.throws { return false }
         if self.annotations != rhs.annotations { return false }
         if self.documentation != rhs.documentation { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
@@ -5572,6 +5590,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
                 }
                 fatalError()
              }; self.documentation = documentation
+            self.isAsync = aDecoder.decode(forKey: "isAsync")
+            self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.definedInTypeName = aDecoder.decode(forKey: "definedInTypeName")
             self.definedInType = aDecoder.decode(forKey: "definedInType")
             guard let attributes: AttributeList = aDecoder.decode(forKey: "attributes") else {
@@ -5607,6 +5627,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             aCoder.encode(self.returnType, forKey: "returnType")
             aCoder.encode(self.readAccess, forKey: "readAccess")
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
+            aCoder.encode(self.isAsync, forKey: "isAsync")
+            aCoder.encode(self.`throws`, forKey: "`throws`")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.definedInTypeName, forKey: "definedInTypeName")

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -4758,6 +4758,12 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     /// For immutable variables this value is empty string
     public var writeAccess: String
 
+    /// Whether subscript is async
+    public let isAsync: Bool
+
+    /// Whether subscript throws
+    public let `throws`: Bool
+
     /// Whether variable is mutable or not
     public var isMutable: Bool {
         return writeAccess != AccessLevel.none.rawValue
@@ -4808,6 +4814,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     public init(parameters: [MethodParameter] = [],
                 returnTypeName: TypeName,
                 accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
+                isAsync: Bool = false,
+                `throws`: Bool = false,
                 genericParameters: [GenericParameter] = [],
                 genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
@@ -4820,6 +4828,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         self.returnTypeName = returnTypeName
         self.readAccess = accessLevel.read.rawValue
         self.writeAccess = accessLevel.write.rawValue
+        self.isAsync = isAsync
+        self.throws = `throws`
         self.genericParameters = genericParameters
         self.genericRequirements = genericRequirements
         self.attributes = attributes
@@ -4838,6 +4848,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         string += "isFinal = \(String(describing: self.isFinal)), "
         string += "readAccess = \(String(describing: self.readAccess)), "
         string += "writeAccess = \(String(describing: self.writeAccess)), "
+        string += "isAsync = \(String(describing: self.isAsync)), "
+        string += "`throws` = \(String(describing: self.throws)), "
         string += "isMutable = \(String(describing: self.isMutable)), "
         string += "annotations = \(String(describing: self.annotations)), "
         string += "documentation = \(String(describing: self.documentation)), "
@@ -4861,6 +4873,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
+        results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
+        results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.throws, expected: castObject.throws))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "documentation").trackDifference(actual: self.documentation, expected: castObject.documentation))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
@@ -4877,6 +4891,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         hasher.combine(self.returnTypeName)
         hasher.combine(self.readAccess)
         hasher.combine(self.writeAccess)
+        hasher.combine(self.isAsync)
+        hasher.combine(self.throws)
         hasher.combine(self.annotations)
         hasher.combine(self.documentation)
         hasher.combine(self.definedInTypeName)
@@ -4894,6 +4910,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         if self.returnTypeName != rhs.returnTypeName { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
+        if self.isAsync != rhs.isAsync { return false }
+        if self.throws != rhs.throws { return false }
         if self.annotations != rhs.annotations { return false }
         if self.documentation != rhs.documentation { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
@@ -4945,6 +4963,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
                 }
                 fatalError()
              }; self.documentation = documentation
+            self.isAsync = aDecoder.decode(forKey: "isAsync")
+            self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.definedInTypeName = aDecoder.decode(forKey: "definedInTypeName")
             self.definedInType = aDecoder.decode(forKey: "definedInType")
             guard let attributes: AttributeList = aDecoder.decode(forKey: "attributes") else {
@@ -4980,6 +5000,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             aCoder.encode(self.returnType, forKey: "returnType")
             aCoder.encode(self.readAccess, forKey: "readAccess")
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
+            aCoder.encode(self.isAsync, forKey: "isAsync")
+            aCoder.encode(self.`throws`, forKey: "`throws`")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.definedInTypeName, forKey: "definedInTypeName")

--- a/SourceryTests/Parsing/FileParser_SubscriptsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_SubscriptsSpec.swift
@@ -117,6 +117,24 @@ class FileParserSubscriptsSpec: QuickSpec {
                     expect(subscripts?[2].genericRequirements.first?.relationshipSyntax).to(equal(":"))
                     expect(subscripts?[2].genericRequirements.first?.rightType.typeName.name).to(equal("Cancellable"))
                 }
+
+                it("extracts async and throws") {
+                    let subscripts = parse("""
+                                           protocol Subscript: AnyObject {
+                                             subscript(arg1: Int) -> Int? { get async }
+                                             subscript(arg2: Int) -> Int? { get throws }
+                                             subscript(arg3: Int) -> Int? { get async throws }
+                                           }
+                                           """).first?.subscripts
+
+                    expect(subscripts?[0].isAsync).to(beTrue())
+                    expect(subscripts?[1].isAsync).to(beFalse())
+                    expect(subscripts?[2].isAsync).to(beTrue())
+
+                    expect(subscripts?[0].throws).to(beFalse())
+                    expect(subscripts?[1].throws).to(beTrue())
+                    expect(subscripts?[2].throws).to(beTrue())
+                }
             }
         }
     }

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -122,9 +122,9 @@ import {{ import }}
 
 {% macro mockSubscript subscript index %}
     //MARK: - Subscript #{{ index }}
-    {% call accessLevel variable.readAccess %}subscript{% if subscript.isGeneric %}<{% for genericParameter in subscript.genericParameters %}{{ genericParameter.name }}{% if genericParameter.inheritedTypeName %}: {{ genericParameter.inheritedTypeName.name }}{% endif %}{{ ', ' if not forloop.last }}{% endfor %}>{% endif %}({% for parameter in subscript.parameters %}{{ parameter.asSource }}{{ ', ' if not forloop.last }}{% endfor %}) -> {{ subscript.returnTypeName.name }}{% if subscript.genericRequirements|count != 0 %} where {% for requirement in subscript.genericRequirements %}{{ requirement.leftType.name }} {{ requirement.relationshipSyntax }} {{ requirement.rightType.typeName.name }}{{ ', ' if not forloop.last }}{% endfor %}{% endif %} {
-    {% if subscript.readAccess %} get { fatalError("Subscripts are not fully supported yet") }{% endif %}
-    {% if subscript.writeAccess %} set { fatalError("Subscripts are not fully supported yet") }{% endif %}
+    {% call accessLevel subscript.readAccess %}subscript{% if subscript.isGeneric %}<{% for genericParameter in subscript.genericParameters %}{{ genericParameter.name }}{% if genericParameter.inheritedTypeName %}: {{ genericParameter.inheritedTypeName.name }}{% endif %}{{ ', ' if not forloop.last }}{% endfor %}>{% endif %}({% for parameter in subscript.parameters %}{{ parameter.asSource }}{{ ', ' if not forloop.last }}{% endfor %}) -> {{ subscript.returnTypeName.name }}{% if subscript.genericRequirements|count != 0 %} where {% for requirement in subscript.genericRequirements %}{{ requirement.leftType.name }} {{ requirement.relationshipSyntax }} {{ requirement.rightType.typeName.name }}{{ ', ' if not forloop.last }}{% endfor %}{% endif %} {
+        {% if subscript.readAccess %}get{% if subscript.isAsync %} async{% endif %}{% if subscript.throws %} throws{% endif %} { fatalError("Subscripts are not fully supported yet") }{% endif %}
+        {% if subscript.writeAccess %}set { fatalError("Subscripts are not fully supported yet") }{% endif %}
     }
 {% endmacro %}
 

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -231,6 +231,7 @@ public protocol ProtocolWithOverrides {
 protocol SubscriptProtocol {
     subscript(arg: Int) -> String { get set }
     subscript<T>(arg: T) -> Int { get }
+    subscript<T>(arg: T) -> String { get async }
     subscript<T: Hashable>(arg: T) -> T? { get set }
-    subscript<T>(arg: String) -> T? where T: Cancellable { get }
+    subscript<T>(arg: String) -> T? where T: Cancellable { get throws }
 }

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -231,6 +231,7 @@ public protocol ProtocolWithOverrides {
 protocol SubscriptProtocol {
     subscript(arg: Int) -> String { get set }
     subscript<T>(arg: T) -> Int { get }
+    subscript<T>(arg: T) -> String { get async }
     subscript<T: Hashable>(arg: T) -> T? { get set }
-    subscript<T>(arg: String) -> T? where T: Cancellable { get }
+    subscript<T>(arg: String) -> T? where T: Cancellable { get throws }
 }

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1393,22 +1393,26 @@ class StaticMethodProtocolMock: StaticMethodProtocol {
 }
 class SubscriptProtocolMock: SubscriptProtocol {
     //MARK: - Subscript #1
-     subscript(arg: Int) -> String {
-     get { fatalError("Subscripts are not fully supported yet") }
-     set { fatalError("Subscripts are not fully supported yet") }
+    subscript(arg: Int) -> String {
+        get { fatalError("Subscripts are not fully supported yet") }
+        set { fatalError("Subscripts are not fully supported yet") }
     }
     //MARK: - Subscript #2
-     subscript<T>(arg: T) -> Int {
-     get { fatalError("Subscripts are not fully supported yet") }
+    subscript<T>(arg: T) -> Int {
+        get { fatalError("Subscripts are not fully supported yet") }
     }
     //MARK: - Subscript #3
-     subscript<T: Hashable>(arg: T) -> T? {
-     get { fatalError("Subscripts are not fully supported yet") }
-     set { fatalError("Subscripts are not fully supported yet") }
+    subscript<T>(arg: T) -> String {
+        get async { fatalError("Subscripts are not fully supported yet") }
     }
     //MARK: - Subscript #4
-     subscript<T>(arg: String) -> T? where T : Cancellable {
-     get { fatalError("Subscripts are not fully supported yet") }
+    subscript<T: Hashable>(arg: T) -> T? {
+        get { fatalError("Subscripts are not fully supported yet") }
+        set { fatalError("Subscripts are not fully supported yet") }
+    }
+    //MARK: - Subscript #5
+    subscript<T>(arg: String) -> T? where T : Cancellable {
+        get throws { fatalError("Subscripts are not fully supported yet") }
     }
 }
 class ThrowableProtocolMock: ThrowableProtocol {


### PR DESCRIPTION
Added two more fields to Subscript to handle cases when subscript is async or throws. For example,

```
protocol Subscript: AnyObject {
    subscript(arg1: Int) -> Int? { get async }
    subscript(arg2: Int) -> Int? { get throws }
    subscript(arg3: Int) -> Int? { get async throws }
}
```

This now produces:

```
Subscript: ... isAsync = true, `throws` = false ...
Subscript: ... isAsync = false, `throws` = true ...
Subscript: ... isAsync = true, `throws` = true ...
```