### PR TITLE
Update AutoMockable.expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Sourcery CHANGELOG
+## 2.1.4
+## Changes
+- Added generic requirements and generic parameters to Subscript ([#1242](https://github.com/krzysztofzablocki/Sourcery/issues/1242))
+- Added isAsync and throws to Subscript ([#1249](https://github.com/krzysztofzablocki/Sourcery/issues/1249))
+- Initialise Subscript's returnTypeName with TypeSyntax, not String ([#1250](https://github.com/krzysztofzablocki/Sourcery/issues/1250))
+- Swifty generated variable names + fixed generated mocks compilation issues due to method generic parameters ([#1252](https://github.com/krzysztofzablocki/Sourcery/issues/1252))
+
 ## 2.1.3
 ## Changes
 - Add support for `typealias`es in EJS templates. ([#1208](https://github.com/krzysztofzablocki/Sourcery/pull/1208))

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -235,3 +235,8 @@ protocol SubscriptProtocol {
     subscript<T: Hashable>(arg: T) -> T? { get set }
     subscript<T>(arg: String) -> T? where T: Cancellable { get throws }
 }
+
+// sourcery: AutoMockable
+public protocol ProtocolWithMethodWithGenericParameters {
+    func execute(param: Result<Int, Error>) -> Result<String, Error>
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -10,6 +10,29 @@ import UIKit
 import AppKit
 #endif
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 public class AccessLevelProtocolMock: AccessLevelProtocol {
 
     public init() {}
@@ -40,6 +63,7 @@ public class AccessLevelProtocolMock: AccessLevelProtocol {
         }
     }
 
+
 }
 class AnnotatedProtocolMock: AnnotatedProtocol {
 
@@ -62,6 +86,7 @@ class AnnotatedProtocolMock: AnnotatedProtocol {
         sayHelloWithNameStringVoidReceivedInvocations.append(name)
         sayHelloWithNameStringVoidClosure?(name)
     }
+
 
 }
 class AnyProtocolMock: AnyProtocol {
@@ -395,6 +420,7 @@ class AnyProtocolMock: AnyProtocol {
         }
     }
 
+
 }
 class AsyncProtocolMock: AsyncProtocol {
 
@@ -488,6 +514,7 @@ class AsyncProtocolMock: AsyncProtocol {
         try await callAsyncAndThrowVoidParameterIntVoidClosure?(parameter)
     }
 
+
 }
 class AsyncThrowingVariablesProtocolMock: AsyncThrowingVariablesProtocol {
 
@@ -536,6 +563,7 @@ class AsyncThrowingVariablesProtocolMock: AsyncThrowingVariablesProtocol {
     var firstNameClosure: (() async throws -> String)?
 
 
+
 }
 class AsyncVariablesProtocolMock: AsyncVariablesProtocol {
 
@@ -574,6 +602,7 @@ class AsyncVariablesProtocolMock: AsyncVariablesProtocol {
     }
     var underlyingFirstName: String!
     var firstNameClosure: (() async -> String)?
+
 
 
 }
@@ -617,6 +646,7 @@ class BasicProtocolMock: BasicProtocol {
         saveConfigurationStringVoidClosure?(configuration)
     }
 
+
 }
 class ClosureProtocolMock: ClosureProtocol {
 
@@ -640,6 +670,7 @@ class ClosureProtocolMock: ClosureProtocol {
         setClosureClosureEscapingVoidVoidClosure?(closure)
     }
 
+
 }
 class CurrencyPresenterMock: CurrencyPresenter {
 
@@ -662,6 +693,7 @@ class CurrencyPresenterMock: CurrencyPresenter {
         showSourceCurrencyCurrencyStringVoidReceivedInvocations.append(currency)
         showSourceCurrencyCurrencyStringVoidClosure?(currency)
     }
+
 
 }
 class ExampleVarargMock: ExampleVararg {
@@ -691,6 +723,7 @@ class ExampleVarargMock: ExampleVararg {
         }
     }
 
+
 }
 class ExtendableProtocolMock: ExtendableProtocol {
 
@@ -718,6 +751,7 @@ class ExtendableProtocolMock: ExtendableProtocol {
         reportMessageStringVoidReceivedInvocations.append(message)
         reportMessageStringVoidClosure?(message)
     }
+
 
 }
 class FunctionWithAttributesMock: FunctionWithAttributes {
@@ -785,6 +819,7 @@ class FunctionWithAttributesMock: FunctionWithAttributes {
         }
     }
 
+
 }
 class FunctionWithClosureReturnTypeMock: FunctionWithClosureReturnType {
 
@@ -827,6 +862,7 @@ class FunctionWithClosureReturnTypeMock: FunctionWithClosureReturnType {
         }
     }
 
+
 }
 class FunctionWithMultilineDeclarationMock: FunctionWithMultilineDeclaration {
 
@@ -850,6 +886,7 @@ class FunctionWithMultilineDeclarationMock: FunctionWithMultilineDeclaration {
         startCarStringOfModelStringVoidClosure?(car, model)
     }
 
+
 }
 class HouseProtocolMock: HouseProtocol {
 
@@ -866,6 +903,7 @@ class HouseProtocolMock: HouseProtocol {
     var f2Publisher: GenericType<Never, any PersonProtocol, Never>?
     var f3Publisher: GenericType<Never, Never, any PersonProtocol>?
     var f4Publisher: GenericType<any PersonProtocol, any PersonProtocol, any PersonProtocol>?
+
 
 
 }
@@ -891,6 +929,7 @@ class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOpt
             return implicitReturnStringReturnValue
         }
     }
+
 
 }
 class InitializationProtocolMock: InitializationProtocol {
@@ -935,6 +974,7 @@ class InitializationProtocolMock: InitializationProtocol {
         stopVoidClosure?()
     }
 
+
 }
 class MultiClosureProtocolMock: MultiClosureProtocol {
 
@@ -958,6 +998,7 @@ class MultiClosureProtocolMock: MultiClosureProtocol {
         setClosureNameStringClosureEscapingVoidVoidClosure?(name, closure)
     }
 
+
 }
 class MultiNonEscapingClosureProtocolMock: MultiNonEscapingClosureProtocol {
 
@@ -976,6 +1017,7 @@ class MultiNonEscapingClosureProtocolMock: MultiNonEscapingClosureProtocol {
         executeClosureNameStringClosureVoidVoidCallsCount += 1
         executeClosureNameStringClosureVoidVoidClosure?(name, closure)
     }
+
 
 }
 class NonEscapingClosureProtocolMock: NonEscapingClosureProtocol {
@@ -1025,6 +1067,7 @@ public class ProtocolWithMethodWithGenericParametersMock: ProtocolWithMethodWith
             return executeParamResultIntErrorResultStringErrorReturnValue
         }
     }
+
 
 }
 public class ProtocolWithOverridesMock: ProtocolWithOverrides {
@@ -1195,6 +1238,7 @@ public class ProtocolWithOverridesMock: ProtocolWithOverrides {
         }
     }
 
+
 }
 class ReservedWordsProtocolMock: ReservedWordsProtocol {
 
@@ -1222,6 +1266,7 @@ class ReservedWordsProtocolMock: ReservedWordsProtocol {
             return continueWithMessageStringStringReturnValue
         }
     }
+
 
 }
 class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
@@ -1263,6 +1308,7 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
         startPlaneStringOfModelStringVoidClosure?(plane, model)
     }
 
+
 }
 class SingleOptionalParameterFunctionMock: SingleOptionalParameterFunction {
 
@@ -1285,6 +1331,7 @@ class SingleOptionalParameterFunctionMock: SingleOptionalParameterFunction {
         sendMessageStringVoidReceivedInvocations.append(message)
         sendMessageStringVoidClosure?(message)
     }
+
 
 }
 class SomeProtocolMock: SomeProtocol {
@@ -1382,6 +1429,7 @@ class SomeProtocolMock: SomeProtocol {
         dXSomeStubWithSomeNameProtocolVoidClosure?(x)
     }
 
+
 }
 class StaticMethodProtocolMock: StaticMethodProtocol {
 
@@ -1420,8 +1468,14 @@ class StaticMethodProtocolMock: StaticMethodProtocol {
         }
     }
 
+
 }
 class SubscriptProtocolMock: SubscriptProtocol {
+
+
+
+
+
     //MARK: - Subscript #1
     subscript(arg: Int) -> String {
         get { fatalError("Subscripts are not fully supported yet") }
@@ -1489,6 +1543,7 @@ class ThrowableProtocolMock: ThrowableProtocol {
         try doOrThrowVoidVoidClosure?()
     }
 
+
 }
 class ThrowingVariablesProtocolMock: ThrowingVariablesProtocol {
 
@@ -1537,6 +1592,7 @@ class ThrowingVariablesProtocolMock: ThrowingVariablesProtocol {
     var firstNameClosure: (() throws -> String)?
 
 
+
 }
 class VariablesProtocolMock: VariablesProtocol {
 
@@ -1554,7 +1610,6 @@ class VariablesProtocolMock: VariablesProtocol {
     var underlyingAge: (Int)!
     var kids: [String] = []
     var universityMarks: [String: Int] = [:]
-
 
 
 

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -24,19 +24,19 @@ public class AccessLevelProtocolMock: AccessLevelProtocol {
 
     //MARK: - loadConfiguration
 
-    public var LoadConfigurationStringCallsCount = 0
-    public var LoadConfigurationStringCalled: Bool {
-        return LoadConfigurationStringCallsCount > 0
+    public var loadConfigurationStringCallsCount = 0
+    public var loadConfigurationStringCalled: Bool {
+        return loadConfigurationStringCallsCount > 0
     }
-    public var LoadConfigurationStringReturnValue: String?
-    public var LoadConfigurationStringClosure: (() -> String?)?
+    public var loadConfigurationStringReturnValue: String?
+    public var loadConfigurationStringClosure: (() -> String?)?
 
     public func loadConfiguration() -> String? {
-        LoadConfigurationStringCallsCount += 1
-        if let LoadConfigurationStringClosure = LoadConfigurationStringClosure {
-            return LoadConfigurationStringClosure()
+        loadConfigurationStringCallsCount += 1
+        if let loadConfigurationStringClosure = loadConfigurationStringClosure {
+            return loadConfigurationStringClosure()
         } else {
-            return LoadConfigurationStringReturnValue
+            return loadConfigurationStringReturnValue
         }
     }
 
@@ -48,19 +48,19 @@ class AnnotatedProtocolMock: AnnotatedProtocol {
 
     //MARK: - sayHelloWith
 
-    var SayHelloWithNameStringVoidCallsCount = 0
-    var SayHelloWithNameStringVoidCalled: Bool {
-        return SayHelloWithNameStringVoidCallsCount > 0
+    var sayHelloWithNameStringVoidCallsCount = 0
+    var sayHelloWithNameStringVoidCalled: Bool {
+        return sayHelloWithNameStringVoidCallsCount > 0
     }
-    var SayHelloWithNameStringVoidReceivedName: (String)?
-    var SayHelloWithNameStringVoidReceivedInvocations: [(String)] = []
-    var SayHelloWithNameStringVoidClosure: ((String) -> Void)?
+    var sayHelloWithNameStringVoidReceivedName: (String)?
+    var sayHelloWithNameStringVoidReceivedInvocations: [(String)] = []
+    var sayHelloWithNameStringVoidClosure: ((String) -> Void)?
 
     func sayHelloWith(name: String) {
-        SayHelloWithNameStringVoidCallsCount += 1
-        SayHelloWithNameStringVoidReceivedName = name
-        SayHelloWithNameStringVoidReceivedInvocations.append(name)
-        SayHelloWithNameStringVoidClosure?(name)
+        sayHelloWithNameStringVoidCallsCount += 1
+        sayHelloWithNameStringVoidReceivedName = name
+        sayHelloWithNameStringVoidReceivedInvocations.append(name)
+        sayHelloWithNameStringVoidClosure?(name)
     }
 
 }
@@ -101,297 +101,297 @@ class AnyProtocolMock: AnyProtocol {
 
     //MARK: - f
 
-    var FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidCallsCount = 0
-    var FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidCalled: Bool {
-        return FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidCallsCount > 0
+    var fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidCallsCount = 0
+    var fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidCalled: Bool {
+        return fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidCallsCount > 0
     }
-    var FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidReceivedArguments: (x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)?
-    var FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidReceivedInvocations: [(x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)] = []
-    var FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidClosure: (((any StubProtocol)?, (any StubProtocol)?, any StubProtocol) -> Void)?
+    var fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidReceivedArguments: (x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)?
+    var fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidReceivedInvocations: [(x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)] = []
+    var fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidClosure: (((any StubProtocol)?, (any StubProtocol)?, any StubProtocol) -> Void)?
 
     func f(_ x: (any StubProtocol)?, y: (any StubProtocol)!, z: any StubProtocol) {
-        FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidCallsCount += 1
-        FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidReceivedArguments = (x: x, y: y, z: z)
-        FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidReceivedInvocations.append((x: x, y: y, z: z))
-        FXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidClosure?(x, y, z)
+        fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidCallsCount += 1
+        fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidReceivedArguments = (x: x, y: y, z: z)
+        fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidReceivedInvocations.append((x: x, y: y, z: z))
+        fXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolVoidClosure?(x, y, z)
     }
 
     //MARK: - j
 
-    var JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringCallsCount = 0
-    var JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringCalled: Bool {
-        return JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringCallsCount > 0
+    var jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringCallsCount = 0
+    var jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringCalled: Bool {
+        return jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringCallsCount > 0
     }
-    var JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReceivedArguments: (x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)?
-    var JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReceivedInvocations: [(x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)] = []
-    var JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReturnValue: String!
-    var JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringClosure: (((any StubProtocol)?, (any StubProtocol)?, any StubProtocol) async -> String)?
+    var jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReceivedArguments: (x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)?
+    var jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReceivedInvocations: [(x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)] = []
+    var jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReturnValue: String!
+    var jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringClosure: (((any StubProtocol)?, (any StubProtocol)?, any StubProtocol) async -> String)?
 
     func j(x: (any StubProtocol)?, y: (any StubProtocol)!, z: any StubProtocol) async -> String {
-        JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringCallsCount += 1
-        JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReceivedArguments = (x: x, y: y, z: z)
-        JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReceivedInvocations.append((x: x, y: y, z: z))
-        if let JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringClosure = JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringClosure {
-            return await JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringClosure(x, y, z)
+        jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringCallsCount += 1
+        jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReceivedArguments = (x: x, y: y, z: z)
+        jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReceivedInvocations.append((x: x, y: y, z: z))
+        if let jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringClosure = jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringClosure {
+            return await jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringClosure(x, y, z)
         } else {
-            return JXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReturnValue
+            return jXAnyStubProtocolYAnyStubProtocolZAnyStubProtocolStringReturnValue
         }
     }
 
     //MARK: - k
 
-    var KXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount = 0
-    var KXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCalled: Bool {
-        return KXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount > 0
+    var kXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount = 0
+    var kXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCalled: Bool {
+        return kXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount > 0
     }
-    var KXAnyStubProtocolVoidYAnyStubProtocolVoidVoidClosure: ((((any StubProtocol)?) -> Void, (any StubProtocol) -> Void) -> Void)?
+    var kXAnyStubProtocolVoidYAnyStubProtocolVoidVoidClosure: ((((any StubProtocol)?) -> Void, (any StubProtocol) -> Void) -> Void)?
 
     func k(x: ((any StubProtocol)?) -> Void, y: (any StubProtocol) -> Void) {
-        KXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount += 1
-        KXAnyStubProtocolVoidYAnyStubProtocolVoidVoidClosure?(x, y)
+        kXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount += 1
+        kXAnyStubProtocolVoidYAnyStubProtocolVoidVoidClosure?(x, y)
     }
 
     //MARK: - l
 
-    var LXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount = 0
-    var LXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCalled: Bool {
-        return LXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount > 0
+    var lXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount = 0
+    var lXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCalled: Bool {
+        return lXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount > 0
     }
-    var LXAnyStubProtocolVoidYAnyStubProtocolVoidVoidClosure: ((((any StubProtocol)?) -> Void, (any StubProtocol) -> Void) -> Void)?
+    var lXAnyStubProtocolVoidYAnyStubProtocolVoidVoidClosure: ((((any StubProtocol)?) -> Void, (any StubProtocol) -> Void) -> Void)?
 
     func l(x: ((any StubProtocol)?) -> Void, y: (any StubProtocol) -> Void) {
-        LXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount += 1
-        LXAnyStubProtocolVoidYAnyStubProtocolVoidVoidClosure?(x, y)
+        lXAnyStubProtocolVoidYAnyStubProtocolVoidVoidCallsCount += 1
+        lXAnyStubProtocolVoidYAnyStubProtocolVoidVoidClosure?(x, y)
     }
 
     //MARK: - m
 
-    var MAnyConfusingArgumentNameAnyStubProtocolVoidCallsCount = 0
-    var MAnyConfusingArgumentNameAnyStubProtocolVoidCalled: Bool {
-        return MAnyConfusingArgumentNameAnyStubProtocolVoidCallsCount > 0
+    var mAnyConfusingArgumentNameAnyStubProtocolVoidCallsCount = 0
+    var mAnyConfusingArgumentNameAnyStubProtocolVoidCalled: Bool {
+        return mAnyConfusingArgumentNameAnyStubProtocolVoidCallsCount > 0
     }
-    var MAnyConfusingArgumentNameAnyStubProtocolVoidReceivedAnyConfusingArgumentName: (any StubProtocol)?
-    var MAnyConfusingArgumentNameAnyStubProtocolVoidReceivedInvocations: [(any StubProtocol)] = []
-    var MAnyConfusingArgumentNameAnyStubProtocolVoidClosure: ((any StubProtocol) -> Void)?
+    var mAnyConfusingArgumentNameAnyStubProtocolVoidReceivedAnyConfusingArgumentName: (any StubProtocol)?
+    var mAnyConfusingArgumentNameAnyStubProtocolVoidReceivedInvocations: [(any StubProtocol)] = []
+    var mAnyConfusingArgumentNameAnyStubProtocolVoidClosure: ((any StubProtocol) -> Void)?
 
     func m(anyConfusingArgumentName: any StubProtocol) {
-        MAnyConfusingArgumentNameAnyStubProtocolVoidCallsCount += 1
-        MAnyConfusingArgumentNameAnyStubProtocolVoidReceivedAnyConfusingArgumentName = anyConfusingArgumentName
-        MAnyConfusingArgumentNameAnyStubProtocolVoidReceivedInvocations.append(anyConfusingArgumentName)
-        MAnyConfusingArgumentNameAnyStubProtocolVoidClosure?(anyConfusingArgumentName)
+        mAnyConfusingArgumentNameAnyStubProtocolVoidCallsCount += 1
+        mAnyConfusingArgumentNameAnyStubProtocolVoidReceivedAnyConfusingArgumentName = anyConfusingArgumentName
+        mAnyConfusingArgumentNameAnyStubProtocolVoidReceivedInvocations.append(anyConfusingArgumentName)
+        mAnyConfusingArgumentNameAnyStubProtocolVoidClosure?(anyConfusingArgumentName)
     }
 
     //MARK: - n
 
-    var NXEscapingAnyStubProtocolVoidVoidCallsCount = 0
-    var NXEscapingAnyStubProtocolVoidVoidCalled: Bool {
-        return NXEscapingAnyStubProtocolVoidVoidCallsCount > 0
+    var nXEscapingAnyStubProtocolVoidVoidCallsCount = 0
+    var nXEscapingAnyStubProtocolVoidVoidCalled: Bool {
+        return nXEscapingAnyStubProtocolVoidVoidCallsCount > 0
     }
-    var NXEscapingAnyStubProtocolVoidVoidReceivedX: ((((any StubProtocol)?) -> Void))?
-    var NXEscapingAnyStubProtocolVoidVoidReceivedInvocations: [((((any StubProtocol)?) -> Void))] = []
-    var NXEscapingAnyStubProtocolVoidVoidClosure: ((@escaping ((any StubProtocol)?) -> Void) -> Void)?
+    var nXEscapingAnyStubProtocolVoidVoidReceivedX: ((((any StubProtocol)?) -> Void))?
+    var nXEscapingAnyStubProtocolVoidVoidReceivedInvocations: [((((any StubProtocol)?) -> Void))] = []
+    var nXEscapingAnyStubProtocolVoidVoidClosure: ((@escaping ((any StubProtocol)?) -> Void) -> Void)?
 
     func n(x: @escaping ((any StubProtocol)?) -> Void) {
-        NXEscapingAnyStubProtocolVoidVoidCallsCount += 1
-        NXEscapingAnyStubProtocolVoidVoidReceivedX = x
-        NXEscapingAnyStubProtocolVoidVoidReceivedInvocations.append(x)
-        NXEscapingAnyStubProtocolVoidVoidClosure?(x)
+        nXEscapingAnyStubProtocolVoidVoidCallsCount += 1
+        nXEscapingAnyStubProtocolVoidVoidReceivedX = x
+        nXEscapingAnyStubProtocolVoidVoidReceivedInvocations.append(x)
+        nXEscapingAnyStubProtocolVoidVoidClosure?(x)
     }
 
     //MARK: - p
 
-    var PXAnyStubWithAnyNameProtocolVoidCallsCount = 0
-    var PXAnyStubWithAnyNameProtocolVoidCalled: Bool {
-        return PXAnyStubWithAnyNameProtocolVoidCallsCount > 0
+    var pXAnyStubWithAnyNameProtocolVoidCallsCount = 0
+    var pXAnyStubWithAnyNameProtocolVoidCalled: Bool {
+        return pXAnyStubWithAnyNameProtocolVoidCallsCount > 0
     }
-    var PXAnyStubWithAnyNameProtocolVoidReceivedX: (any StubWithAnyNameProtocol)?
-    var PXAnyStubWithAnyNameProtocolVoidReceivedInvocations: [(any StubWithAnyNameProtocol)?] = []
-    var PXAnyStubWithAnyNameProtocolVoidClosure: (((any StubWithAnyNameProtocol)?) -> Void)?
+    var pXAnyStubWithAnyNameProtocolVoidReceivedX: (any StubWithAnyNameProtocol)?
+    var pXAnyStubWithAnyNameProtocolVoidReceivedInvocations: [(any StubWithAnyNameProtocol)?] = []
+    var pXAnyStubWithAnyNameProtocolVoidClosure: (((any StubWithAnyNameProtocol)?) -> Void)?
 
     func p(_ x: (any StubWithAnyNameProtocol)?) {
-        PXAnyStubWithAnyNameProtocolVoidCallsCount += 1
-        PXAnyStubWithAnyNameProtocolVoidReceivedX = x
-        PXAnyStubWithAnyNameProtocolVoidReceivedInvocations.append(x)
-        PXAnyStubWithAnyNameProtocolVoidClosure?(x)
+        pXAnyStubWithAnyNameProtocolVoidCallsCount += 1
+        pXAnyStubWithAnyNameProtocolVoidReceivedX = x
+        pXAnyStubWithAnyNameProtocolVoidReceivedInvocations.append(x)
+        pXAnyStubWithAnyNameProtocolVoidClosure?(x)
     }
 
     //MARK: - q
 
-    var QAnyStubProtocolCallsCount = 0
-    var QAnyStubProtocolCalled: Bool {
-        return QAnyStubProtocolCallsCount > 0
+    var qAnyStubProtocolCallsCount = 0
+    var qAnyStubProtocolCalled: Bool {
+        return qAnyStubProtocolCallsCount > 0
     }
-    var QAnyStubProtocolReturnValue: (any StubProtocol)!
-    var QAnyStubProtocolClosure: (() -> any StubProtocol)?
+    var qAnyStubProtocolReturnValue: (any StubProtocol)!
+    var qAnyStubProtocolClosure: (() -> any StubProtocol)?
 
     func q() -> any StubProtocol {
-        QAnyStubProtocolCallsCount += 1
-        if let QAnyStubProtocolClosure = QAnyStubProtocolClosure {
-            return QAnyStubProtocolClosure()
+        qAnyStubProtocolCallsCount += 1
+        if let qAnyStubProtocolClosure = qAnyStubProtocolClosure {
+            return qAnyStubProtocolClosure()
         } else {
-            return QAnyStubProtocolReturnValue
+            return qAnyStubProtocolReturnValue
         }
     }
 
     //MARK: - r
 
-    var RAnyStubProtocolCallsCount = 0
-    var RAnyStubProtocolCalled: Bool {
-        return RAnyStubProtocolCallsCount > 0
+    var rAnyStubProtocolCallsCount = 0
+    var rAnyStubProtocolCalled: Bool {
+        return rAnyStubProtocolCallsCount > 0
     }
-    var RAnyStubProtocolReturnValue: ((any StubProtocol)?)
-    var RAnyStubProtocolClosure: (() -> (any StubProtocol)?)?
+    var rAnyStubProtocolReturnValue: ((any StubProtocol)?)
+    var rAnyStubProtocolClosure: (() -> (any StubProtocol)?)?
 
     func r() -> (any StubProtocol)? {
-        RAnyStubProtocolCallsCount += 1
-        if let RAnyStubProtocolClosure = RAnyStubProtocolClosure {
-            return RAnyStubProtocolClosure()
+        rAnyStubProtocolCallsCount += 1
+        if let rAnyStubProtocolClosure = rAnyStubProtocolClosure {
+            return rAnyStubProtocolClosure()
         } else {
-            return RAnyStubProtocolReturnValue
+            return rAnyStubProtocolReturnValue
         }
     }
 
     //MARK: - s
 
-    var S____AnyStubProtocolCallsCount = 0
-    var S____AnyStubProtocolCalled: Bool {
-        return S____AnyStubProtocolCallsCount > 0
+    var s____AnyStubProtocolCallsCount = 0
+    var s____AnyStubProtocolCalled: Bool {
+        return s____AnyStubProtocolCallsCount > 0
     }
-    var S____AnyStubProtocolReturnValue: ((() -> any StubProtocol))!
-    var S____AnyStubProtocolClosure: (() -> (() -> any StubProtocol))?
+    var s____AnyStubProtocolReturnValue: ((() -> any StubProtocol))!
+    var s____AnyStubProtocolClosure: (() -> (() -> any StubProtocol))?
 
     func s() -> (() -> any StubProtocol) {
-        S____AnyStubProtocolCallsCount += 1
-        if let S____AnyStubProtocolClosure = S____AnyStubProtocolClosure {
-            return S____AnyStubProtocolClosure()
+        s____AnyStubProtocolCallsCount += 1
+        if let s____AnyStubProtocolClosure = s____AnyStubProtocolClosure {
+            return s____AnyStubProtocolClosure()
         } else {
-            return S____AnyStubProtocolReturnValue
+            return s____AnyStubProtocolReturnValue
         }
     }
 
     //MARK: - t
 
-    var T____AnyStubProtocolCallsCount = 0
-    var T____AnyStubProtocolCalled: Bool {
-        return T____AnyStubProtocolCallsCount > 0
+    var t____AnyStubProtocolCallsCount = 0
+    var t____AnyStubProtocolCalled: Bool {
+        return t____AnyStubProtocolCallsCount > 0
     }
-    var T____AnyStubProtocolReturnValue: ((() -> (any StubProtocol)?))!
-    var T____AnyStubProtocolClosure: (() -> (() -> (any StubProtocol)?))?
+    var t____AnyStubProtocolReturnValue: ((() -> (any StubProtocol)?))!
+    var t____AnyStubProtocolClosure: (() -> (() -> (any StubProtocol)?))?
 
     func t() -> (() -> (any StubProtocol)?) {
-        T____AnyStubProtocolCallsCount += 1
-        if let T____AnyStubProtocolClosure = T____AnyStubProtocolClosure {
-            return T____AnyStubProtocolClosure()
+        t____AnyStubProtocolCallsCount += 1
+        if let t____AnyStubProtocolClosure = t____AnyStubProtocolClosure {
+            return t____AnyStubProtocolClosure()
         } else {
-            return T____AnyStubProtocolReturnValue
+            return t____AnyStubProtocolReturnValue
         }
     }
 
     //MARK: - u
 
-    var U_IntAnyStubProtocolCallsCount = 0
-    var U_IntAnyStubProtocolCalled: Bool {
-        return U_IntAnyStubProtocolCallsCount > 0
+    var u_IntAnyStubProtocolCallsCount = 0
+    var u_IntAnyStubProtocolCalled: Bool {
+        return u_IntAnyStubProtocolCallsCount > 0
     }
-    var U_IntAnyStubProtocolReturnValue: ((Int, () -> (any StubProtocol)?))!
-    var U_IntAnyStubProtocolClosure: (() -> (Int, () -> (any StubProtocol)?))?
+    var u_IntAnyStubProtocolReturnValue: ((Int, () -> (any StubProtocol)?))!
+    var u_IntAnyStubProtocolClosure: (() -> (Int, () -> (any StubProtocol)?))?
 
     func u() -> (Int, () -> (any StubProtocol)?) {
-        U_IntAnyStubProtocolCallsCount += 1
-        if let U_IntAnyStubProtocolClosure = U_IntAnyStubProtocolClosure {
-            return U_IntAnyStubProtocolClosure()
+        u_IntAnyStubProtocolCallsCount += 1
+        if let u_IntAnyStubProtocolClosure = u_IntAnyStubProtocolClosure {
+            return u_IntAnyStubProtocolClosure()
         } else {
-            return U_IntAnyStubProtocolReturnValue
+            return u_IntAnyStubProtocolReturnValue
         }
     }
 
     //MARK: - v
 
-    var V_IntAnyStubProtocolCallsCount = 0
-    var V_IntAnyStubProtocolCalled: Bool {
-        return V_IntAnyStubProtocolCallsCount > 0
+    var v_IntAnyStubProtocolCallsCount = 0
+    var v_IntAnyStubProtocolCalled: Bool {
+        return v_IntAnyStubProtocolCallsCount > 0
     }
-    var V_IntAnyStubProtocolReturnValue: ((Int, (() -> any StubProtocol)?))!
-    var V_IntAnyStubProtocolClosure: (() -> (Int, (() -> any StubProtocol)?))?
+    var v_IntAnyStubProtocolReturnValue: ((Int, (() -> any StubProtocol)?))!
+    var v_IntAnyStubProtocolClosure: (() -> (Int, (() -> any StubProtocol)?))?
 
     func v() -> (Int, (() -> any StubProtocol)?) {
-        V_IntAnyStubProtocolCallsCount += 1
-        if let V_IntAnyStubProtocolClosure = V_IntAnyStubProtocolClosure {
-            return V_IntAnyStubProtocolClosure()
+        v_IntAnyStubProtocolCallsCount += 1
+        if let v_IntAnyStubProtocolClosure = v_IntAnyStubProtocolClosure {
+            return v_IntAnyStubProtocolClosure()
         } else {
-            return V_IntAnyStubProtocolReturnValue
+            return v_IntAnyStubProtocolReturnValue
         }
     }
 
     //MARK: - w
 
-    var W_AnyStubProtocolCallsCount = 0
-    var W_AnyStubProtocolCalled: Bool {
-        return W_AnyStubProtocolCallsCount > 0
+    var w_AnyStubProtocolCallsCount = 0
+    var w_AnyStubProtocolCalled: Bool {
+        return w_AnyStubProtocolCallsCount > 0
     }
-    var W_AnyStubProtocolReturnValue: ([(any StubProtocol)?])!
-    var W_AnyStubProtocolClosure: (() -> [(any StubProtocol)?])?
+    var w_AnyStubProtocolReturnValue: ([(any StubProtocol)?])!
+    var w_AnyStubProtocolClosure: (() -> [(any StubProtocol)?])?
 
     func w() -> [(any StubProtocol)?] {
-        W_AnyStubProtocolCallsCount += 1
-        if let W_AnyStubProtocolClosure = W_AnyStubProtocolClosure {
-            return W_AnyStubProtocolClosure()
+        w_AnyStubProtocolCallsCount += 1
+        if let w_AnyStubProtocolClosure = w_AnyStubProtocolClosure {
+            return w_AnyStubProtocolClosure()
         } else {
-            return W_AnyStubProtocolReturnValue
+            return w_AnyStubProtocolReturnValue
         }
     }
 
     //MARK: - x
 
-    var XStringAnyStubProtocolCallsCount = 0
-    var XStringAnyStubProtocolCalled: Bool {
-        return XStringAnyStubProtocolCallsCount > 0
+    var xStringAnyStubProtocolCallsCount = 0
+    var xStringAnyStubProtocolCalled: Bool {
+        return xStringAnyStubProtocolCallsCount > 0
     }
-    var XStringAnyStubProtocolReturnValue: ([String: (any StubProtocol)?])!
-    var XStringAnyStubProtocolClosure: (() -> [String: (any StubProtocol)?])?
+    var xStringAnyStubProtocolReturnValue: ([String: (any StubProtocol)?])!
+    var xStringAnyStubProtocolClosure: (() -> [String: (any StubProtocol)?])?
 
     func x() -> [String: (any StubProtocol)?] {
-        XStringAnyStubProtocolCallsCount += 1
-        if let XStringAnyStubProtocolClosure = XStringAnyStubProtocolClosure {
-            return XStringAnyStubProtocolClosure()
+        xStringAnyStubProtocolCallsCount += 1
+        if let xStringAnyStubProtocolClosure = xStringAnyStubProtocolClosure {
+            return xStringAnyStubProtocolClosure()
         } else {
-            return XStringAnyStubProtocolReturnValue
+            return xStringAnyStubProtocolReturnValue
         }
     }
 
     //MARK: - y
 
-    var Y_AnyStubProtocolAnyStubProtocolCallsCount = 0
-    var Y_AnyStubProtocolAnyStubProtocolCalled: Bool {
-        return Y_AnyStubProtocolAnyStubProtocolCallsCount > 0
+    var y_AnyStubProtocolAnyStubProtocolCallsCount = 0
+    var y_AnyStubProtocolAnyStubProtocolCalled: Bool {
+        return y_AnyStubProtocolAnyStubProtocolCallsCount > 0
     }
-    var Y_AnyStubProtocolAnyStubProtocolReturnValue: ((any StubProtocol, (any StubProtocol)?))!
-    var Y_AnyStubProtocolAnyStubProtocolClosure: (() -> (any StubProtocol, (any StubProtocol)?))?
+    var y_AnyStubProtocolAnyStubProtocolReturnValue: ((any StubProtocol, (any StubProtocol)?))!
+    var y_AnyStubProtocolAnyStubProtocolClosure: (() -> (any StubProtocol, (any StubProtocol)?))?
 
     func y() -> (any StubProtocol, (any StubProtocol)?) {
-        Y_AnyStubProtocolAnyStubProtocolCallsCount += 1
-        if let Y_AnyStubProtocolAnyStubProtocolClosure = Y_AnyStubProtocolAnyStubProtocolClosure {
-            return Y_AnyStubProtocolAnyStubProtocolClosure()
+        y_AnyStubProtocolAnyStubProtocolCallsCount += 1
+        if let y_AnyStubProtocolAnyStubProtocolClosure = y_AnyStubProtocolAnyStubProtocolClosure {
+            return y_AnyStubProtocolAnyStubProtocolClosure()
         } else {
-            return Y_AnyStubProtocolAnyStubProtocolReturnValue
+            return y_AnyStubProtocolAnyStubProtocolReturnValue
         }
     }
 
     //MARK: - z
 
-    var ZAnyStubProtocol&CustomStringConvertibleCallsCount = 0
-    var ZAnyStubProtocol&CustomStringConvertibleCalled: Bool {
-        return ZAnyStubProtocol&CustomStringConvertibleCallsCount > 0
+    var zAnyStubProtocol&CustomStringConvertibleCallsCount = 0
+    var zAnyStubProtocol&CustomStringConvertibleCalled: Bool {
+        return zAnyStubProtocol&CustomStringConvertibleCallsCount > 0
     }
-    var ZAnyStubProtocol&CustomStringConvertibleReturnValue: (any StubProtocol & CustomStringConvertible)!
-    var ZAnyStubProtocol&CustomStringConvertibleClosure: (() -> any StubProtocol & CustomStringConvertible)?
+    var zAnyStubProtocol&CustomStringConvertibleReturnValue: (any StubProtocol & CustomStringConvertible)!
+    var zAnyStubProtocol&CustomStringConvertibleClosure: (() -> any StubProtocol & CustomStringConvertible)?
 
     func z() -> any StubProtocol & CustomStringConvertible {
-        ZAnyStubProtocol&CustomStringConvertibleCallsCount += 1
-        if let ZAnyStubProtocol&CustomStringConvertibleClosure = ZAnyStubProtocol&CustomStringConvertibleClosure {
-            return ZAnyStubProtocol&CustomStringConvertibleClosure()
+        zAnyStubProtocol&CustomStringConvertibleCallsCount += 1
+        if let zAnyStubProtocol&CustomStringConvertibleClosure = zAnyStubProtocol&CustomStringConvertibleClosure {
+            return zAnyStubProtocol&CustomStringConvertibleClosure()
         } else {
-            return ZAnyStubProtocol&CustomStringConvertibleReturnValue
+            return zAnyStubProtocol&CustomStringConvertibleReturnValue
         }
     }
 
@@ -403,89 +403,89 @@ class AsyncProtocolMock: AsyncProtocol {
 
     //MARK: - callAsync
 
-    var CallAsyncParameterIntStringCallsCount = 0
-    var CallAsyncParameterIntStringCalled: Bool {
-        return CallAsyncParameterIntStringCallsCount > 0
+    var callAsyncParameterIntStringCallsCount = 0
+    var callAsyncParameterIntStringCalled: Bool {
+        return callAsyncParameterIntStringCallsCount > 0
     }
-    var CallAsyncParameterIntStringReceivedParameter: (Int)?
-    var CallAsyncParameterIntStringReceivedInvocations: [(Int)] = []
-    var CallAsyncParameterIntStringReturnValue: String!
-    var CallAsyncParameterIntStringClosure: ((Int) async -> String)?
+    var callAsyncParameterIntStringReceivedParameter: (Int)?
+    var callAsyncParameterIntStringReceivedInvocations: [(Int)] = []
+    var callAsyncParameterIntStringReturnValue: String!
+    var callAsyncParameterIntStringClosure: ((Int) async -> String)?
 
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func callAsync(parameter: Int) async -> String {
-        CallAsyncParameterIntStringCallsCount += 1
-        CallAsyncParameterIntStringReceivedParameter = parameter
-        CallAsyncParameterIntStringReceivedInvocations.append(parameter)
-        if let CallAsyncParameterIntStringClosure = CallAsyncParameterIntStringClosure {
-            return await CallAsyncParameterIntStringClosure(parameter)
+        callAsyncParameterIntStringCallsCount += 1
+        callAsyncParameterIntStringReceivedParameter = parameter
+        callAsyncParameterIntStringReceivedInvocations.append(parameter)
+        if let callAsyncParameterIntStringClosure = callAsyncParameterIntStringClosure {
+            return await callAsyncParameterIntStringClosure(parameter)
         } else {
-            return CallAsyncParameterIntStringReturnValue
+            return callAsyncParameterIntStringReturnValue
         }
     }
 
     //MARK: - callAsyncAndThrow
 
-    var CallAsyncAndThrowParameterIntStringThrowableError: Error?
-    var CallAsyncAndThrowParameterIntStringCallsCount = 0
-    var CallAsyncAndThrowParameterIntStringCalled: Bool {
-        return CallAsyncAndThrowParameterIntStringCallsCount > 0
+    var callAsyncAndThrowParameterIntStringThrowableError: Error?
+    var callAsyncAndThrowParameterIntStringCallsCount = 0
+    var callAsyncAndThrowParameterIntStringCalled: Bool {
+        return callAsyncAndThrowParameterIntStringCallsCount > 0
     }
-    var CallAsyncAndThrowParameterIntStringReceivedParameter: (Int)?
-    var CallAsyncAndThrowParameterIntStringReceivedInvocations: [(Int)] = []
-    var CallAsyncAndThrowParameterIntStringReturnValue: String!
-    var CallAsyncAndThrowParameterIntStringClosure: ((Int) async throws -> String)?
+    var callAsyncAndThrowParameterIntStringReceivedParameter: (Int)?
+    var callAsyncAndThrowParameterIntStringReceivedInvocations: [(Int)] = []
+    var callAsyncAndThrowParameterIntStringReturnValue: String!
+    var callAsyncAndThrowParameterIntStringClosure: ((Int) async throws -> String)?
 
     func callAsyncAndThrow(parameter: Int) async throws -> String {
-        CallAsyncAndThrowParameterIntStringCallsCount += 1
-        CallAsyncAndThrowParameterIntStringReceivedParameter = parameter
-        CallAsyncAndThrowParameterIntStringReceivedInvocations.append(parameter)
-        if let error = CallAsyncAndThrowParameterIntStringThrowableError {
+        callAsyncAndThrowParameterIntStringCallsCount += 1
+        callAsyncAndThrowParameterIntStringReceivedParameter = parameter
+        callAsyncAndThrowParameterIntStringReceivedInvocations.append(parameter)
+        if let error = callAsyncAndThrowParameterIntStringThrowableError {
             throw error
         }
-        if let CallAsyncAndThrowParameterIntStringClosure = CallAsyncAndThrowParameterIntStringClosure {
-            return try await CallAsyncAndThrowParameterIntStringClosure(parameter)
+        if let callAsyncAndThrowParameterIntStringClosure = callAsyncAndThrowParameterIntStringClosure {
+            return try await callAsyncAndThrowParameterIntStringClosure(parameter)
         } else {
-            return CallAsyncAndThrowParameterIntStringReturnValue
+            return callAsyncAndThrowParameterIntStringReturnValue
         }
     }
 
     //MARK: - callAsyncVoid
 
-    var CallAsyncVoidParameterIntVoidCallsCount = 0
-    var CallAsyncVoidParameterIntVoidCalled: Bool {
-        return CallAsyncVoidParameterIntVoidCallsCount > 0
+    var callAsyncVoidParameterIntVoidCallsCount = 0
+    var callAsyncVoidParameterIntVoidCalled: Bool {
+        return callAsyncVoidParameterIntVoidCallsCount > 0
     }
-    var CallAsyncVoidParameterIntVoidReceivedParameter: (Int)?
-    var CallAsyncVoidParameterIntVoidReceivedInvocations: [(Int)] = []
-    var CallAsyncVoidParameterIntVoidClosure: ((Int) async -> Void)?
+    var callAsyncVoidParameterIntVoidReceivedParameter: (Int)?
+    var callAsyncVoidParameterIntVoidReceivedInvocations: [(Int)] = []
+    var callAsyncVoidParameterIntVoidClosure: ((Int) async -> Void)?
 
     func callAsyncVoid(parameter: Int) async {
-        CallAsyncVoidParameterIntVoidCallsCount += 1
-        CallAsyncVoidParameterIntVoidReceivedParameter = parameter
-        CallAsyncVoidParameterIntVoidReceivedInvocations.append(parameter)
-        await CallAsyncVoidParameterIntVoidClosure?(parameter)
+        callAsyncVoidParameterIntVoidCallsCount += 1
+        callAsyncVoidParameterIntVoidReceivedParameter = parameter
+        callAsyncVoidParameterIntVoidReceivedInvocations.append(parameter)
+        await callAsyncVoidParameterIntVoidClosure?(parameter)
     }
 
     //MARK: - callAsyncAndThrowVoid
 
-    var CallAsyncAndThrowVoidParameterIntVoidThrowableError: Error?
-    var CallAsyncAndThrowVoidParameterIntVoidCallsCount = 0
-    var CallAsyncAndThrowVoidParameterIntVoidCalled: Bool {
-        return CallAsyncAndThrowVoidParameterIntVoidCallsCount > 0
+    var callAsyncAndThrowVoidParameterIntVoidThrowableError: Error?
+    var callAsyncAndThrowVoidParameterIntVoidCallsCount = 0
+    var callAsyncAndThrowVoidParameterIntVoidCalled: Bool {
+        return callAsyncAndThrowVoidParameterIntVoidCallsCount > 0
     }
-    var CallAsyncAndThrowVoidParameterIntVoidReceivedParameter: (Int)?
-    var CallAsyncAndThrowVoidParameterIntVoidReceivedInvocations: [(Int)] = []
-    var CallAsyncAndThrowVoidParameterIntVoidClosure: ((Int) async throws -> Void)?
+    var callAsyncAndThrowVoidParameterIntVoidReceivedParameter: (Int)?
+    var callAsyncAndThrowVoidParameterIntVoidReceivedInvocations: [(Int)] = []
+    var callAsyncAndThrowVoidParameterIntVoidClosure: ((Int) async throws -> Void)?
 
     func callAsyncAndThrowVoid(parameter: Int) async throws {
-        CallAsyncAndThrowVoidParameterIntVoidCallsCount += 1
-        CallAsyncAndThrowVoidParameterIntVoidReceivedParameter = parameter
-        CallAsyncAndThrowVoidParameterIntVoidReceivedInvocations.append(parameter)
-        if let error = CallAsyncAndThrowVoidParameterIntVoidThrowableError {
+        callAsyncAndThrowVoidParameterIntVoidCallsCount += 1
+        callAsyncAndThrowVoidParameterIntVoidReceivedParameter = parameter
+        callAsyncAndThrowVoidParameterIntVoidReceivedInvocations.append(parameter)
+        if let error = callAsyncAndThrowVoidParameterIntVoidThrowableError {
             throw error
         }
-        try await CallAsyncAndThrowVoidParameterIntVoidClosure?(parameter)
+        try await callAsyncAndThrowVoidParameterIntVoidClosure?(parameter)
     }
 
 }
@@ -584,37 +584,37 @@ class BasicProtocolMock: BasicProtocol {
 
     //MARK: - loadConfiguration
 
-    var LoadConfigurationStringCallsCount = 0
-    var LoadConfigurationStringCalled: Bool {
-        return LoadConfigurationStringCallsCount > 0
+    var loadConfigurationStringCallsCount = 0
+    var loadConfigurationStringCalled: Bool {
+        return loadConfigurationStringCallsCount > 0
     }
-    var LoadConfigurationStringReturnValue: String?
-    var LoadConfigurationStringClosure: (() -> String?)?
+    var loadConfigurationStringReturnValue: String?
+    var loadConfigurationStringClosure: (() -> String?)?
 
     func loadConfiguration() -> String? {
-        LoadConfigurationStringCallsCount += 1
-        if let LoadConfigurationStringClosure = LoadConfigurationStringClosure {
-            return LoadConfigurationStringClosure()
+        loadConfigurationStringCallsCount += 1
+        if let loadConfigurationStringClosure = loadConfigurationStringClosure {
+            return loadConfigurationStringClosure()
         } else {
-            return LoadConfigurationStringReturnValue
+            return loadConfigurationStringReturnValue
         }
     }
 
     //MARK: - save
 
-    var SaveConfigurationStringVoidCallsCount = 0
-    var SaveConfigurationStringVoidCalled: Bool {
-        return SaveConfigurationStringVoidCallsCount > 0
+    var saveConfigurationStringVoidCallsCount = 0
+    var saveConfigurationStringVoidCalled: Bool {
+        return saveConfigurationStringVoidCallsCount > 0
     }
-    var SaveConfigurationStringVoidReceivedConfiguration: (String)?
-    var SaveConfigurationStringVoidReceivedInvocations: [(String)] = []
-    var SaveConfigurationStringVoidClosure: ((String) -> Void)?
+    var saveConfigurationStringVoidReceivedConfiguration: (String)?
+    var saveConfigurationStringVoidReceivedInvocations: [(String)] = []
+    var saveConfigurationStringVoidClosure: ((String) -> Void)?
 
     func save(configuration: String) {
-        SaveConfigurationStringVoidCallsCount += 1
-        SaveConfigurationStringVoidReceivedConfiguration = configuration
-        SaveConfigurationStringVoidReceivedInvocations.append(configuration)
-        SaveConfigurationStringVoidClosure?(configuration)
+        saveConfigurationStringVoidCallsCount += 1
+        saveConfigurationStringVoidReceivedConfiguration = configuration
+        saveConfigurationStringVoidReceivedInvocations.append(configuration)
+        saveConfigurationStringVoidClosure?(configuration)
     }
 
 }
@@ -625,19 +625,19 @@ class ClosureProtocolMock: ClosureProtocol {
 
     //MARK: - setClosure
 
-    var SetClosureClosureEscapingVoidVoidCallsCount = 0
-    var SetClosureClosureEscapingVoidVoidCalled: Bool {
-        return SetClosureClosureEscapingVoidVoidCallsCount > 0
+    var setClosureClosureEscapingVoidVoidCallsCount = 0
+    var setClosureClosureEscapingVoidVoidCalled: Bool {
+        return setClosureClosureEscapingVoidVoidCallsCount > 0
     }
-    var SetClosureClosureEscapingVoidVoidReceivedClosure: ((() -> Void))?
-    var SetClosureClosureEscapingVoidVoidReceivedInvocations: [((() -> Void))] = []
-    var SetClosureClosureEscapingVoidVoidClosure: ((@escaping () -> Void) -> Void)?
+    var setClosureClosureEscapingVoidVoidReceivedClosure: ((() -> Void))?
+    var setClosureClosureEscapingVoidVoidReceivedInvocations: [((() -> Void))] = []
+    var setClosureClosureEscapingVoidVoidClosure: ((@escaping () -> Void) -> Void)?
 
     func setClosure(_ closure: @escaping () -> Void) {
-        SetClosureClosureEscapingVoidVoidCallsCount += 1
-        SetClosureClosureEscapingVoidVoidReceivedClosure = closure
-        SetClosureClosureEscapingVoidVoidReceivedInvocations.append(closure)
-        SetClosureClosureEscapingVoidVoidClosure?(closure)
+        setClosureClosureEscapingVoidVoidCallsCount += 1
+        setClosureClosureEscapingVoidVoidReceivedClosure = closure
+        setClosureClosureEscapingVoidVoidReceivedInvocations.append(closure)
+        setClosureClosureEscapingVoidVoidClosure?(closure)
     }
 
 }
@@ -648,19 +648,19 @@ class CurrencyPresenterMock: CurrencyPresenter {
 
     //MARK: - showSourceCurrency
 
-    var ShowSourceCurrencyCurrencyStringVoidCallsCount = 0
-    var ShowSourceCurrencyCurrencyStringVoidCalled: Bool {
-        return ShowSourceCurrencyCurrencyStringVoidCallsCount > 0
+    var showSourceCurrencyCurrencyStringVoidCallsCount = 0
+    var showSourceCurrencyCurrencyStringVoidCalled: Bool {
+        return showSourceCurrencyCurrencyStringVoidCallsCount > 0
     }
-    var ShowSourceCurrencyCurrencyStringVoidReceivedCurrency: (String)?
-    var ShowSourceCurrencyCurrencyStringVoidReceivedInvocations: [(String)] = []
-    var ShowSourceCurrencyCurrencyStringVoidClosure: ((String) -> Void)?
+    var showSourceCurrencyCurrencyStringVoidReceivedCurrency: (String)?
+    var showSourceCurrencyCurrencyStringVoidReceivedInvocations: [(String)] = []
+    var showSourceCurrencyCurrencyStringVoidClosure: ((String) -> Void)?
 
     func showSourceCurrency(_ currency: String) {
-        ShowSourceCurrencyCurrencyStringVoidCallsCount += 1
-        ShowSourceCurrencyCurrencyStringVoidReceivedCurrency = currency
-        ShowSourceCurrencyCurrencyStringVoidReceivedInvocations.append(currency)
-        ShowSourceCurrencyCurrencyStringVoidClosure?(currency)
+        showSourceCurrencyCurrencyStringVoidCallsCount += 1
+        showSourceCurrencyCurrencyStringVoidReceivedCurrency = currency
+        showSourceCurrencyCurrencyStringVoidReceivedInvocations.append(currency)
+        showSourceCurrencyCurrencyStringVoidClosure?(currency)
     }
 
 }
@@ -671,23 +671,23 @@ class ExampleVarargMock: ExampleVararg {
 
     //MARK: - string
 
-    var StringKeyStringArgsCVarArgStringCallsCount = 0
-    var StringKeyStringArgsCVarArgStringCalled: Bool {
-        return StringKeyStringArgsCVarArgStringCallsCount > 0
+    var stringKeyStringArgsCVarArgStringCallsCount = 0
+    var stringKeyStringArgsCVarArgStringCalled: Bool {
+        return stringKeyStringArgsCVarArgStringCallsCount > 0
     }
-    var StringKeyStringArgsCVarArgStringReceivedArguments: (key: String, args: CVarArg...)?
-    var StringKeyStringArgsCVarArgStringReceivedInvocations: [(key: String, args: CVarArg...)] = []
-    var StringKeyStringArgsCVarArgStringReturnValue: String!
-    var StringKeyStringArgsCVarArgStringClosure: ((String, CVarArg...) -> String)?
+    var stringKeyStringArgsCVarArgStringReceivedArguments: (key: String, args: CVarArg...)?
+    var stringKeyStringArgsCVarArgStringReceivedInvocations: [(key: String, args: CVarArg...)] = []
+    var stringKeyStringArgsCVarArgStringReturnValue: String!
+    var stringKeyStringArgsCVarArgStringClosure: ((String, CVarArg...) -> String)?
 
     func string(key: String, args: CVarArg...) -> String {
-        StringKeyStringArgsCVarArgStringCallsCount += 1
-        StringKeyStringArgsCVarArgStringReceivedArguments = (key: key, args: args)
-        StringKeyStringArgsCVarArgStringReceivedInvocations.append((key: key, args: args))
-        if let StringKeyStringArgsCVarArgStringClosure = StringKeyStringArgsCVarArgStringClosure {
-            return StringKeyStringArgsCVarArgStringClosure(key, args)
+        stringKeyStringArgsCVarArgStringCallsCount += 1
+        stringKeyStringArgsCVarArgStringReceivedArguments = (key: key, args: args)
+        stringKeyStringArgsCVarArgStringReceivedInvocations.append((key: key, args: args))
+        if let stringKeyStringArgsCVarArgStringClosure = stringKeyStringArgsCVarArgStringClosure {
+            return stringKeyStringArgsCVarArgStringClosure(key, args)
         } else {
-            return StringKeyStringArgsCVarArgStringReturnValue
+            return stringKeyStringArgsCVarArgStringReturnValue
         }
     }
 
@@ -704,19 +704,19 @@ class ExtendableProtocolMock: ExtendableProtocol {
 
     //MARK: - report
 
-    var ReportMessageStringVoidCallsCount = 0
-    var ReportMessageStringVoidCalled: Bool {
-        return ReportMessageStringVoidCallsCount > 0
+    var reportMessageStringVoidCallsCount = 0
+    var reportMessageStringVoidCalled: Bool {
+        return reportMessageStringVoidCallsCount > 0
     }
-    var ReportMessageStringVoidReceivedMessage: (String)?
-    var ReportMessageStringVoidReceivedInvocations: [(String)] = []
-    var ReportMessageStringVoidClosure: ((String) -> Void)?
+    var reportMessageStringVoidReceivedMessage: (String)?
+    var reportMessageStringVoidReceivedInvocations: [(String)] = []
+    var reportMessageStringVoidClosure: ((String) -> Void)?
 
     func report(message: String) {
-        ReportMessageStringVoidCallsCount += 1
-        ReportMessageStringVoidReceivedMessage = message
-        ReportMessageStringVoidReceivedInvocations.append(message)
-        ReportMessageStringVoidClosure?(message)
+        reportMessageStringVoidCallsCount += 1
+        reportMessageStringVoidReceivedMessage = message
+        reportMessageStringVoidReceivedInvocations.append(message)
+        reportMessageStringVoidClosure?(message)
     }
 
 }
@@ -727,61 +727,61 @@ class FunctionWithAttributesMock: FunctionWithAttributes {
 
     //MARK: - callOneAttribute
 
-    var CallOneAttributeStringCallsCount = 0
-    var CallOneAttributeStringCalled: Bool {
-        return CallOneAttributeStringCallsCount > 0
+    var callOneAttributeStringCallsCount = 0
+    var callOneAttributeStringCalled: Bool {
+        return callOneAttributeStringCallsCount > 0
     }
-    var CallOneAttributeStringReturnValue: String!
-    var CallOneAttributeStringClosure: (() -> String)?
+    var callOneAttributeStringReturnValue: String!
+    var callOneAttributeStringClosure: (() -> String)?
 
     @discardableResult
     func callOneAttribute() -> String {
-        CallOneAttributeStringCallsCount += 1
-        if let CallOneAttributeStringClosure = CallOneAttributeStringClosure {
-            return CallOneAttributeStringClosure()
+        callOneAttributeStringCallsCount += 1
+        if let callOneAttributeStringClosure = callOneAttributeStringClosure {
+            return callOneAttributeStringClosure()
         } else {
-            return CallOneAttributeStringReturnValue
+            return callOneAttributeStringReturnValue
         }
     }
 
     //MARK: - callTwoAttributes
 
-    var CallTwoAttributesIntCallsCount = 0
-    var CallTwoAttributesIntCalled: Bool {
-        return CallTwoAttributesIntCallsCount > 0
+    var callTwoAttributesIntCallsCount = 0
+    var callTwoAttributesIntCalled: Bool {
+        return callTwoAttributesIntCallsCount > 0
     }
-    var CallTwoAttributesIntReturnValue: Int!
-    var CallTwoAttributesIntClosure: (() -> Int)?
+    var callTwoAttributesIntReturnValue: Int!
+    var callTwoAttributesIntClosure: (() -> Int)?
 
     @available(macOS 10.15, *)
     @discardableResult
     func callTwoAttributes() -> Int {
-        CallTwoAttributesIntCallsCount += 1
-        if let CallTwoAttributesIntClosure = CallTwoAttributesIntClosure {
-            return CallTwoAttributesIntClosure()
+        callTwoAttributesIntCallsCount += 1
+        if let callTwoAttributesIntClosure = callTwoAttributesIntClosure {
+            return callTwoAttributesIntClosure()
         } else {
-            return CallTwoAttributesIntReturnValue
+            return callTwoAttributesIntReturnValue
         }
     }
 
     //MARK: - callRepeatedAttributes
 
-    var CallRepeatedAttributesBoolCallsCount = 0
-    var CallRepeatedAttributesBoolCalled: Bool {
-        return CallRepeatedAttributesBoolCallsCount > 0
+    var callRepeatedAttributesBoolCallsCount = 0
+    var callRepeatedAttributesBoolCalled: Bool {
+        return callRepeatedAttributesBoolCallsCount > 0
     }
-    var CallRepeatedAttributesBoolReturnValue: Bool!
-    var CallRepeatedAttributesBoolClosure: (() -> Bool)?
+    var callRepeatedAttributesBoolReturnValue: Bool!
+    var callRepeatedAttributesBoolClosure: (() -> Bool)?
 
     @available(iOS 13.0, *)
     @available(macOS 10.15, *)
     @discardableResult
     func callRepeatedAttributes() -> Bool {
-        CallRepeatedAttributesBoolCallsCount += 1
-        if let CallRepeatedAttributesBoolClosure = CallRepeatedAttributesBoolClosure {
-            return CallRepeatedAttributesBoolClosure()
+        callRepeatedAttributesBoolCallsCount += 1
+        if let callRepeatedAttributesBoolClosure = callRepeatedAttributesBoolClosure {
+            return callRepeatedAttributesBoolClosure()
         } else {
-            return CallRepeatedAttributesBoolReturnValue
+            return callRepeatedAttributesBoolReturnValue
         }
     }
 
@@ -793,37 +793,37 @@ class FunctionWithClosureReturnTypeMock: FunctionWithClosureReturnType {
 
     //MARK: - get
 
-    var Get____VoidCallsCount = 0
-    var Get____VoidCalled: Bool {
-        return Get____VoidCallsCount > 0
+    var get____VoidCallsCount = 0
+    var get____VoidCalled: Bool {
+        return get____VoidCallsCount > 0
     }
-    var Get____VoidReturnValue: ((() -> Void))!
-    var Get____VoidClosure: (() -> (() -> Void))?
+    var get____VoidReturnValue: ((() -> Void))!
+    var get____VoidClosure: (() -> (() -> Void))?
 
     func get() -> (() -> Void) {
-        Get____VoidCallsCount += 1
-        if let Get____VoidClosure = Get____VoidClosure {
-            return Get____VoidClosure()
+        get____VoidCallsCount += 1
+        if let get____VoidClosure = get____VoidClosure {
+            return get____VoidClosure()
         } else {
-            return Get____VoidReturnValue
+            return get____VoidReturnValue
         }
     }
 
     //MARK: - getOptional
 
-    var GetOptional_____VoidCallsCount = 0
-    var GetOptional_____VoidCalled: Bool {
-        return GetOptional_____VoidCallsCount > 0
+    var getOptional_____VoidCallsCount = 0
+    var getOptional_____VoidCalled: Bool {
+        return getOptional_____VoidCallsCount > 0
     }
-    var GetOptional_____VoidReturnValue: ((() -> Void)?)
-    var GetOptional_____VoidClosure: (() -> ((() -> Void)?))?
+    var getOptional_____VoidReturnValue: ((() -> Void)?)
+    var getOptional_____VoidClosure: (() -> ((() -> Void)?))?
 
     func getOptional() -> ((() -> Void)?) {
-        GetOptional_____VoidCallsCount += 1
-        if let GetOptional_____VoidClosure = GetOptional_____VoidClosure {
-            return GetOptional_____VoidClosure()
+        getOptional_____VoidCallsCount += 1
+        if let getOptional_____VoidClosure = getOptional_____VoidClosure {
+            return getOptional_____VoidClosure()
         } else {
-            return GetOptional_____VoidReturnValue
+            return getOptional_____VoidReturnValue
         }
     }
 
@@ -835,19 +835,19 @@ class FunctionWithMultilineDeclarationMock: FunctionWithMultilineDeclaration {
 
     //MARK: - start
 
-    var StartCarStringOfModelStringVoidCallsCount = 0
-    var StartCarStringOfModelStringVoidCalled: Bool {
-        return StartCarStringOfModelStringVoidCallsCount > 0
+    var startCarStringOfModelStringVoidCallsCount = 0
+    var startCarStringOfModelStringVoidCalled: Bool {
+        return startCarStringOfModelStringVoidCallsCount > 0
     }
-    var StartCarStringOfModelStringVoidReceivedArguments: (car: String, model: String)?
-    var StartCarStringOfModelStringVoidReceivedInvocations: [(car: String, model: String)] = []
-    var StartCarStringOfModelStringVoidClosure: ((String, String) -> Void)?
+    var startCarStringOfModelStringVoidReceivedArguments: (car: String, model: String)?
+    var startCarStringOfModelStringVoidReceivedInvocations: [(car: String, model: String)] = []
+    var startCarStringOfModelStringVoidClosure: ((String, String) -> Void)?
 
     func start(car: String, of model: String) {
-        StartCarStringOfModelStringVoidCallsCount += 1
-        StartCarStringOfModelStringVoidReceivedArguments = (car: car, model: model)
-        StartCarStringOfModelStringVoidReceivedInvocations.append((car: car, model: model))
-        StartCarStringOfModelStringVoidClosure?(car, model)
+        startCarStringOfModelStringVoidCallsCount += 1
+        startCarStringOfModelStringVoidReceivedArguments = (car: car, model: model)
+        startCarStringOfModelStringVoidReceivedInvocations.append((car: car, model: model))
+        startCarStringOfModelStringVoidClosure?(car, model)
     }
 
 }
@@ -876,19 +876,19 @@ class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOpt
 
     //MARK: - implicitReturn
 
-    var ImplicitReturnStringCallsCount = 0
-    var ImplicitReturnStringCalled: Bool {
-        return ImplicitReturnStringCallsCount > 0
+    var implicitReturnStringCallsCount = 0
+    var implicitReturnStringCalled: Bool {
+        return implicitReturnStringCallsCount > 0
     }
-    var ImplicitReturnStringReturnValue: String!
-    var ImplicitReturnStringClosure: (() -> String!)?
+    var implicitReturnStringReturnValue: String!
+    var implicitReturnStringClosure: (() -> String!)?
 
     func implicitReturn() -> String! {
-        ImplicitReturnStringCallsCount += 1
-        if let ImplicitReturnStringClosure = ImplicitReturnStringClosure {
-            return ImplicitReturnStringClosure()
+        implicitReturnStringCallsCount += 1
+        if let implicitReturnStringClosure = implicitReturnStringClosure {
+            return implicitReturnStringClosure()
         } else {
-            return ImplicitReturnStringReturnValue
+            return implicitReturnStringReturnValue
         }
     }
 
@@ -900,39 +900,39 @@ class InitializationProtocolMock: InitializationProtocol {
 
     //MARK: - init
 
-    var InitIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolReceivedArguments: (intParameter: Int, stringParameter: String, optionalParameter: String?)?
-    var InitIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolReceivedInvocations: [(intParameter: Int, stringParameter: String, optionalParameter: String?)] = []
-    var InitIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolClosure: ((Int, String, String?) -> Void)?
+    var initIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolReceivedArguments: (intParameter: Int, stringParameter: String, optionalParameter: String?)?
+    var initIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolReceivedInvocations: [(intParameter: Int, stringParameter: String, optionalParameter: String?)] = []
+    var initIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolClosure: ((Int, String, String?) -> Void)?
 
     required init(intParameter: Int, stringParameter: String, optionalParameter: String?) {
-        InitIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolReceivedArguments = (intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter)
-        InitIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolReceivedInvocations.append((intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter))
-        InitIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolClosure?(intParameter, stringParameter, optionalParameter)
+        initIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolReceivedArguments = (intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter)
+        initIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolReceivedInvocations.append((intParameter: intParameter, stringParameter: stringParameter, optionalParameter: optionalParameter))
+        initIntParameterIntStringParameterStringOptionalParameterStringInitializationProtocolClosure?(intParameter, stringParameter, optionalParameter)
     }
     //MARK: - start
 
-    var StartVoidCallsCount = 0
-    var StartVoidCalled: Bool {
-        return StartVoidCallsCount > 0
+    var startVoidCallsCount = 0
+    var startVoidCalled: Bool {
+        return startVoidCallsCount > 0
     }
-    var StartVoidClosure: (() -> Void)?
+    var startVoidClosure: (() -> Void)?
 
     func start() {
-        StartVoidCallsCount += 1
-        StartVoidClosure?()
+        startVoidCallsCount += 1
+        startVoidClosure?()
     }
 
     //MARK: - stop
 
-    var StopVoidCallsCount = 0
-    var StopVoidCalled: Bool {
-        return StopVoidCallsCount > 0
+    var stopVoidCallsCount = 0
+    var stopVoidCalled: Bool {
+        return stopVoidCallsCount > 0
     }
-    var StopVoidClosure: (() -> Void)?
+    var stopVoidClosure: (() -> Void)?
 
     func stop() {
-        StopVoidCallsCount += 1
-        StopVoidClosure?()
+        stopVoidCallsCount += 1
+        stopVoidClosure?()
     }
 
 }
@@ -943,19 +943,19 @@ class MultiClosureProtocolMock: MultiClosureProtocol {
 
     //MARK: - setClosure
 
-    var SetClosureNameStringClosureEscapingVoidVoidCallsCount = 0
-    var SetClosureNameStringClosureEscapingVoidVoidCalled: Bool {
-        return SetClosureNameStringClosureEscapingVoidVoidCallsCount > 0
+    var setClosureNameStringClosureEscapingVoidVoidCallsCount = 0
+    var setClosureNameStringClosureEscapingVoidVoidCalled: Bool {
+        return setClosureNameStringClosureEscapingVoidVoidCallsCount > 0
     }
-    var SetClosureNameStringClosureEscapingVoidVoidReceivedArguments: (name: String, closure: () -> Void)?
-    var SetClosureNameStringClosureEscapingVoidVoidReceivedInvocations: [(name: String, closure: () -> Void)] = []
-    var SetClosureNameStringClosureEscapingVoidVoidClosure: ((String, @escaping () -> Void) -> Void)?
+    var setClosureNameStringClosureEscapingVoidVoidReceivedArguments: (name: String, closure: () -> Void)?
+    var setClosureNameStringClosureEscapingVoidVoidReceivedInvocations: [(name: String, closure: () -> Void)] = []
+    var setClosureNameStringClosureEscapingVoidVoidClosure: ((String, @escaping () -> Void) -> Void)?
 
     func setClosure(name: String, _ closure: @escaping () -> Void) {
-        SetClosureNameStringClosureEscapingVoidVoidCallsCount += 1
-        SetClosureNameStringClosureEscapingVoidVoidReceivedArguments = (name: name, closure: closure)
-        SetClosureNameStringClosureEscapingVoidVoidReceivedInvocations.append((name: name, closure: closure))
-        SetClosureNameStringClosureEscapingVoidVoidClosure?(name, closure)
+        setClosureNameStringClosureEscapingVoidVoidCallsCount += 1
+        setClosureNameStringClosureEscapingVoidVoidReceivedArguments = (name: name, closure: closure)
+        setClosureNameStringClosureEscapingVoidVoidReceivedInvocations.append((name: name, closure: closure))
+        setClosureNameStringClosureEscapingVoidVoidClosure?(name, closure)
     }
 
 }
@@ -966,15 +966,15 @@ class MultiNonEscapingClosureProtocolMock: MultiNonEscapingClosureProtocol {
 
     //MARK: - executeClosure
 
-    var ExecuteClosureNameStringClosureVoidVoidCallsCount = 0
-    var ExecuteClosureNameStringClosureVoidVoidCalled: Bool {
-        return ExecuteClosureNameStringClosureVoidVoidCallsCount > 0
+    var executeClosureNameStringClosureVoidVoidCallsCount = 0
+    var executeClosureNameStringClosureVoidVoidCalled: Bool {
+        return executeClosureNameStringClosureVoidVoidCallsCount > 0
     }
-    var ExecuteClosureNameStringClosureVoidVoidClosure: ((String, () -> Void) -> Void)?
+    var executeClosureNameStringClosureVoidVoidClosure: ((String, () -> Void) -> Void)?
 
     func executeClosure(name: String, _ closure: () -> Void) {
-        ExecuteClosureNameStringClosureVoidVoidCallsCount += 1
-        ExecuteClosureNameStringClosureVoidVoidClosure?(name, closure)
+        executeClosureNameStringClosureVoidVoidCallsCount += 1
+        executeClosureNameStringClosureVoidVoidClosure?(name, closure)
     }
 
 }
@@ -985,15 +985,45 @@ class NonEscapingClosureProtocolMock: NonEscapingClosureProtocol {
 
     //MARK: - executeClosure
 
-    var ExecuteClosureClosureVoidVoidCallsCount = 0
-    var ExecuteClosureClosureVoidVoidCalled: Bool {
-        return ExecuteClosureClosureVoidVoidCallsCount > 0
+    var executeClosureClosureVoidVoidCallsCount = 0
+    var executeClosureClosureVoidVoidCalled: Bool {
+        return executeClosureClosureVoidVoidCallsCount > 0
     }
-    var ExecuteClosureClosureVoidVoidClosure: ((() -> Void) -> Void)?
+    var executeClosureClosureVoidVoidClosure: ((() -> Void) -> Void)?
 
     func executeClosure(_ closure: () -> Void) {
-        ExecuteClosureClosureVoidVoidCallsCount += 1
-        ExecuteClosureClosureVoidVoidClosure?(closure)
+        executeClosureClosureVoidVoidCallsCount += 1
+        executeClosureClosureVoidVoidClosure?(closure)
+    }
+
+
+}
+public class ProtocolWithMethodWithGenericParametersMock: ProtocolWithMethodWithGenericParameters {
+
+    public init() {}
+
+
+
+    //MARK: - execute
+
+    public var executeParamResultIntErrorResultStringErrorCallsCount = 0
+    public var executeParamResultIntErrorResultStringErrorCalled: Bool {
+        return executeParamResultIntErrorResultStringErrorCallsCount > 0
+    }
+    public var executeParamResultIntErrorResultStringErrorReceivedParam: (Result<Int, Error>)?
+    public var executeParamResultIntErrorResultStringErrorReceivedInvocations: [(Result<Int, Error>)] = []
+    public var executeParamResultIntErrorResultStringErrorReturnValue: Result<String, Error>!
+    public var executeParamResultIntErrorResultStringErrorClosure: ((Result<Int, Error>) -> Result<String, Error>)?
+
+    public func execute(param: Result<Int, Error>) -> Result<String, Error> {
+        executeParamResultIntErrorResultStringErrorCallsCount += 1
+        executeParamResultIntErrorResultStringErrorReceivedParam = param
+        executeParamResultIntErrorResultStringErrorReceivedInvocations.append(param)
+        if let executeParamResultIntErrorResultStringErrorClosure = executeParamResultIntErrorResultStringErrorClosure {
+            return executeParamResultIntErrorResultStringErrorClosure(param)
+        } else {
+            return executeParamResultIntErrorResultStringErrorReturnValue
+        }
     }
 
 }
@@ -1005,163 +1035,163 @@ public class ProtocolWithOverridesMock: ProtocolWithOverrides {
 
     //MARK: - doSomething
 
-    public var DoSomethingDataIntStringCallsCount = 0
-    public var DoSomethingDataIntStringCalled: Bool {
-        return DoSomethingDataIntStringCallsCount > 0
+    public var doSomethingDataIntStringCallsCount = 0
+    public var doSomethingDataIntStringCalled: Bool {
+        return doSomethingDataIntStringCallsCount > 0
     }
-    public var DoSomethingDataIntStringReceivedData: (Int)?
-    public var DoSomethingDataIntStringReceivedInvocations: [(Int)] = []
-    public var DoSomethingDataIntStringReturnValue: [String]!
-    public var DoSomethingDataIntStringClosure: ((Int) -> [String])?
+    public var doSomethingDataIntStringReceivedData: (Int)?
+    public var doSomethingDataIntStringReceivedInvocations: [(Int)] = []
+    public var doSomethingDataIntStringReturnValue: [String]!
+    public var doSomethingDataIntStringClosure: ((Int) -> [String])?
 
     public func doSomething(_ data: Int) -> [String] {
-        DoSomethingDataIntStringCallsCount += 1
-        DoSomethingDataIntStringReceivedData = data
-        DoSomethingDataIntStringReceivedInvocations.append(data)
-        if let DoSomethingDataIntStringClosure = DoSomethingDataIntStringClosure {
-            return DoSomethingDataIntStringClosure(data)
+        doSomethingDataIntStringCallsCount += 1
+        doSomethingDataIntStringReceivedData = data
+        doSomethingDataIntStringReceivedInvocations.append(data)
+        if let doSomethingDataIntStringClosure = doSomethingDataIntStringClosure {
+            return doSomethingDataIntStringClosure(data)
         } else {
-            return DoSomethingDataIntStringReturnValue
+            return doSomethingDataIntStringReturnValue
         }
     }
 
     //MARK: - doSomething
 
-    public var DoSomethingDataStringStringCallsCount = 0
-    public var DoSomethingDataStringStringCalled: Bool {
-        return DoSomethingDataStringStringCallsCount > 0
+    public var doSomethingDataStringStringCallsCount = 0
+    public var doSomethingDataStringStringCalled: Bool {
+        return doSomethingDataStringStringCallsCount > 0
     }
-    public var DoSomethingDataStringStringReceivedData: (String)?
-    public var DoSomethingDataStringStringReceivedInvocations: [(String)] = []
-    public var DoSomethingDataStringStringReturnValue: [String]!
-    public var DoSomethingDataStringStringClosure: ((String) -> [String])?
+    public var doSomethingDataStringStringReceivedData: (String)?
+    public var doSomethingDataStringStringReceivedInvocations: [(String)] = []
+    public var doSomethingDataStringStringReturnValue: [String]!
+    public var doSomethingDataStringStringClosure: ((String) -> [String])?
 
     public func doSomething(_ data: String) -> [String] {
-        DoSomethingDataStringStringCallsCount += 1
-        DoSomethingDataStringStringReceivedData = data
-        DoSomethingDataStringStringReceivedInvocations.append(data)
-        if let DoSomethingDataStringStringClosure = DoSomethingDataStringStringClosure {
-            return DoSomethingDataStringStringClosure(data)
+        doSomethingDataStringStringCallsCount += 1
+        doSomethingDataStringStringReceivedData = data
+        doSomethingDataStringStringReceivedInvocations.append(data)
+        if let doSomethingDataStringStringClosure = doSomethingDataStringStringClosure {
+            return doSomethingDataStringStringClosure(data)
         } else {
-            return DoSomethingDataStringStringReturnValue
+            return doSomethingDataStringStringReturnValue
         }
     }
 
     //MARK: - doSomething
 
-    public var DoSomethingDataStringIntCallsCount = 0
-    public var DoSomethingDataStringIntCalled: Bool {
-        return DoSomethingDataStringIntCallsCount > 0
+    public var doSomethingDataStringIntCallsCount = 0
+    public var doSomethingDataStringIntCalled: Bool {
+        return doSomethingDataStringIntCallsCount > 0
     }
-    public var DoSomethingDataStringIntReceivedData: (String)?
-    public var DoSomethingDataStringIntReceivedInvocations: [(String)] = []
-    public var DoSomethingDataStringIntReturnValue: [Int]!
-    public var DoSomethingDataStringIntClosure: ((String) -> [Int])?
+    public var doSomethingDataStringIntReceivedData: (String)?
+    public var doSomethingDataStringIntReceivedInvocations: [(String)] = []
+    public var doSomethingDataStringIntReturnValue: [Int]!
+    public var doSomethingDataStringIntClosure: ((String) -> [Int])?
 
     public func doSomething(_ data: String) -> [Int] {
-        DoSomethingDataStringIntCallsCount += 1
-        DoSomethingDataStringIntReceivedData = data
-        DoSomethingDataStringIntReceivedInvocations.append(data)
-        if let DoSomethingDataStringIntClosure = DoSomethingDataStringIntClosure {
-            return DoSomethingDataStringIntClosure(data)
+        doSomethingDataStringIntCallsCount += 1
+        doSomethingDataStringIntReceivedData = data
+        doSomethingDataStringIntReceivedInvocations.append(data)
+        if let doSomethingDataStringIntClosure = doSomethingDataStringIntClosure {
+            return doSomethingDataStringIntClosure(data)
         } else {
-            return DoSomethingDataStringIntReturnValue
+            return doSomethingDataStringIntReturnValue
         }
     }
 
     //MARK: - doSomething
 
-    public var DoSomethingDataString_IntStringCallsCount = 0
-    public var DoSomethingDataString_IntStringCalled: Bool {
-        return DoSomethingDataString_IntStringCallsCount > 0
+    public var doSomethingDataString_IntStringCallsCount = 0
+    public var doSomethingDataString_IntStringCalled: Bool {
+        return doSomethingDataString_IntStringCallsCount > 0
     }
-    public var DoSomethingDataString_IntStringReceivedData: (String)?
-    public var DoSomethingDataString_IntStringReceivedInvocations: [(String)] = []
-    public var DoSomethingDataString_IntStringReturnValue: ([Int], [String])!
-    public var DoSomethingDataString_IntStringClosure: ((String) -> ([Int], [String]))?
+    public var doSomethingDataString_IntStringReceivedData: (String)?
+    public var doSomethingDataString_IntStringReceivedInvocations: [(String)] = []
+    public var doSomethingDataString_IntStringReturnValue: ([Int], [String])!
+    public var doSomethingDataString_IntStringClosure: ((String) -> ([Int], [String]))?
 
     public func doSomething(_ data: String) -> ([Int], [String]) {
-        DoSomethingDataString_IntStringCallsCount += 1
-        DoSomethingDataString_IntStringReceivedData = data
-        DoSomethingDataString_IntStringReceivedInvocations.append(data)
-        if let DoSomethingDataString_IntStringClosure = DoSomethingDataString_IntStringClosure {
-            return DoSomethingDataString_IntStringClosure(data)
+        doSomethingDataString_IntStringCallsCount += 1
+        doSomethingDataString_IntStringReceivedData = data
+        doSomethingDataString_IntStringReceivedInvocations.append(data)
+        if let doSomethingDataString_IntStringClosure = doSomethingDataString_IntStringClosure {
+            return doSomethingDataString_IntStringClosure(data)
         } else {
-            return DoSomethingDataString_IntStringReturnValue
+            return doSomethingDataString_IntStringReturnValue
         }
     }
 
     //MARK: - doSomething
 
-    public var DoSomethingDataString_IntAnyThrowableError: Error?
-    public var DoSomethingDataString_IntAnyCallsCount = 0
-    public var DoSomethingDataString_IntAnyCalled: Bool {
-        return DoSomethingDataString_IntAnyCallsCount > 0
+    public var doSomethingDataString_IntAnyThrowableError: Error?
+    public var doSomethingDataString_IntAnyCallsCount = 0
+    public var doSomethingDataString_IntAnyCalled: Bool {
+        return doSomethingDataString_IntAnyCallsCount > 0
     }
-    public var DoSomethingDataString_IntAnyReceivedData: (String)?
-    public var DoSomethingDataString_IntAnyReceivedInvocations: [(String)] = []
-    public var DoSomethingDataString_IntAnyReturnValue: ([Int], [Any])!
-    public var DoSomethingDataString_IntAnyClosure: ((String) throws -> ([Int], [Any]))?
+    public var doSomethingDataString_IntAnyReceivedData: (String)?
+    public var doSomethingDataString_IntAnyReceivedInvocations: [(String)] = []
+    public var doSomethingDataString_IntAnyReturnValue: ([Int], [Any])!
+    public var doSomethingDataString_IntAnyClosure: ((String) throws -> ([Int], [Any]))?
 
     public func doSomething(_ data: String) throws -> ([Int], [Any]) {
-        DoSomethingDataString_IntAnyCallsCount += 1
-        DoSomethingDataString_IntAnyReceivedData = data
-        DoSomethingDataString_IntAnyReceivedInvocations.append(data)
-        if let error = DoSomethingDataString_IntAnyThrowableError {
+        doSomethingDataString_IntAnyCallsCount += 1
+        doSomethingDataString_IntAnyReceivedData = data
+        doSomethingDataString_IntAnyReceivedInvocations.append(data)
+        if let error = doSomethingDataString_IntAnyThrowableError {
             throw error
         }
-        if let DoSomethingDataString_IntAnyClosure = DoSomethingDataString_IntAnyClosure {
-            return try DoSomethingDataString_IntAnyClosure(data)
+        if let doSomethingDataString_IntAnyClosure = doSomethingDataString_IntAnyClosure {
+            return try doSomethingDataString_IntAnyClosure(data)
         } else {
-            return DoSomethingDataString_IntAnyReturnValue
+            return doSomethingDataString_IntAnyReturnValue
         }
     }
 
     //MARK: - doSomething
 
-    public var DoSomethingDataString_IntStringVoidCallsCount = 0
-    public var DoSomethingDataString_IntStringVoidCalled: Bool {
-        return DoSomethingDataString_IntStringVoidCallsCount > 0
+    public var doSomethingDataString_IntStringVoidCallsCount = 0
+    public var doSomethingDataString_IntStringVoidCalled: Bool {
+        return doSomethingDataString_IntStringVoidCallsCount > 0
     }
-    public var DoSomethingDataString_IntStringVoidReceivedData: (String)?
-    public var DoSomethingDataString_IntStringVoidReceivedInvocations: [(String)] = []
-    public var DoSomethingDataString_IntStringVoidReturnValue: ((([Int], [String]) -> Void))!
-    public var DoSomethingDataString_IntStringVoidClosure: ((String) -> (([Int], [String]) -> Void))?
+    public var doSomethingDataString_IntStringVoidReceivedData: (String)?
+    public var doSomethingDataString_IntStringVoidReceivedInvocations: [(String)] = []
+    public var doSomethingDataString_IntStringVoidReturnValue: ((([Int], [String]) -> Void))!
+    public var doSomethingDataString_IntStringVoidClosure: ((String) -> (([Int], [String]) -> Void))?
 
     public func doSomething(_ data: String) -> (([Int], [String]) -> Void) {
-        DoSomethingDataString_IntStringVoidCallsCount += 1
-        DoSomethingDataString_IntStringVoidReceivedData = data
-        DoSomethingDataString_IntStringVoidReceivedInvocations.append(data)
-        if let DoSomethingDataString_IntStringVoidClosure = DoSomethingDataString_IntStringVoidClosure {
-            return DoSomethingDataString_IntStringVoidClosure(data)
+        doSomethingDataString_IntStringVoidCallsCount += 1
+        doSomethingDataString_IntStringVoidReceivedData = data
+        doSomethingDataString_IntStringVoidReceivedInvocations.append(data)
+        if let doSomethingDataString_IntStringVoidClosure = doSomethingDataString_IntStringVoidClosure {
+            return doSomethingDataString_IntStringVoidClosure(data)
         } else {
-            return DoSomethingDataString_IntStringVoidReturnValue
+            return doSomethingDataString_IntStringVoidReturnValue
         }
     }
 
     //MARK: - doSomething
 
-    public var DoSomethingDataString_IntAnyVoidThrowableError: Error?
-    public var DoSomethingDataString_IntAnyVoidCallsCount = 0
-    public var DoSomethingDataString_IntAnyVoidCalled: Bool {
-        return DoSomethingDataString_IntAnyVoidCallsCount > 0
+    public var doSomethingDataString_IntAnyVoidThrowableError: Error?
+    public var doSomethingDataString_IntAnyVoidCallsCount = 0
+    public var doSomethingDataString_IntAnyVoidCalled: Bool {
+        return doSomethingDataString_IntAnyVoidCallsCount > 0
     }
-    public var DoSomethingDataString_IntAnyVoidReceivedData: (String)?
-    public var DoSomethingDataString_IntAnyVoidReceivedInvocations: [(String)] = []
-    public var DoSomethingDataString_IntAnyVoidReturnValue: ((([Int], [Any]) -> Void))!
-    public var DoSomethingDataString_IntAnyVoidClosure: ((String) throws -> (([Int], [Any]) -> Void))?
+    public var doSomethingDataString_IntAnyVoidReceivedData: (String)?
+    public var doSomethingDataString_IntAnyVoidReceivedInvocations: [(String)] = []
+    public var doSomethingDataString_IntAnyVoidReturnValue: ((([Int], [Any]) -> Void))!
+    public var doSomethingDataString_IntAnyVoidClosure: ((String) throws -> (([Int], [Any]) -> Void))?
 
     public func doSomething(_ data: String) throws -> (([Int], [Any]) -> Void) {
-        DoSomethingDataString_IntAnyVoidCallsCount += 1
-        DoSomethingDataString_IntAnyVoidReceivedData = data
-        DoSomethingDataString_IntAnyVoidReceivedInvocations.append(data)
-        if let error = DoSomethingDataString_IntAnyVoidThrowableError {
+        doSomethingDataString_IntAnyVoidCallsCount += 1
+        doSomethingDataString_IntAnyVoidReceivedData = data
+        doSomethingDataString_IntAnyVoidReceivedInvocations.append(data)
+        if let error = doSomethingDataString_IntAnyVoidThrowableError {
             throw error
         }
-        if let DoSomethingDataString_IntAnyVoidClosure = DoSomethingDataString_IntAnyVoidClosure {
-            return try DoSomethingDataString_IntAnyVoidClosure(data)
+        if let doSomethingDataString_IntAnyVoidClosure = doSomethingDataString_IntAnyVoidClosure {
+            return try doSomethingDataString_IntAnyVoidClosure(data)
         } else {
-            return DoSomethingDataString_IntAnyVoidReturnValue
+            return doSomethingDataString_IntAnyVoidReturnValue
         }
     }
 
@@ -1173,23 +1203,23 @@ class ReservedWordsProtocolMock: ReservedWordsProtocol {
 
     //MARK: - `continue`
 
-    var ContinueWithMessageStringStringCallsCount = 0
-    var ContinueWithMessageStringStringCalled: Bool {
-        return ContinueWithMessageStringStringCallsCount > 0
+    var continueWithMessageStringStringCallsCount = 0
+    var continueWithMessageStringStringCalled: Bool {
+        return continueWithMessageStringStringCallsCount > 0
     }
-    var ContinueWithMessageStringStringReceivedMessage: (String)?
-    var ContinueWithMessageStringStringReceivedInvocations: [(String)] = []
-    var ContinueWithMessageStringStringReturnValue: String!
-    var ContinueWithMessageStringStringClosure: ((String) -> String)?
+    var continueWithMessageStringStringReceivedMessage: (String)?
+    var continueWithMessageStringStringReceivedInvocations: [(String)] = []
+    var continueWithMessageStringStringReturnValue: String!
+    var continueWithMessageStringStringClosure: ((String) -> String)?
 
     func `continue`(with message: String) -> String {
-        ContinueWithMessageStringStringCallsCount += 1
-        ContinueWithMessageStringStringReceivedMessage = message
-        ContinueWithMessageStringStringReceivedInvocations.append(message)
-        if let ContinueWithMessageStringStringClosure = ContinueWithMessageStringStringClosure {
-            return ContinueWithMessageStringStringClosure(message)
+        continueWithMessageStringStringCallsCount += 1
+        continueWithMessageStringStringReceivedMessage = message
+        continueWithMessageStringStringReceivedInvocations.append(message)
+        if let continueWithMessageStringStringClosure = continueWithMessageStringStringClosure {
+            return continueWithMessageStringStringClosure(message)
         } else {
-            return ContinueWithMessageStringStringReturnValue
+            return continueWithMessageStringStringReturnValue
         }
     }
 
@@ -1201,36 +1231,36 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
 
     //MARK: - start
 
-    var StartCarStringOfModelStringVoidCallsCount = 0
-    var StartCarStringOfModelStringVoidCalled: Bool {
-        return StartCarStringOfModelStringVoidCallsCount > 0
+    var startCarStringOfModelStringVoidCallsCount = 0
+    var startCarStringOfModelStringVoidCalled: Bool {
+        return startCarStringOfModelStringVoidCallsCount > 0
     }
-    var StartCarStringOfModelStringVoidReceivedArguments: (car: String, model: String)?
-    var StartCarStringOfModelStringVoidReceivedInvocations: [(car: String, model: String)] = []
-    var StartCarStringOfModelStringVoidClosure: ((String, String) -> Void)?
+    var startCarStringOfModelStringVoidReceivedArguments: (car: String, model: String)?
+    var startCarStringOfModelStringVoidReceivedInvocations: [(car: String, model: String)] = []
+    var startCarStringOfModelStringVoidClosure: ((String, String) -> Void)?
 
     func start(car: String, of model: String) {
-        StartCarStringOfModelStringVoidCallsCount += 1
-        StartCarStringOfModelStringVoidReceivedArguments = (car: car, model: model)
-        StartCarStringOfModelStringVoidReceivedInvocations.append((car: car, model: model))
-        StartCarStringOfModelStringVoidClosure?(car, model)
+        startCarStringOfModelStringVoidCallsCount += 1
+        startCarStringOfModelStringVoidReceivedArguments = (car: car, model: model)
+        startCarStringOfModelStringVoidReceivedInvocations.append((car: car, model: model))
+        startCarStringOfModelStringVoidClosure?(car, model)
     }
 
     //MARK: - start
 
-    var StartPlaneStringOfModelStringVoidCallsCount = 0
-    var StartPlaneStringOfModelStringVoidCalled: Bool {
-        return StartPlaneStringOfModelStringVoidCallsCount > 0
+    var startPlaneStringOfModelStringVoidCallsCount = 0
+    var startPlaneStringOfModelStringVoidCalled: Bool {
+        return startPlaneStringOfModelStringVoidCallsCount > 0
     }
-    var StartPlaneStringOfModelStringVoidReceivedArguments: (plane: String, model: String)?
-    var StartPlaneStringOfModelStringVoidReceivedInvocations: [(plane: String, model: String)] = []
-    var StartPlaneStringOfModelStringVoidClosure: ((String, String) -> Void)?
+    var startPlaneStringOfModelStringVoidReceivedArguments: (plane: String, model: String)?
+    var startPlaneStringOfModelStringVoidReceivedInvocations: [(plane: String, model: String)] = []
+    var startPlaneStringOfModelStringVoidClosure: ((String, String) -> Void)?
 
     func start(plane: String, of model: String) {
-        StartPlaneStringOfModelStringVoidCallsCount += 1
-        StartPlaneStringOfModelStringVoidReceivedArguments = (plane: plane, model: model)
-        StartPlaneStringOfModelStringVoidReceivedInvocations.append((plane: plane, model: model))
-        StartPlaneStringOfModelStringVoidClosure?(plane, model)
+        startPlaneStringOfModelStringVoidCallsCount += 1
+        startPlaneStringOfModelStringVoidReceivedArguments = (plane: plane, model: model)
+        startPlaneStringOfModelStringVoidReceivedInvocations.append((plane: plane, model: model))
+        startPlaneStringOfModelStringVoidClosure?(plane, model)
     }
 
 }
@@ -1241,19 +1271,19 @@ class SingleOptionalParameterFunctionMock: SingleOptionalParameterFunction {
 
     //MARK: - send
 
-    var SendMessageStringVoidCallsCount = 0
-    var SendMessageStringVoidCalled: Bool {
-        return SendMessageStringVoidCallsCount > 0
+    var sendMessageStringVoidCallsCount = 0
+    var sendMessageStringVoidCalled: Bool {
+        return sendMessageStringVoidCallsCount > 0
     }
-    var SendMessageStringVoidReceivedMessage: (String)?
-    var SendMessageStringVoidReceivedInvocations: [(String)?] = []
-    var SendMessageStringVoidClosure: ((String?) -> Void)?
+    var sendMessageStringVoidReceivedMessage: (String)?
+    var sendMessageStringVoidReceivedInvocations: [(String)?] = []
+    var sendMessageStringVoidClosure: ((String?) -> Void)?
 
     func send(message: String?) {
-        SendMessageStringVoidCallsCount += 1
-        SendMessageStringVoidReceivedMessage = message
-        SendMessageStringVoidReceivedInvocations.append(message)
-        SendMessageStringVoidClosure?(message)
+        sendMessageStringVoidCallsCount += 1
+        sendMessageStringVoidReceivedMessage = message
+        sendMessageStringVoidReceivedInvocations.append(message)
+        sendMessageStringVoidClosure?(message)
     }
 
 }
@@ -1264,92 +1294,92 @@ class SomeProtocolMock: SomeProtocol {
 
     //MARK: - a
 
-    var AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidCallsCount = 0
-    var AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidCalled: Bool {
-        return AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidCallsCount > 0
+    var aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidCallsCount = 0
+    var aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidCalled: Bool {
+        return aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidCallsCount > 0
     }
-    var AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidReceivedArguments: (x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)?
-    var AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidReceivedInvocations: [(x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)] = []
-    var AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidClosure: (((any StubProtocol)?, (any StubProtocol)?, any StubProtocol) -> Void)?
+    var aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidReceivedArguments: (x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)?
+    var aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidReceivedInvocations: [(x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)] = []
+    var aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidClosure: (((any StubProtocol)?, (any StubProtocol)?, any StubProtocol) -> Void)?
 
     func a(_ x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol) {
-        AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidCallsCount += 1
-        AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidReceivedArguments = (x: x, y: y, z: z)
-        AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidReceivedInvocations.append((x: x, y: y, z: z))
-        AXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidClosure?(x, y, z)
+        aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidCallsCount += 1
+        aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidReceivedArguments = (x: x, y: y, z: z)
+        aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidReceivedInvocations.append((x: x, y: y, z: z))
+        aXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolVoidClosure?(x, y, z)
     }
 
     //MARK: - b
 
-    var BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringCallsCount = 0
-    var BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringCalled: Bool {
-        return BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringCallsCount > 0
+    var bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringCallsCount = 0
+    var bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringCalled: Bool {
+        return bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringCallsCount > 0
     }
-    var BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReceivedArguments: (x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)?
-    var BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReceivedInvocations: [(x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)] = []
-    var BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReturnValue: String!
-    var BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringClosure: (((any StubProtocol)?, (any StubProtocol)?, any StubProtocol) async -> String)?
+    var bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReceivedArguments: (x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)?
+    var bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReceivedInvocations: [(x: (any StubProtocol)?, y: (any StubProtocol)?, z: any StubProtocol)] = []
+    var bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReturnValue: String!
+    var bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringClosure: (((any StubProtocol)?, (any StubProtocol)?, any StubProtocol) async -> String)?
 
     func b(x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol) async -> String {
-        BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringCallsCount += 1
-        BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReceivedArguments = (x: x, y: y, z: z)
-        BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReceivedInvocations.append((x: x, y: y, z: z))
-        if let BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringClosure = BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringClosure {
-            return await BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringClosure(x, y, z)
+        bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringCallsCount += 1
+        bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReceivedArguments = (x: x, y: y, z: z)
+        bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReceivedInvocations.append((x: x, y: y, z: z))
+        if let bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringClosure = bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringClosure {
+            return await bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringClosure(x, y, z)
         } else {
-            return BXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReturnValue
+            return bXSomeStubProtocolYSomeStubProtocolZSomeStubProtocolStringReturnValue
         }
     }
 
     //MARK: - someConfusingFuncName
 
-    var SomeConfusingFuncNameXSomeStubProtocolVoidCallsCount = 0
-    var SomeConfusingFuncNameXSomeStubProtocolVoidCalled: Bool {
-        return SomeConfusingFuncNameXSomeStubProtocolVoidCallsCount > 0
+    var someConfusingFuncNameXSomeStubProtocolVoidCallsCount = 0
+    var someConfusingFuncNameXSomeStubProtocolVoidCalled: Bool {
+        return someConfusingFuncNameXSomeStubProtocolVoidCallsCount > 0
     }
-    var SomeConfusingFuncNameXSomeStubProtocolVoidReceivedX: (any StubProtocol)?
-    var SomeConfusingFuncNameXSomeStubProtocolVoidReceivedInvocations: [(any StubProtocol)] = []
-    var SomeConfusingFuncNameXSomeStubProtocolVoidClosure: ((any StubProtocol) -> Void)?
+    var someConfusingFuncNameXSomeStubProtocolVoidReceivedX: (any StubProtocol)?
+    var someConfusingFuncNameXSomeStubProtocolVoidReceivedInvocations: [(any StubProtocol)] = []
+    var someConfusingFuncNameXSomeStubProtocolVoidClosure: ((any StubProtocol) -> Void)?
 
     func someConfusingFuncName(x: some StubProtocol) {
-        SomeConfusingFuncNameXSomeStubProtocolVoidCallsCount += 1
-        SomeConfusingFuncNameXSomeStubProtocolVoidReceivedX = x
-        SomeConfusingFuncNameXSomeStubProtocolVoidReceivedInvocations.append(x)
-        SomeConfusingFuncNameXSomeStubProtocolVoidClosure?(x)
+        someConfusingFuncNameXSomeStubProtocolVoidCallsCount += 1
+        someConfusingFuncNameXSomeStubProtocolVoidReceivedX = x
+        someConfusingFuncNameXSomeStubProtocolVoidReceivedInvocations.append(x)
+        someConfusingFuncNameXSomeStubProtocolVoidClosure?(x)
     }
 
     //MARK: - c
 
-    var CSomeConfusingArgumentNameSomeStubProtocolVoidCallsCount = 0
-    var CSomeConfusingArgumentNameSomeStubProtocolVoidCalled: Bool {
-        return CSomeConfusingArgumentNameSomeStubProtocolVoidCallsCount > 0
+    var cSomeConfusingArgumentNameSomeStubProtocolVoidCallsCount = 0
+    var cSomeConfusingArgumentNameSomeStubProtocolVoidCalled: Bool {
+        return cSomeConfusingArgumentNameSomeStubProtocolVoidCallsCount > 0
     }
-    var CSomeConfusingArgumentNameSomeStubProtocolVoidReceivedSomeConfusingArgumentName: (any StubProtocol)?
-    var CSomeConfusingArgumentNameSomeStubProtocolVoidReceivedInvocations: [(any StubProtocol)] = []
-    var CSomeConfusingArgumentNameSomeStubProtocolVoidClosure: ((any StubProtocol) -> Void)?
+    var cSomeConfusingArgumentNameSomeStubProtocolVoidReceivedSomeConfusingArgumentName: (any StubProtocol)?
+    var cSomeConfusingArgumentNameSomeStubProtocolVoidReceivedInvocations: [(any StubProtocol)] = []
+    var cSomeConfusingArgumentNameSomeStubProtocolVoidClosure: ((any StubProtocol) -> Void)?
 
     func c(someConfusingArgumentName: some StubProtocol) {
-        CSomeConfusingArgumentNameSomeStubProtocolVoidCallsCount += 1
-        CSomeConfusingArgumentNameSomeStubProtocolVoidReceivedSomeConfusingArgumentName = someConfusingArgumentName
-        CSomeConfusingArgumentNameSomeStubProtocolVoidReceivedInvocations.append(someConfusingArgumentName)
-        CSomeConfusingArgumentNameSomeStubProtocolVoidClosure?(someConfusingArgumentName)
+        cSomeConfusingArgumentNameSomeStubProtocolVoidCallsCount += 1
+        cSomeConfusingArgumentNameSomeStubProtocolVoidReceivedSomeConfusingArgumentName = someConfusingArgumentName
+        cSomeConfusingArgumentNameSomeStubProtocolVoidReceivedInvocations.append(someConfusingArgumentName)
+        cSomeConfusingArgumentNameSomeStubProtocolVoidClosure?(someConfusingArgumentName)
     }
 
     //MARK: - d
 
-    var DXSomeStubWithSomeNameProtocolVoidCallsCount = 0
-    var DXSomeStubWithSomeNameProtocolVoidCalled: Bool {
-        return DXSomeStubWithSomeNameProtocolVoidCallsCount > 0
+    var dXSomeStubWithSomeNameProtocolVoidCallsCount = 0
+    var dXSomeStubWithSomeNameProtocolVoidCalled: Bool {
+        return dXSomeStubWithSomeNameProtocolVoidCallsCount > 0
     }
-    var DXSomeStubWithSomeNameProtocolVoidReceivedX: (any StubWithSomeNameProtocol)?
-    var DXSomeStubWithSomeNameProtocolVoidReceivedInvocations: [(any StubWithSomeNameProtocol)?] = []
-    var DXSomeStubWithSomeNameProtocolVoidClosure: (((any StubWithSomeNameProtocol)?) -> Void)?
+    var dXSomeStubWithSomeNameProtocolVoidReceivedX: (any StubWithSomeNameProtocol)?
+    var dXSomeStubWithSomeNameProtocolVoidReceivedInvocations: [(any StubWithSomeNameProtocol)?] = []
+    var dXSomeStubWithSomeNameProtocolVoidClosure: (((any StubWithSomeNameProtocol)?) -> Void)?
 
     func d(_ x: (some StubWithSomeNameProtocol)?) {
-        DXSomeStubWithSomeNameProtocolVoidCallsCount += 1
-        DXSomeStubWithSomeNameProtocolVoidReceivedX = x
-        DXSomeStubWithSomeNameProtocolVoidReceivedInvocations.append(x)
-        DXSomeStubWithSomeNameProtocolVoidClosure?(x)
+        dXSomeStubWithSomeNameProtocolVoidCallsCount += 1
+        dXSomeStubWithSomeNameProtocolVoidReceivedX = x
+        dXSomeStubWithSomeNameProtocolVoidReceivedInvocations.append(x)
+        dXSomeStubWithSomeNameProtocolVoidClosure?(x)
     }
 
 }
@@ -1360,33 +1390,33 @@ class StaticMethodProtocolMock: StaticMethodProtocol {
     static func reset()
     {
          //MARK: - staticFunction
-        StaticFunctionStringStringCallsCount = 0
-        StaticFunctionStringStringReceived = nil
-        StaticFunctionStringStringReceivedInvocations = []
-        StaticFunctionStringStringClosure = nil
+        staticFunctionStringStringCallsCount = 0
+        staticFunctionStringStringReceived = nil
+        staticFunctionStringStringReceivedInvocations = []
+        staticFunctionStringStringClosure = nil
 
 
     }
 
     //MARK: - staticFunction
 
-    static var StaticFunctionStringStringCallsCount = 0
-    static var StaticFunctionStringStringCalled: Bool {
-        return StaticFunctionStringStringCallsCount > 0
+    static var staticFunctionStringStringCallsCount = 0
+    static var staticFunctionStringStringCalled: Bool {
+        return staticFunctionStringStringCallsCount > 0
     }
-    static var StaticFunctionStringStringReceived: (String)?
-    static var StaticFunctionStringStringReceivedInvocations: [(String)] = []
-    static var StaticFunctionStringStringReturnValue: String!
-    static var StaticFunctionStringStringClosure: ((String) -> String)?
+    static var staticFunctionStringStringReceived: (String)?
+    static var staticFunctionStringStringReceivedInvocations: [(String)] = []
+    static var staticFunctionStringStringReturnValue: String!
+    static var staticFunctionStringStringClosure: ((String) -> String)?
 
     static func staticFunction(_ : String) -> String {
-        StaticFunctionStringStringCallsCount += 1
-        StaticFunctionStringStringReceived = 
-        StaticFunctionStringStringReceivedInvocations.append()
-        if let StaticFunctionStringStringClosure = StaticFunctionStringStringClosure {
-            return StaticFunctionStringStringClosure()
+        staticFunctionStringStringCallsCount += 1
+        staticFunctionStringStringReceived = 
+        staticFunctionStringStringReceivedInvocations.append()
+        if let staticFunctionStringStringClosure = staticFunctionStringStringClosure {
+            return staticFunctionStringStringClosure()
         } else {
-            return StaticFunctionStringStringReturnValue
+            return staticFunctionStringStringReturnValue
         }
     }
 
@@ -1422,41 +1452,41 @@ class ThrowableProtocolMock: ThrowableProtocol {
 
     //MARK: - doOrThrow
 
-    var DoOrThrowStringThrowableError: Error?
-    var DoOrThrowStringCallsCount = 0
-    var DoOrThrowStringCalled: Bool {
-        return DoOrThrowStringCallsCount > 0
+    var doOrThrowStringThrowableError: Error?
+    var doOrThrowStringCallsCount = 0
+    var doOrThrowStringCalled: Bool {
+        return doOrThrowStringCallsCount > 0
     }
-    var DoOrThrowStringReturnValue: String!
-    var DoOrThrowStringClosure: (() throws -> String)?
+    var doOrThrowStringReturnValue: String!
+    var doOrThrowStringClosure: (() throws -> String)?
 
     func doOrThrow() throws -> String {
-        DoOrThrowStringCallsCount += 1
-        if let error = DoOrThrowStringThrowableError {
+        doOrThrowStringCallsCount += 1
+        if let error = doOrThrowStringThrowableError {
             throw error
         }
-        if let DoOrThrowStringClosure = DoOrThrowStringClosure {
-            return try DoOrThrowStringClosure()
+        if let doOrThrowStringClosure = doOrThrowStringClosure {
+            return try doOrThrowStringClosure()
         } else {
-            return DoOrThrowStringReturnValue
+            return doOrThrowStringReturnValue
         }
     }
 
     //MARK: - doOrThrowVoid
 
-    var DoOrThrowVoidVoidThrowableError: Error?
-    var DoOrThrowVoidVoidCallsCount = 0
-    var DoOrThrowVoidVoidCalled: Bool {
-        return DoOrThrowVoidVoidCallsCount > 0
+    var doOrThrowVoidVoidThrowableError: Error?
+    var doOrThrowVoidVoidCallsCount = 0
+    var doOrThrowVoidVoidCalled: Bool {
+        return doOrThrowVoidVoidCallsCount > 0
     }
-    var DoOrThrowVoidVoidClosure: (() throws -> Void)?
+    var doOrThrowVoidVoidClosure: (() throws -> Void)?
 
     func doOrThrowVoid() throws {
-        DoOrThrowVoidVoidCallsCount += 1
-        if let error = DoOrThrowVoidVoidThrowableError {
+        doOrThrowVoidVoidCallsCount += 1
+        if let error = doOrThrowVoidVoidThrowableError {
             throw error
         }
-        try DoOrThrowVoidVoidClosure?()
+        try doOrThrowVoidVoidClosure?()
     }
 
 }
@@ -1526,33 +1556,6 @@ class VariablesProtocolMock: VariablesProtocol {
     var universityMarks: [String: Int] = [:]
 
 
-}
-class ProtocolWithMethodWithGenericParameters: SomeProtocol {
-
-
-
-
-    //MARK: - execute
-
-    var executeParamResultIntErrorResultStringErrorCallsCount = 0
-    var executeParamResultIntErrorResultStringErrorCalled: Bool {
-        return executeParamResultIntErrorResultStringErrorCallsCount > 0
-    }
-    var executeParamResultIntErrorResultStringErrorReceivedParam: (Result<Int, Error>)?
-    var executeParamResultIntErrorResultStringErrorReceivedInvocations: [(Result<Int, Error>)] = []
-    var executeParamResultIntErrorResultStringErrorReturnValue: Result<String, Error>!
-    var executeParamResultIntErrorResultStringErrorClosure: ((Result<Int, Error>) -> Result<String, Error>)?
-
-    func execute(param: Result<Int, Error>) -> Result<String, Error> {
-        executeParamResultIntErrorResultStringErrorCallsCount += 1
-        executeParamResultIntErrorResultStringErrorReceivedParam = param
-        executeParamResultIntErrorResultStringErrorReceivedInvocations.append(param)
-        if let executeParamResultIntErrorResultStringErrorClosure = executeParamResultIntErrorResultStringErrorClosure {
-            return executeParamResultIntErrorResultStringErrorClosure(param)
-        } else {
-            return executeParamResultIntErrorResultStringErrorReturnValue
-        }
-    }
 
 
 }


### PR DESCRIPTION
## Context

[#1252](https://github.com/krzysztofzablocki/Sourcery/issues/1252) introduced support for generic arguments to be mockable after a regression in 2.1.3 release (particularly related to #1240).

This PR updates the entire `AutoMockable.expected` to resolve unit test failures on both Linux and macOS.

## Details

To get currently generated `AutoMockable.expected` to update it, one needs to:

1. put breakpoint in `TemplatesTests.swift` on **line 90** (`expect(generatedFileFilteredLines).to(equal(expectedFileFilteredLines))`)
2. print value of `generatedFilePath`
3. open file located at the printed path
4. copy contents and paste into `AutoMockable.expected` file, removing redundant new lines (there'd be a few).