### PR TITLE
Changed action triggers

### DIFF
--- a/.github/workflows/release_macOS.yml
+++ b/.github/workflows/release_macOS.yml
@@ -1,10 +1,6 @@
 name: release macOS
 
 on:
-  workflow_run:
-    workflows: [test macOS]
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       ref:
@@ -16,8 +12,9 @@ on:
       - '*'
       
 jobs:
+  tests:
+    uses: ./.github/workflows/test_macOS.yml
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Build Sourcery for macOS
     runs-on: macos-13
     steps:
@@ -95,4 +92,4 @@ jobs:
         with:
           name: ${{ steps.build.outputs.ARTIFACTBUNDLENAME }}
           path: "~/${{ steps.build.outputs.ARTIFACTBUNDLENAME }}"
-          retention-days: 5          
+          retention-days: 5

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -1,10 +1,6 @@
 name: release ubuntu
 
 on:
-  workflow_run:
-    workflows: [test ubuntu]
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       ref:
@@ -16,8 +12,9 @@ on:
       - '*'
 
 jobs:
+  tests:
+    uses: ./.github/workflows/test_ubuntu.yml
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Build Sourcery for Ubuntu (latest)
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Context

Follow up of #1254 - release actions are not triggered. For some reason, `workflow_run` is not triggered, i.e. tests are not run when a new tag is created and release action is attempting to start.

To fix this, `workflow_run` is replaced with a separate `job` for tests.