### PR TITLE
Initialise Subscript's returnTypeName with TypeSyntax, not String

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
@@ -64,7 +64,7 @@ extension Subscript {
 
         self.init(
           parameters: node.indices.parameterList.map { MethodParameter($0, annotationsParser: annotationsParser) },
-          returnTypeName: TypeName(node.result.returnType.description.trimmed),
+          returnTypeName: TypeName(node.result.returnType),
           accessLevel: (read: readAccess, write: isWritable ? writeAccess : .none),
           genericParameters: genericParameters,
           genericRequirements: genericRequirements,

--- a/SourceryTests/Parsing/FileParser_SubscriptsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_SubscriptsSpec.swift
@@ -117,6 +117,21 @@ class FileParserSubscriptsSpec: QuickSpec {
                     expect(subscripts?[2].genericRequirements.first?.relationshipSyntax).to(equal(":"))
                     expect(subscripts?[2].genericRequirements.first?.rightType.typeName.name).to(equal("Cancellable"))
                 }
+
+                it("extracts optional return type") {
+                    let subscripts = parse("""
+                                           protocol Subscript: AnyObject {
+                                             subscript(arg1: Int) -> Int? { get set }
+                                             subscript(arg2: Int) -> Int! { get }
+                                           }
+                                           """).first?.subscripts
+
+                    expect(subscripts?[0].returnTypeName.name).to(equal("Int?"))
+                    expect(subscripts?[0].returnTypeName.unwrappedTypeName).to(equal("Int"))
+
+                    expect(subscripts?[1].returnTypeName.name).to(equal("Int!"))
+                    expect(subscripts?[1].returnTypeName.unwrappedTypeName).to(equal("Int"))
+                }
             }
         }
     }


### PR DESCRIPTION
The current implementation doesn't handle optional return types in subscripts well.

For example:

```
protocol Subscript: AnyObject {
    subscript(arg1: Int) -> Int? { get set }
    subscript(arg2: Int) -> Int! { get }
}
```

In this case `subscript.returnTypeName.unwrappedTypeName` will be the same as `subscript.returnTypeName.name`. This should be fixed now.