### PR TITLE
Fixed swift-package-manager version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "805deae27a7506dcad043604c00a9dc52d465dcb",
-        "version" : "0.7.0"
+        "revision" : "c7e239b5c1492ffc3ebd7fbcc7a92548ce4e78f0",
+        "version" : "1.1.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "35a7df2d9d71c401a47de9be2e3de629a01370c2",
-        "version" : "0.4.1"
+        "revision" : "01d7664523af5c169f26038f1e5d444ce47ae5ff",
+        "version" : "1.0.1"
       }
     },
     {
@@ -131,34 +131,35 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "33a20e650c33f6d72d822d558333f2085effa3dc",
-        "version" : "2.5.0"
+        "revision" : "629f0b679d0fd0a6ae823d7f750b9ab032c00b80",
+        "version" : "3.0.0"
       }
     },
     {
       "identity" : "swift-driver",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-driver.git",
+      "location" : "https://github.com/art-divin/swift-driver.git",
       "state" : {
-        "branch" : "release/5.9",
-        "revision" : "1b2b851ae4718caffa5f18fd1861bc0ddd1791a3"
+        "revision" : "1c07ced84c1dfc1f9c3253dcbaa216fc9c76ee25",
+        "version" : "1.0.1"
       }
     },
     {
       "identity" : "swift-llbuild",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-llbuild.git",
+      "location" : "https://github.com/art-divin/swift-llbuild.git",
       "state" : {
-        "branch" : "release/5.9",
-        "revision" : "d73a305d6e5a82e4bf3bf1727da3d1376e87efab"
+        "revision" : "783aec21649a6c47d1a8314db4144bdceb11df30",
+        "version" : "1.0.0"
       }
     },
     {
       "identity" : "swift-package-manager",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-package-manager",
+      "location" : "https://github.com/art-divin/swift-package-manager.git",
       "state" : {
-        "revision" : "848ddac99ee588a4a6cd1ec22beae8822c819671"
+        "revision" : "55ede60ea3116f85bc440944ee4cdfb3d55dfbe8",
+        "version" : "1.0.3"
       }
     },
     {
@@ -182,10 +183,10 @@
     {
       "identity" : "swift-tools-support-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-tools-support-core.git",
+      "location" : "https://github.com/art-divin/swift-tools-support-core.git",
       "state" : {
-        "branch" : "release/5.9",
-        "revision" : "5665fc7641ce1a971ad06faaa476862b222ef44b"
+        "revision" : "930e82e5ae2432c71fe05f440b5d778285270bdb",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -261,7 +261,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
     .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
-    .package(url: "https://github.com/apple/swift-package-manager", revision: "848ddac99ee588a4a6cd1ec22beae8822c819671"),
+    .package(url: "https://github.com/art-divin/swift-package-manager.git", from: "1.0.3"),
 ]
 
 #if !canImport(ObjectiveC)

--- a/Package.swift
+++ b/Package.swift
@@ -265,7 +265,7 @@ var dependencies: [Package.Dependency] = [
 ]
 
 #if !canImport(ObjectiveC)
-dependencies.append(.package(url: "https://github.com/apple/swift-crypto", from: "2.2.3"))
+dependencies.append(.package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"))
 #endif
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -271,7 +271,7 @@ dependencies.append(.package(url: "https://github.com/apple/swift-crypto", from:
 let package = Package(
     name: "Sourcery",
     platforms: [
-        .macOS(.v12),
+        .macOS(.v13),
     ],
     products: [
         // SPM won't generate .swiftmodule for a target directly used by a product,

--- a/Sourcery/Configuration.swift
+++ b/Sourcery/Configuration.swift
@@ -170,7 +170,7 @@ public struct Package {
         }
         let path = Path(packageRootPath, relativeTo: relativePath)
         
-        let packagePath = try AbsolutePath(validating: path.string)
+        let packagePath = try Basics.AbsolutePath(validating: path.string)
         let observability = ObservabilitySystem { Log.verbose("\($0): \($1)") }
         let workspace = try Workspace(forRootPackage: packagePath)
 


### PR DESCRIPTION
Resolves #1276 

## Context

This PR updates version of `swift-package-manager` dependency to use a fork which has an exact version. 
This also includes using forked versions of `swift-llbuild`, `swift-driver` and `swift-tools-support-core` in the same fashion.
