### PR TITLE
Format processing time log message

### DIFF
--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -223,7 +223,7 @@ func runCLI() {
             }
 
             if keepAlive.isEmpty {
-                Log.info("Processing time \(currentTimestamp() - start) seconds")
+                Log.info(String(format: "Processing time %.2f seconds", currentTimestamp() - start))
             } else {
                 RunLoop.current.run()
                 _ = keepAlive
@@ -396,7 +396,7 @@ func runCLI() {
             }
 
             if keepAlive.isEmpty {
-                Log.info("Processing time \(currentTimestamp() - start) seconds")
+                Log.info(String(format: "Processing time %.2f seconds", currentTimestamp() - start))
             } else {
                 RunLoop.current.run()
                 _ = keepAlive


### PR DESCRIPTION
`Processing time: 4.69904798269272 seconds`
 -> 
 `Processing time: 4.70 seconds`