### PR TITLE
ClosureParameter isVariadic Support

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -140,7 +140,8 @@ extension TypeName {
                   argumentLabel: firstName,
                   name: node.secondName?.text.trimmed ?? firstName,
                   typeName: typeName,
-                  isInout: specifiers.isInOut
+                  isInout: specifiers.isInOut,
+                  isVariadic: node.type.as(PackExpansionTypeSyntax.self)?.ellipsis != nil
                 )
             }
             let returnTypeName = TypeName(typeIdentifier.returnType)

--- a/SourceryRuntime/Sources/AST/ClosureParameter.swift
+++ b/SourceryRuntime/Sources/AST/ClosureParameter.swift
@@ -1,7 +1,7 @@
+#if canImport(ObjectiveC)
 import Foundation
 
 // sourcery: skipDiffing
-#if canImport(ObjectiveC)
 @objcMembers
 public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
     /// Parameter external name

--- a/SourceryRuntime/Sources/AST/ClosureParameter.swift
+++ b/SourceryRuntime/Sources/AST/ClosureParameter.swift
@@ -21,6 +21,9 @@ public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
     /// Parameter type, if known
     public var type: Type?
 
+    /// Parameter if the argument has a variadic type or not
+    public var isVariadic: Bool
+
     /// Parameter type attributes, i.e. `@escaping`
     public var typeAttributes: AttributeList {
         return typeName.attributes
@@ -34,7 +37,8 @@ public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
 
     /// :nodoc:
     public init(argumentLabel: String? = nil, name: String? = nil, typeName: TypeName, type: Type? = nil,
-                defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false) {
+                defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false, 
+                isVariadic: Bool = false) {
         self.typeName = typeName
         self.argumentLabel = argumentLabel
         self.name = name
@@ -42,10 +46,11 @@ public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
         self.defaultValue = defaultValue
         self.annotations = annotations
         self.`inout` = isInout
+        self.isVariadic = isVariadic
     }
 
     public var asSource: String {
-        let typeInfo = "\(`inout` ? "inout " : "")\(typeName.asSource)"
+        let typeInfo = "\(`inout` ? "inout " : "")\(typeName.asSource)\(isVariadic ? "..." : "")"
         if argumentLabel?.nilIfNotValidParameterName == nil, name?.nilIfNotValidParameterName == nil {
             return typeInfo
         }
@@ -68,6 +73,7 @@ public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
         hasher.combine(self.name)
         hasher.combine(self.typeName)
         hasher.combine(self.`inout`)
+        hasher.combine(self.isVariadic)
         hasher.combine(self.defaultValue)
         hasher.combine(self.annotations)
         return hasher.finalize()
@@ -94,6 +100,7 @@ public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
         if self.name != rhs.name { return false }
         if self.typeName != rhs.typeName { return false }
         if self.`inout` != rhs.`inout` { return false }
+        if self.isVariadic != rhs.isVariadic { return false }
         if self.defaultValue != rhs.defaultValue { return false }
         if self.annotations != rhs.annotations { return false }
         return true
@@ -112,6 +119,7 @@ public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
                     fatalError()
                  }; self.typeName = typeName
                 self.`inout` = aDecoder.decode(forKey: "`inout`")
+                self.isVariadic = aDecoder.decode(forKey: "isVariadic")
                 self.type = aDecoder.decode(forKey: "type")
                 self.defaultValue = aDecoder.decode(forKey: "defaultValue")
                 guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
@@ -128,6 +136,7 @@ public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
                 aCoder.encode(self.name, forKey: "name")
                 aCoder.encode(self.typeName, forKey: "typeName")
                 aCoder.encode(self.`inout`, forKey: "`inout`")
+                aCoder.encode(self.isVariadic, forKey: "isVariadic")
                 aCoder.encode(self.type, forKey: "type")
                 aCoder.encode(self.defaultValue, forKey: "defaultValue")
                 aCoder.encode(self.annotations, forKey: "annotations")

--- a/SourceryRuntime/Sources/AST/ClosureParameter_Linux.swift
+++ b/SourceryRuntime/Sources/AST/ClosureParameter_Linux.swift
@@ -1,7 +1,11 @@
+#if !canImport(ObjectiveC)
 import Foundation
+// For DynamicMemberLookup we need to import Stencil,
+// however, this is different from SourceryRuntime.content.generated.swift, because
+// it cannot reference Stencil
+import Stencil
 
 // sourcery: skipDiffing
-#if !canImport(ObjectiveC)
 public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated, DynamicMemberLookup {
     public subscript(dynamicMember member: String) -> Any? {
         switch member {
@@ -168,3 +172,4 @@ extension Array where Element == ClosureParameter {
         "(\(map { $0.asSource }.joined(separator: ", ")))"
     }
 }
+#endif

--- a/SourceryRuntime/Sources/AST/ClosureParameter_Linux.swift
+++ b/SourceryRuntime/Sources/AST/ClosureParameter_Linux.swift
@@ -1,9 +1,28 @@
 import Foundation
 
 // sourcery: skipDiffing
-#if canImport(ObjectiveC)
-@objcMembers
-public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated {
+#if !canImport(ObjectiveC)
+public final class ClosureParameter: NSObject, SourceryModel, Typed, Annotated, DynamicMemberLookup {
+    public subscript(dynamicMember member: String) -> Any? {
+        switch member {
+        case "argumentLabel":
+            return argumentLabel
+        case "name":
+            return name
+        case "typeName":
+            return typeName
+        case "inout":
+            return `inout`
+        case "type":
+            return type
+        case "isVariadic":
+            return isVariadic
+        case "defaultValue":
+            return defaultValue
+        default:
+            fatalError("unable to lookup: \(member) in \(self)")
+        }
+    }
     /// Parameter external name
     public var argumentLabel: String?
 

--- a/SourceryRuntime/Sources/AST/TypeName/Closure_Linux.swift
+++ b/SourceryRuntime/Sources/AST/TypeName/Closure_Linux.swift
@@ -1,10 +1,42 @@
-#if canImport(ObjectiveC)
+#if !canImport(ObjectiveC)
 import Foundation
-
+// For DynamicMemberLookup we need to import Stencil,
+// however, this is different from SourceryRuntime.content.generated.swift, because
+// it cannot reference Stencil
+import Stencil
 /// Describes closure type
-@objcMembers
-public final class ClosureType: NSObject, SourceryModel, Diffable {
 
+public final class ClosureType: NSObject, SourceryModel, Diffable, DynamicMemberLookup {
+    public subscript(dynamicMember member: String) -> Any? {
+        switch member {
+            case "name":
+                return name
+            case "parameters":
+                return parameters
+            case "returnTypeName":
+                return returnTypeName
+            case "actualReturnTypeName":
+                return actualReturnTypeName
+            case "returnType":
+                return returnType
+            case "isOptionalReturnType":
+                return isOptionalReturnType
+            case "isImplicitlyUnwrappedOptionalReturnType":
+                return isImplicitlyUnwrappedOptionalReturnType
+            case "unwrappedReturnTypeName":
+                return unwrappedReturnTypeName
+            case "isAsync":
+                return isAsync
+            case "asyncKeyword":
+                return asyncKeyword
+            case "throws":
+                return `throws`
+            case "throwsOrRethrowsKeyword":
+                return throwsOrRethrowsKeyword
+            default:
+                fatalError("unable to lookup: \(member) in \(self)")
+        }
+    }
     /// Type name used in declaration with stripped whitespaces and new lines
     public let name: String
 

--- a/SourceryRuntime/Sources/AST/TypeName/TypeName_Linux.swift
+++ b/SourceryRuntime/Sources/AST/TypeName/TypeName_Linux.swift
@@ -27,6 +27,8 @@ public final class TypeName: NSObject, SourceryModelWithoutDescription, Lossless
                 return isVoid
             case "isClosure":
                 return isClosure
+            case "closure":
+                return closure
             default:
                 fatalError("unable to lookup: \(member) in \(self)")
         }

--- a/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
@@ -11,17 +11,29 @@ import SourceryRuntime
 class TypeNameSpec: QuickSpec {
     override func spec() {
         describe("TypeName") {
-            func typeName(_ code: String) -> TypeName {
+            func variableTypeName(_ variableType: String) -> TypeName {
                 let wrappedCode =
                   """
                   struct Wrapper {
-                      var myFoo: \(code)
+                      var myFoo: \(variableType)
                   }
                   """
                 guard let parser = try? makeParser(for: wrappedCode) else { fail(); return TypeName(name: "") }
                 let result = try? parser.parse()
                 let variable = result?.types.first?.variables.first
                 return variable?.typeName ?? TypeName(name: "")
+            }
+            func funcArgumentTypeName(_ functionArgumentType: String) -> MethodParameter? {
+                let wrappedCode =
+                  """
+                  struct Wrapper {
+                    func myFunc(_ arg: \(functionArgumentType)) {}
+                  }
+                  """
+                guard let parser = try? makeParser(for: wrappedCode) else { fail(); return MethodParameter(name: "", typeName: TypeName(name: "")) }
+                let result = try? parser.parse()
+                let methodParameter = result?.types.first?.methods.first?.parameters.first
+                return methodParameter
             }
 
             func typeNameFromTypealias(_ code: String) -> TypeName {
@@ -33,158 +45,164 @@ class TypeNameSpec: QuickSpec {
 
             context("given optional type with short syntax") {
                 it("reports optional true") {
-                    expect(typeName("Int?").isOptional).to(beTrue())
-                    expect(typeName("Int!").isOptional).to(beTrue())
-                    expect(typeName("Int?").isImplicitlyUnwrappedOptional).to(beFalse())
-                    expect(typeName("Int!").isImplicitlyUnwrappedOptional).to(beTrue())
+                    expect(variableTypeName("Int?").isOptional).to(beTrue())
+                    expect(variableTypeName("Int!").isOptional).to(beTrue())
+                    expect(variableTypeName("Int?").isImplicitlyUnwrappedOptional).to(beFalse())
+                    expect(variableTypeName("Int!").isImplicitlyUnwrappedOptional).to(beTrue())
                 }
 
                 it("reports non-optional type for unwrappedTypeName") {
-                    expect(typeName("Int?").unwrappedTypeName).to(equal("Int"))
-                    expect(typeName("Int!").unwrappedTypeName).to(equal("Int"))
+                    expect(variableTypeName("Int?").unwrappedTypeName).to(equal("Int"))
+                    expect(variableTypeName("Int!").unwrappedTypeName).to(equal("Int"))
                 }
             }
 
             context("given inout type") {
                 it("reports correct unwrappedTypeName") {
-                    expect(typeName("inout String").unwrappedTypeName).to(equal("String"))
+                    expect(variableTypeName("inout String").unwrappedTypeName).to(equal("String"))
                 }
             }
 
             context("given optional type with long generic syntax") {
                 it("reports optional true") {
-                    expect(typeName("Optional<Int>").isOptional).to(beTrue())
-                    expect(typeName("Optional<Int>").isImplicitlyUnwrappedOptional).to(beFalse())
+                    expect(variableTypeName("Optional<Int>").isOptional).to(beTrue())
+                    expect(variableTypeName("Optional<Int>").isImplicitlyUnwrappedOptional).to(beFalse())
                 }
 
                 it("reports non-optional type for unwrappedTypeName") {
-                    expect(typeName("Optional<Int>").unwrappedTypeName).to(equal("Int"))
+                    expect(variableTypeName("Optional<Int>").unwrappedTypeName).to(equal("Int"))
                 }
             }
 
             context("given type wrapped with extra closures") {
                 it("unwraps it completely") {
-                    expect(typeName("(Int)").unwrappedTypeName).to(equal("Int"))
-                    expect(typeName("(Int)?").unwrappedTypeName).to(equal("Int"))
-                    expect(typeName("(Int, Int)").unwrappedTypeName).to(equal("(Int, Int)"))
-                    expect(typeName("(Int)").unwrappedTypeName).to(equal("Int"))
-                    expect(typeName("((Int, Int))").unwrappedTypeName).to(equal("(Int, Int)"))
-                    expect(typeName("((Int, Int) -> ())").unwrappedTypeName).to(equal("(Int, Int) -> ()"))
+                    expect(variableTypeName("(Int)").unwrappedTypeName).to(equal("Int"))
+                    expect(variableTypeName("(Int)?").unwrappedTypeName).to(equal("Int"))
+                    expect(variableTypeName("(Int, Int)").unwrappedTypeName).to(equal("(Int, Int)"))
+                    expect(variableTypeName("(Int)").unwrappedTypeName).to(equal("Int"))
+                    expect(variableTypeName("((Int, Int))").unwrappedTypeName).to(equal("(Int, Int)"))
+                    expect(variableTypeName("((Int, Int) -> ())").unwrappedTypeName).to(equal("(Int, Int) -> ()"))
                 }
             }
 
             context("given tuple type") {
                 it("reports tuple correctly") {
-                    expect(typeName("(Int, Int)").isTuple).to(beTrue())
-                    expect(typeName("(Int, Int)?").isTuple).to(beTrue())
-                    expect(typeName("(Int)").isTuple).to(beFalse())
-                    expect(typeName("Int").isTuple).to(beFalse())
-                    expect(typeName("(Int) -> (Int)").isTuple).to(beFalse())
-                    expect(typeName("(Int, Int) -> (Int)").isTuple).to(beFalse())
-                    expect(typeName("(Int, (Int, Int) -> (Int))").isTuple).to(beTrue())
-                    expect(typeName("(Int, (Int, Int))").isTuple).to(beTrue())
-                    expect(typeName("(Int, (Int) -> (Int -> Int))").isTuple).to(beTrue())
+                    expect(variableTypeName("(Int, Int)").isTuple).to(beTrue())
+                    expect(variableTypeName("(Int, Int)?").isTuple).to(beTrue())
+                    expect(variableTypeName("(Int)").isTuple).to(beFalse())
+                    expect(variableTypeName("Int").isTuple).to(beFalse())
+                    expect(variableTypeName("(Int) -> (Int)").isTuple).to(beFalse())
+                    expect(variableTypeName("(Int, Int) -> (Int)").isTuple).to(beFalse())
+                    expect(variableTypeName("(Int, (Int, Int) -> (Int))").isTuple).to(beTrue())
+                    expect(variableTypeName("(Int, (Int, Int))").isTuple).to(beTrue())
+                    expect(variableTypeName("(Int, (Int) -> (Int -> Int))").isTuple).to(beTrue())
                 }
             }
 
             context("given array type") {
                 it("reports array correctly") {
-                    expect(typeName("Array<Int>").isArray).to(beTrue())
-                    expect(typeName("[Int]").isArray).to(beTrue())
-                    expect(typeName("[[Int]]").isArray).to(beTrue())
-                    expect(typeName("[[Int: Int]]").isArray).to(beTrue())
+                    expect(variableTypeName("Array<Int>").isArray).to(beTrue())
+                    expect(variableTypeName("[Int]").isArray).to(beTrue())
+                    expect(variableTypeName("[[Int]]").isArray).to(beTrue())
+                    expect(variableTypeName("[[Int: Int]]").isArray).to(beTrue())
                 }
 
                 it("reports dictionary correctly") {
-                    expect(typeName("[Int]").isDictionary).to(beFalse())
-                    expect(typeName("[[Int]]").isDictionary).to(beFalse())
-                    expect(typeName("[[Int: Int]]").isDictionary).to(beFalse())
+                    expect(variableTypeName("[Int]").isDictionary).to(beFalse())
+                    expect(variableTypeName("[[Int]]").isDictionary).to(beFalse())
+                    expect(variableTypeName("[[Int: Int]]").isDictionary).to(beFalse())
                 }
             }
 
             context("given dictionary type") {
                 context("as name") {
                     it("reports dictionary correctly") {
-                        expect(typeName("Dictionary<Int, Int>").isDictionary).to(beTrue())
-                        expect(typeName("[Int: Int]").isDictionary).to(beTrue())
-                        expect(typeName("[[Int]: [Int]]").isDictionary).to(beTrue())
-                        expect(typeName("[Int: [Int: Int]]").isDictionary).to(beTrue())
+                        expect(variableTypeName("Dictionary<Int, Int>").isDictionary).to(beTrue())
+                        expect(variableTypeName("[Int: Int]").isDictionary).to(beTrue())
+                        expect(variableTypeName("[[Int]: [Int]]").isDictionary).to(beTrue())
+                        expect(variableTypeName("[Int: [Int: Int]]").isDictionary).to(beTrue())
                     }
 
                     it("reports array correctly") {
-                        expect(typeName("[Int: Int]").isArray).to(beFalse())
-                        expect(typeName("[[Int]: [Int]]").isArray).to(beFalse())
-                        expect(typeName("[Int: [Int: Int]]").isArray).to(beFalse())
+                        expect(variableTypeName("[Int: Int]").isArray).to(beFalse())
+                        expect(variableTypeName("[[Int]: [Int]]").isArray).to(beFalse())
+                        expect(variableTypeName("[Int: [Int: Int]]").isArray).to(beFalse())
                     }
                 }
             }
 
             context("given closure type") {
                 it("reports closure correctly") {
-                    expect(typeName("() -> ()").isClosure).to(beTrue())
-                    expect(typeName("(() -> ())?").isClosure).to(beTrue())
-                    expect(typeName("(Int, Int) -> ()").isClosure).to(beTrue())
-                    expect(typeName("() -> (Int, Int)").isClosure).to(beTrue())
-                    expect(typeName("() -> (Int) -> (Int)").isClosure).to(beTrue())
-                    expect(typeName("((Int) -> (Int)) -> ()").isClosure).to(beTrue())
-                    expect(typeName("(Foo<String>) -> Bool").isClosure).to(beTrue())
-                    expect(typeName("(Int) -> Foo<Bool>").isClosure).to(beTrue())
-                    expect(typeName("(Foo<String>) -> Foo<Bool>").isClosure).to(beTrue())
-                    expect(typeName("((Int, Int) -> (), Int)").isClosure).to(beFalse())
+                    expect(variableTypeName("() -> ()").isClosure).to(beTrue())
+                    expect(variableTypeName("(() -> ())?").isClosure).to(beTrue())
+                    expect(variableTypeName("(Int, Int) -> ()").isClosure).to(beTrue())
+                    expect(variableTypeName("() -> (Int, Int)").isClosure).to(beTrue())
+                    expect(variableTypeName("() -> (Int) -> (Int)").isClosure).to(beTrue())
+                    expect(variableTypeName("((Int) -> (Int)) -> ()").isClosure).to(beTrue())
+                    expect(variableTypeName("(Foo<String>) -> Bool").isClosure).to(beTrue())
+                    expect(variableTypeName("(Int) -> Foo<Bool>").isClosure).to(beTrue())
+                    expect(variableTypeName("(Foo<String>) -> Foo<Bool>").isClosure).to(beTrue())
+                    expect(variableTypeName("((Int, Int) -> (), Int)").isClosure).to(beFalse())
                     expect(typeNameFromTypealias("(Foo) -> Bar").isClosure).to(beTrue())
                     expect(typeNameFromTypealias("(Foo) -> Bar & Baz").isClosure).to(beTrue())
                 }
 
-                it("reports optional status correctly") {
-                    expect(typeName("() -> ()").isOptional).to(beFalse())
-                    expect(typeName("() -> ()?").isOptional).to(beFalse())
-                    expect(typeName("() -> ()!").isImplicitlyUnwrappedOptional).to(beFalse())
-                    expect(typeName("(() -> ()!)").isImplicitlyUnwrappedOptional).to(beFalse())
-                    expect(typeName("Optional<()> -> ()").isOptional).to(beFalse())
-                    expect(typeName("(() -> ()?)").isOptional).to(beFalse())
+                it("reports variadicity of closure arguments correctly") {
+                    expect(funcArgumentTypeName("((String...) -> Int)")?.isVariadic).to(beFalse())
+                    expect(funcArgumentTypeName("((String...) -> Int)")?.isClosure).to(beTrue())
+                    expect(funcArgumentTypeName("((String...) -> Int)")?.typeName.closure?.parameters.first?.isVariadic).to(beTrue())
+                }
 
-                    expect(typeName("(() -> ())?").isOptional).to(beTrue())
-                    expect(typeName("(() -> ())!").isImplicitlyUnwrappedOptional).to(beTrue())
-                    expect(typeName("Optional<() -> ()>").isOptional).to(beTrue())
+                it("reports optional status correctly") {
+                    expect(variableTypeName("() -> ()").isOptional).to(beFalse())
+                    expect(variableTypeName("() -> ()?").isOptional).to(beFalse())
+                    expect(variableTypeName("() -> ()!").isImplicitlyUnwrappedOptional).to(beFalse())
+                    expect(variableTypeName("(() -> ()!)").isImplicitlyUnwrappedOptional).to(beFalse())
+                    expect(variableTypeName("Optional<()> -> ()").isOptional).to(beFalse())
+                    expect(variableTypeName("(() -> ()?)").isOptional).to(beFalse())
+
+                    expect(variableTypeName("(() -> ())?").isOptional).to(beTrue())
+                    expect(variableTypeName("(() -> ())!").isImplicitlyUnwrappedOptional).to(beTrue())
+                    expect(variableTypeName("Optional<() -> ()>").isOptional).to(beTrue())
                 }
             }
 
             context("given closure type inside generic type") {
                 it("reports closure correctly") {
-                    expect(typeName("Foo<() -> ()>").isClosure).to(beFalse())
-                    expect(typeName("Foo<(String) -> Bool>").isClosure).to(beFalse())
-                    expect(typeName("Foo<(String) -> Bool?>").isClosure).to(beFalse())
-                    expect(typeName("Foo<(Bar<String>) -> Bool>").isClosure).to(beFalse())
-                    expect(typeName("Foo<(Bar<String>) -> Bar<Bool>>").isClosure).to(beFalse())
+                    expect(variableTypeName("Foo<() -> ()>").isClosure).to(beFalse())
+                    expect(variableTypeName("Foo<(String) -> Bool>").isClosure).to(beFalse())
+                    expect(variableTypeName("Foo<(String) -> Bool?>").isClosure).to(beFalse())
+                    expect(variableTypeName("Foo<(Bar<String>) -> Bool>").isClosure).to(beFalse())
+                    expect(variableTypeName("Foo<(Bar<String>) -> Bar<Bool>>").isClosure).to(beFalse())
                 }
             }
 
             context("given closure type with attributes") {
                 it("removes attributes in unwrappedTypeName") {
-                    expect(typeName("@escaping (@escaping ()->())->()").unwrappedTypeName).to(equal("(@escaping () -> ()) -> ()"))
+                    expect(variableTypeName("@escaping (@escaping ()->())->()").unwrappedTypeName).to(equal("(@escaping () -> ()) -> ()"))
                 }
 
                 it("orders attributes alphabetically") {
-                    expect(typeName("@escaping @autoclosure () -> String").asSource).to(equal("@autoclosure @escaping () -> String"))
-                    expect(typeName("@escaping @autoclosure () -> String").description).to(equal("@autoclosure @escaping () -> String"))
+                    expect(variableTypeName("@escaping @autoclosure () -> String").asSource).to(equal("@autoclosure @escaping () -> String"))
+                    expect(variableTypeName("@escaping @autoclosure () -> String").description).to(equal("@autoclosure @escaping () -> String"))
                 }
             }
 
             context("given optional closure type with attributes") {
                 it("keeps attributes in unwrappedTypeName") {
-                    expect(typeName("(@MainActor @Sendable (Int) -> Void)?").unwrappedTypeName).to(equal("(@MainActor @Sendable (Int) -> Void)"))
+                    expect(variableTypeName("(@MainActor @Sendable (Int) -> Void)?").unwrappedTypeName).to(equal("(@MainActor @Sendable (Int) -> Void)"))
                 }
                 it("keeps attributes in name") {
-                    expect(typeName("(@MainActor @Sendable (Int) -> Void)?").name).to(equal("(@MainActor @Sendable (Int) -> Void)?"))
+                    expect(variableTypeName("(@MainActor @Sendable (Int) -> Void)?").name).to(equal("(@MainActor @Sendable (Int) -> Void)?"))
                 }
             }
 
             context("given implicitly unwrapped optional closure type with attributes") {
                 it("keeps attributes in unwrappedTypeName") {
-                    expect(typeName("(@MainActor @Sendable (Int) -> Void)!").unwrappedTypeName).to(equal("(@MainActor @Sendable (Int) -> Void)"))
+                    expect(variableTypeName("(@MainActor @Sendable (Int) -> Void)!").unwrappedTypeName).to(equal("(@MainActor @Sendable (Int) -> Void)"))
                 }
                 it("keeps attributes in name") {
-                    expect(typeName("(@MainActor @Sendable (Int) -> Void)!").name).to(equal("(@MainActor @Sendable (Int) -> Void)!"))
+                    expect(variableTypeName("(@MainActor @Sendable (Int) -> Void)!").name).to(equal("(@MainActor @Sendable (Int) -> Void)!"))
                 }
             }
         }


### PR DESCRIPTION
## Context

#1265 issue reports that it is not possible to customize Stencil so that it'd be customizable enough when there's a method with an argument of type `ClosureType` with a parameter `ClosureParameter` that is a variadic argument.

Currently, `ClosureParameter` does not provide `isClosure` accessor.