### PR TITLE
Implement GenericRequirement support for member type disambiguation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "cd793adf5680e138bf2bcbaacc292490175d0dcd",
-        "version" : "508.0.0"
+        "revision" : "2c49d66d34dfd6f8130afdba889de77504b58ec0",
+        "version" : "508.0.1"
       }
     },
     {

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Class+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Class+SwiftSyntax.swift
@@ -6,6 +6,15 @@ extension Class {
     convenience init(_ node: ClassDeclSyntax, parent: Type?, annotationsParser: AnnotationsParser) {
         let modifiers = node.modifiers?.map(Modifier.init) ?? []
 
+        let genericRequirements: [GenericRequirement] = node.genericWhereClause?.requirementList.compactMap { requirement in
+            if let sameType = requirement.body.as(SameTypeRequirementSyntax.self) {
+                return GenericRequirement(sameType)
+            } else if let conformanceType = requirement.body.as(ConformanceRequirementSyntax.self) {
+                return GenericRequirement(conformanceType)
+            }
+            return nil
+        } ?? []
+
         self.init(
           name: node.identifier.text.trimmingCharacters(in: .whitespaces),
           parent: parent,
@@ -17,6 +26,7 @@ extension Class {
           inheritedTypes: node.inheritanceClause?.inheritedTypeCollection.map { $0.typeName.description.trimmed } ?? [],
           containedTypes: [],
           typealiases: [],
+          genericRequirements: genericRequirements,
           attributes: Attribute.from(node.attributes),
           modifiers: modifiers.map(SourceryModifier.init),
           annotations: annotationsParser.annotations(from: node),

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/GenericRequirement+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/GenericRequirement+SwiftSyntax.swift
@@ -5,13 +5,17 @@ import SourceryRuntime
 extension GenericRequirement {
     convenience init(_ node: SameTypeRequirementSyntax) {
         let leftType = node.leftTypeIdentifier.description.trimmed
-        let rightType = TypeName(node.rightTypeIdentifier.description.trimmed)
-        self.init(leftType: .init(name: leftType), rightType: .init(typeName: rightType), relationship: .equals)
+        let rightTypeName = TypeName(node.rightTypeIdentifier.description.trimmed)
+        let rightType = Type(name: rightTypeName.unwrappedTypeName)
+        let protocolType = SourceryProtocol(name: rightTypeName.unwrappedTypeName, implements: [rightTypeName.unwrappedTypeName: rightType])
+        self.init(leftType: .init(name: leftType), rightType: .init(typeName: rightTypeName, type: protocolType), relationship: .equals)
     }
 
     convenience init(_ node: ConformanceRequirementSyntax) {
         let leftType = node.leftTypeIdentifier.description.trimmed
-        let rightType = TypeName(node.rightTypeIdentifier.description.trimmed)
-        self.init(leftType: .init(name: leftType), rightType: .init(typeName: rightType), relationship: .conformsTo)
+        let rightTypeName = TypeName(node.rightTypeIdentifier.description.trimmed)
+        let rightType = Type(name: rightTypeName.unwrappedTypeName)
+        let protocolType = SourceryProtocol(name: rightTypeName.unwrappedTypeName, implements: [rightTypeName.unwrappedTypeName: rightType])
+        self.init(leftType: .init(name: leftType), rightType: .init(typeName: rightTypeName, type: protocolType), relationship: .conformsTo)
     }
 }

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Type+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Type+SwiftSyntax.swift
@@ -1,0 +1,12 @@
+import Foundation
+import SourceryRuntime
+import SwiftSyntax
+
+extension Type {
+    convenience init?(_ node: TypeSyntax) {
+        guard let typeIdentifier = node.as(SimpleTypeIdentifierSyntax.self) else { return nil }
+        let name = typeIdentifier.name.text.trimmed
+        let generic = typeIdentifier.genericArgumentClause.map { GenericType(name: typeIdentifier.name.text, node: $0) }
+        self.init(name: name, isGeneric: generic != nil)
+    }
+}

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -19,15 +19,6 @@ extension SyntaxProtocol {
     }
 }
 
-extension Type {
-    convenience init?(_ node: TypeSyntax) {
-        guard let typeIdentifier = node.as(SimpleTypeIdentifierSyntax.self) else { return nil }
-        let name = typeIdentifier.name.text.trimmed
-        let generic = typeIdentifier.genericArgumentClause.map { GenericType(name: typeIdentifier.name.text, node: $0) }
-        self.init(name: name, isGeneric: generic != nil)
-    }
-}
-
 extension TypeName {
     convenience init(_ node: TypeSyntax) {
         /* TODO: redesign what `TypeName` represents, it can represent all those different variants

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -19,6 +19,15 @@ extension SyntaxProtocol {
     }
 }
 
+extension Type {
+    convenience init?(_ node: TypeSyntax) {
+        guard let typeIdentifier = node.as(SimpleTypeIdentifierSyntax.self) else { return nil }
+        let name = typeIdentifier.name.text.trimmed
+        let generic = typeIdentifier.genericArgumentClause.map { GenericType(name: typeIdentifier.name.text, node: $0) }
+        self.init(name: name, isGeneric: generic != nil)
+    }
+}
+
 extension TypeName {
     convenience init(_ node: TypeSyntax) {
         /* TODO: redesign what `TypeName` represents, it can represent all those different variants

--- a/SourceryRuntime/Sources/AST/Actor.swift
+++ b/SourceryRuntime/Sources/AST/Actor.swift
@@ -25,11 +25,13 @@ public final class Actor: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -41,11 +43,13 @@ public final class Actor: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 

--- a/SourceryRuntime/Sources/AST/Class.swift
+++ b/SourceryRuntime/Sources/AST/Class.swift
@@ -24,11 +24,13 @@ public final class Class: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -40,11 +42,13 @@ public final class Class: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 

--- a/SourceryRuntime/Sources/AST/Protocol.swift
+++ b/SourceryRuntime/Sources/AST/Protocol.swift
@@ -28,7 +28,7 @@ public final class Protocol: Type {
     }
 
     /// list of generic requirements
-    public var genericRequirements: [GenericRequirement] {
+    public override var genericRequirements: [GenericRequirement] {
         didSet {
             isGeneric = !associatedTypes.isEmpty || !genericRequirements.isEmpty
         }
@@ -50,8 +50,8 @@ public final class Protocol: Type {
                 attributes: AttributeList = [:],
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
-                documentation: [String] = []) {
-        self.genericRequirements = genericRequirements
+                documentation: [String] = [],
+                implements: [String: Type] = [:]) {
         self.associatedTypes = associatedTypes
         super.init(
             name: name,
@@ -64,11 +64,13 @@ public final class Protocol: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: !associatedTypes.isEmpty || !genericRequirements.isEmpty
+            isGeneric: !associatedTypes.isEmpty || !genericRequirements.isEmpty,
+            implements: implements
         )
     }
 
@@ -78,7 +80,6 @@ public final class Protocol: Type {
         string += ", "
         string += "kind = \(String(describing: self.kind)), "
         string += "associatedTypes = \(String(describing: self.associatedTypes)), "
-        string += "genericRequirements = \(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -89,7 +90,6 @@ public final class Protocol: Type {
             return results
         }
         results.append(contentsOf: DiffableResult(identifier: "associatedTypes").trackDifference(actual: self.associatedTypes, expected: castObject.associatedTypes))
-        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         results.append(contentsOf: super.diffAgainst(castObject))
         return results
     }
@@ -97,7 +97,6 @@ public final class Protocol: Type {
     public override var hash: Int {
         var hasher = Hasher()
         hasher.combine(self.associatedTypes)
-        hasher.combine(self.genericRequirements)
         hasher.combine(super.hash)
         return hasher.finalize()
     }
@@ -106,7 +105,6 @@ public final class Protocol: Type {
     public override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Protocol else { return false }
         if self.associatedTypes != rhs.associatedTypes { return false }
-        if self.genericRequirements != rhs.genericRequirements { return false }
         return super.isEqual(rhs)
     }
 
@@ -120,12 +118,6 @@ public final class Protocol: Type {
                 }
                 fatalError()
              }; self.associatedTypes = associatedTypes
-            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else { 
-                withVaList(["genericRequirements"]) { arguments in
-                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
-                }
-                fatalError()
-             }; self.genericRequirements = genericRequirements
             super.init(coder: aDecoder)
         }
 
@@ -133,7 +125,6 @@ public final class Protocol: Type {
         override public func encode(with aCoder: NSCoder) {
             super.encode(with: aCoder)
             aCoder.encode(self.associatedTypes, forKey: "associatedTypes")
-            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 }

--- a/SourceryRuntime/Sources/AST/ProtocolComposition.swift
+++ b/SourceryRuntime/Sources/AST/ProtocolComposition.swift
@@ -34,7 +34,8 @@ public final class ProtocolComposition: Type {
                 annotations: [String: NSObject] = [:],
                 isGeneric: Bool = false,
                 composedTypeNames: [TypeName] = [],
-                composedTypes: [Type]? = nil) {
+                composedTypes: [Type]? = nil,
+                implements: [String: Type] = [:]) {
         self.composedTypeNames = composedTypeNames
         self.composedTypes = composedTypes
         super.init(
@@ -49,7 +50,8 @@ public final class ProtocolComposition: Type {
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 

--- a/SourceryRuntime/Sources/AST/Struct.swift
+++ b/SourceryRuntime/Sources/AST/Struct.swift
@@ -29,11 +29,13 @@ public final class Struct: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -45,11 +47,13 @@ public final class Struct: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 

--- a/SourceryRuntime/Sources/AST/Type_Linux.swift
+++ b/SourceryRuntime/Sources/AST/Type_Linux.swift
@@ -425,8 +425,8 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
                 documentation: [String] = [],
-                isGeneric: Bool = false) {
-
+                isGeneric: Bool = false,
+                implements: [String: Type] = [:]) {
         self.localName = name
         self.accessLevel = accessLevel.rawValue
         self.isExtension = isExtension
@@ -444,6 +444,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
         self.documentation = documentation
         self.isGeneric = isGeneric
         self.genericRequirements = genericRequirements
+        self.implements = implements
         super.init()
         containedTypes.forEach {
             containedType[$0.localName] = $0

--- a/SourceryRuntime/Sources/AST/Type_Linux.swift
+++ b/SourceryRuntime/Sources/AST/Type_Linux.swift
@@ -54,6 +54,8 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
                 return rawSubscripts
             case "allSubscripts":
                 return allSubscripts
+            case "genericRequirements":
+                return genericRequirements
             default:
                 fatalError("unable to lookup: \(member) in \(self)")
         }   
@@ -94,7 +96,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
 
     // sourcery: forceEquality
     /// Kind of type declaration, i.e. `enum`, `struct`, `class`, `protocol` or `extension`
-    public var kind: String { return isExtension ? "extension" : "unknown" }
+    public var kind: String { isExtension ? "extension" : "unknown" }
 
     /// Type access level, i.e. `internal`, `private`, `fileprivate`, `public`, `open`
     public let accessLevel: String
@@ -397,6 +399,13 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
         }
     }
 
+    /// list of generic requirements
+    public var genericRequirements: [GenericRequirement] {
+        didSet {
+            isGeneric = isGeneric || !genericRequirements.isEmpty
+        }
+    }
+
     /// File name where the type was defined
     public var fileName: String?
 
@@ -411,6 +420,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
                 inheritedTypes: [String] = [],
                 containedTypes: [Type] = [],
                 typealiases: [Typealias] = [],
+                genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
@@ -433,7 +443,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
         self.annotations = annotations
         self.documentation = documentation
         self.isGeneric = isGeneric
-
+        self.genericRequirements = genericRequirements
         super.init()
         containedTypes.forEach {
             containedType[$0.localName] = $0
@@ -495,7 +505,8 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
         string += "parentTypes = \(String(describing: self.parentTypes)), "
         string += "attributes = \(String(describing: self.attributes)), "
         string += "modifiers = \(String(describing: self.modifiers)), "
-        string += "fileName = \(String(describing: self.fileName))"
+        string += "fileName = \(String(describing: self.fileName)), "
+        string += "genericRequirements = \(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -525,6 +536,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
         results.append(contentsOf: DiffableResult(identifier: "modifiers").trackDifference(actual: self.modifiers, expected: castObject.modifiers))
         results.append(contentsOf: DiffableResult(identifier: "fileName").trackDifference(actual: self.fileName, expected: castObject.fileName))
+        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         return results
     }
 
@@ -550,6 +562,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
         hasher.combine(self.attributes)
         hasher.combine(self.modifiers)
         hasher.combine(self.fileName)
+        hasher.combine(self.genericRequirements)
         hasher.combine(kind)
         return hasher.finalize()
     }
@@ -578,6 +591,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
         if self.modifiers != rhs.modifiers { return false }
         if self.fileName != rhs.fileName { return false }
         if self.kind != rhs.kind { return false }
+        if self.genericRequirements != rhs.genericRequirements { return false }
         return true
     }
 
@@ -606,7 +620,13 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
                 fatalError()
              }; self.accessLevel = accessLevel
             self.isGeneric = aDecoder.decode(forKey: "isGeneric")
-            guard let localName: String = aDecoder.decode(forKey: "localName") else { 
+            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
+                withVaList(["genericRequirements"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.genericRequirements = genericRequirements
+            guard let localName: String = aDecoder.decode(forKey: "localName") else {
                 withVaList(["localName"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
@@ -735,6 +755,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Dyn
             aCoder.encode(self.modifiers, forKey: "modifiers")
             aCoder.encode(self.path, forKey: "path")
             aCoder.encode(self.fileName, forKey: "fileName")
+            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 

--- a/SourceryRuntime/Sources/AST/Variable.swift
+++ b/SourceryRuntime/Sources/AST/Variable.swift
@@ -164,6 +164,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         }
         results.append(contentsOf: DiffableResult(identifier: "name").trackDifference(actual: self.name, expected: castObject.name))
         results.append(contentsOf: DiffableResult(identifier: "typeName").trackDifference(actual: self.typeName, expected: castObject.typeName))
+        results.append(contentsOf: DiffableResult(identifier: "type").trackDifference(actual: self.type, expected: castObject.type))
         results.append(contentsOf: DiffableResult(identifier: "isComputed").trackDifference(actual: self.isComputed, expected: castObject.isComputed))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -123,11 +123,13 @@ public final class Actor: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -139,11 +141,13 @@ public final class Actor: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 
@@ -874,11 +878,13 @@ public final class Class: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -890,11 +896,13 @@ public final class Class: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 
@@ -5108,7 +5116,7 @@ public final class Protocol: Type {
     }
 
     /// list of generic requirements
-    public var genericRequirements: [GenericRequirement] {
+    public override var genericRequirements: [GenericRequirement] {
         didSet {
             isGeneric = !associatedTypes.isEmpty || !genericRequirements.isEmpty
         }
@@ -5130,8 +5138,8 @@ public final class Protocol: Type {
                 attributes: AttributeList = [:],
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
-                documentation: [String] = []) {
-        self.genericRequirements = genericRequirements
+                documentation: [String] = [],
+                implements: [String: Type] = [:]) {
         self.associatedTypes = associatedTypes
         super.init(
             name: name,
@@ -5144,11 +5152,13 @@ public final class Protocol: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: !associatedTypes.isEmpty || !genericRequirements.isEmpty
+            isGeneric: !associatedTypes.isEmpty || !genericRequirements.isEmpty,
+            implements: implements
         )
     }
 
@@ -5158,7 +5168,6 @@ public final class Protocol: Type {
         string += ", "
         string += "kind = \\(String(describing: self.kind)), "
         string += "associatedTypes = \\(String(describing: self.associatedTypes)), "
-        string += "genericRequirements = \\(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -5169,7 +5178,6 @@ public final class Protocol: Type {
             return results
         }
         results.append(contentsOf: DiffableResult(identifier: "associatedTypes").trackDifference(actual: self.associatedTypes, expected: castObject.associatedTypes))
-        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         results.append(contentsOf: super.diffAgainst(castObject))
         return results
     }
@@ -5177,7 +5185,6 @@ public final class Protocol: Type {
     public override var hash: Int {
         var hasher = Hasher()
         hasher.combine(self.associatedTypes)
-        hasher.combine(self.genericRequirements)
         hasher.combine(super.hash)
         return hasher.finalize()
     }
@@ -5186,7 +5193,6 @@ public final class Protocol: Type {
     public override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Protocol else { return false }
         if self.associatedTypes != rhs.associatedTypes { return false }
-        if self.genericRequirements != rhs.genericRequirements { return false }
         return super.isEqual(rhs)
     }
 
@@ -5200,12 +5206,6 @@ public final class Protocol: Type {
                 }
                 fatalError()
              }; self.associatedTypes = associatedTypes
-            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
-                withVaList(["genericRequirements"]) { arguments in
-                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
-                }
-                fatalError()
-             }; self.genericRequirements = genericRequirements
             super.init(coder: aDecoder)
         }
 
@@ -5213,7 +5213,6 @@ public final class Protocol: Type {
         override public func encode(with aCoder: NSCoder) {
             super.encode(with: aCoder)
             aCoder.encode(self.associatedTypes, forKey: "associatedTypes")
-            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 }
@@ -5256,7 +5255,8 @@ public final class ProtocolComposition: Type {
                 annotations: [String: NSObject] = [:],
                 isGeneric: Bool = false,
                 composedTypeNames: [TypeName] = [],
-                composedTypes: [Type]? = nil) {
+                composedTypes: [Type]? = nil,
+                implements: [String: Type] = [:]) {
         self.composedTypeNames = composedTypeNames
         self.composedTypes = composedTypes
         super.init(
@@ -5271,7 +5271,8 @@ public final class ProtocolComposition: Type {
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 
@@ -5365,11 +5366,13 @@ public final class Struct: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -5381,11 +5384,13 @@ public final class Struct: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 
@@ -6370,7 +6375,6 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
     }
 
     // All local typealiases
-    // sourcery: skipJSExport
     /// :nodoc:
     public var typealiases: [String: Typealias] {
         didSet {
@@ -6384,7 +6388,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
 
     // sourcery: forceEquality
     /// Kind of type declaration, i.e. `enum`, `struct`, `class`, `protocol` or `extension`
-    public var kind: String { return isExtension ? "extension" : "unknown" }
+    public var kind: String { isExtension ? "extension" : "unknown" }
 
     /// Type access level, i.e. `internal`, `private`, `fileprivate`, `public`, `open`
     public let accessLevel: String
@@ -6622,7 +6626,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
 
     // sourcery: skipEquality, skipDescription
     /// Protocols this type implements
-    public var implements = [String: Type]()
+    public var implements: [String: Type] = [:]
 
     /// Contained types
     public var containedTypes: [Type] {
@@ -6687,6 +6691,13 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         }
     }
 
+    /// list of generic requirements
+    public var genericRequirements: [GenericRequirement] {
+        didSet {
+            isGeneric = isGeneric || !genericRequirements.isEmpty
+        }
+    }
+
     /// File name where the type was defined
     public var fileName: String?
 
@@ -6701,12 +6712,13 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
                 inheritedTypes: [String] = [],
                 containedTypes: [Type] = [],
                 typealiases: [Typealias] = [],
+                genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
                 documentation: [String] = [],
-                isGeneric: Bool = false) {
-
+                isGeneric: Bool = false,
+                implements: [String: Type] = [:]) {
         self.localName = name
         self.accessLevel = accessLevel.rawValue
         self.isExtension = isExtension
@@ -6723,7 +6735,8 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         self.annotations = annotations
         self.documentation = documentation
         self.isGeneric = isGeneric
-
+        self.genericRequirements = genericRequirements
+        self.implements = implements
         super.init()
         containedTypes.forEach {
             containedType[$0.localName] = $0
@@ -6785,7 +6798,8 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         string += "parentTypes = \\(String(describing: self.parentTypes)), "
         string += "attributes = \\(String(describing: self.attributes)), "
         string += "modifiers = \\(String(describing: self.modifiers)), "
-        string += "fileName = \\(String(describing: self.fileName))"
+        string += "fileName = \\(String(describing: self.fileName)), "
+        string += "genericRequirements = \\(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -6815,6 +6829,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
         results.append(contentsOf: DiffableResult(identifier: "modifiers").trackDifference(actual: self.modifiers, expected: castObject.modifiers))
         results.append(contentsOf: DiffableResult(identifier: "fileName").trackDifference(actual: self.fileName, expected: castObject.fileName))
+        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         return results
     }
 
@@ -6840,6 +6855,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         hasher.combine(self.attributes)
         hasher.combine(self.modifiers)
         hasher.combine(self.fileName)
+        hasher.combine(self.genericRequirements)
         hasher.combine(kind)
         return hasher.finalize()
     }
@@ -6868,6 +6884,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         if self.modifiers != rhs.modifiers { return false }
         if self.fileName != rhs.fileName { return false }
         if self.kind != rhs.kind { return false }
+        if self.genericRequirements != rhs.genericRequirements { return false }
         return true
     }
 
@@ -6896,6 +6913,12 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
                 fatalError()
              }; self.accessLevel = accessLevel
             self.isGeneric = aDecoder.decode(forKey: "isGeneric")
+            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
+                withVaList(["genericRequirements"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.genericRequirements = genericRequirements
             guard let localName: String = aDecoder.decode(forKey: "localName") else {
                 withVaList(["localName"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
@@ -7025,6 +7048,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
             aCoder.encode(self.modifiers, forKey: "modifiers")
             aCoder.encode(self.path, forKey: "path")
             aCoder.encode(self.fileName, forKey: "fileName")
+            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -121,11 +121,13 @@ public final class Actor: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -137,11 +139,13 @@ public final class Actor: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 
@@ -886,11 +890,13 @@ public final class Class: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -902,11 +908,13 @@ public final class Class: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 
@@ -4482,7 +4490,7 @@ public final class Protocol: Type {
     }
 
     /// list of generic requirements
-    public var genericRequirements: [GenericRequirement] {
+    public override var genericRequirements: [GenericRequirement] {
         didSet {
             isGeneric = !associatedTypes.isEmpty || !genericRequirements.isEmpty
         }
@@ -4504,8 +4512,8 @@ public final class Protocol: Type {
                 attributes: AttributeList = [:],
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
-                documentation: [String] = []) {
-        self.genericRequirements = genericRequirements
+                documentation: [String] = [],
+                implements: [String: Type] = [:]) {
         self.associatedTypes = associatedTypes
         super.init(
             name: name,
@@ -4518,11 +4526,13 @@ public final class Protocol: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: !associatedTypes.isEmpty || !genericRequirements.isEmpty
+            isGeneric: !associatedTypes.isEmpty || !genericRequirements.isEmpty,
+            implements: implements
         )
     }
 
@@ -4532,7 +4542,6 @@ public final class Protocol: Type {
         string += ", "
         string += "kind = \\(String(describing: self.kind)), "
         string += "associatedTypes = \\(String(describing: self.associatedTypes)), "
-        string += "genericRequirements = \\(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -4543,7 +4552,6 @@ public final class Protocol: Type {
             return results
         }
         results.append(contentsOf: DiffableResult(identifier: "associatedTypes").trackDifference(actual: self.associatedTypes, expected: castObject.associatedTypes))
-        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         results.append(contentsOf: super.diffAgainst(castObject))
         return results
     }
@@ -4551,7 +4559,6 @@ public final class Protocol: Type {
     public override var hash: Int {
         var hasher = Hasher()
         hasher.combine(self.associatedTypes)
-        hasher.combine(self.genericRequirements)
         hasher.combine(super.hash)
         return hasher.finalize()
     }
@@ -4560,7 +4567,6 @@ public final class Protocol: Type {
     public override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Protocol else { return false }
         if self.associatedTypes != rhs.associatedTypes { return false }
-        if self.genericRequirements != rhs.genericRequirements { return false }
         return super.isEqual(rhs)
     }
 
@@ -4574,12 +4580,6 @@ public final class Protocol: Type {
                 }
                 fatalError()
              }; self.associatedTypes = associatedTypes
-            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
-                withVaList(["genericRequirements"]) { arguments in
-                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
-                }
-                fatalError()
-             }; self.genericRequirements = genericRequirements
             super.init(coder: aDecoder)
         }
 
@@ -4587,7 +4587,6 @@ public final class Protocol: Type {
         override public func encode(with aCoder: NSCoder) {
             super.encode(with: aCoder)
             aCoder.encode(self.associatedTypes, forKey: "associatedTypes")
-            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 }
@@ -4629,7 +4628,8 @@ public final class ProtocolComposition: Type {
                 annotations: [String: NSObject] = [:],
                 isGeneric: Bool = false,
                 composedTypeNames: [TypeName] = [],
-                composedTypes: [Type]? = nil) {
+                composedTypes: [Type]? = nil,
+                implements: [String: Type] = [:]) {
         self.composedTypeNames = composedTypeNames
         self.composedTypes = composedTypes
         super.init(
@@ -4644,7 +4644,8 @@ public final class ProtocolComposition: Type {
             containedTypes: containedTypes,
             typealiases: typealiases,
             annotations: annotations,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 
@@ -4737,11 +4738,13 @@ public final class Struct: Type {
                          inheritedTypes: [String] = [],
                          containedTypes: [Type] = [],
                          typealiases: [Typealias] = [],
+                         genericRequirements: [GenericRequirement] = [],
                          attributes: AttributeList = [:],
                          modifiers: [SourceryModifier] = [],
                          annotations: [String: NSObject] = [:],
                          documentation: [String] = [],
-                         isGeneric: Bool = false) {
+                         isGeneric: Bool = false,
+                         implements: [String: Type] = [:]) {
         super.init(
             name: name,
             parent: parent,
@@ -4753,11 +4756,13 @@ public final class Struct: Type {
             inheritedTypes: inheritedTypes,
             containedTypes: containedTypes,
             typealiases: typealiases,
+            genericRequirements: genericRequirements,
             attributes: attributes,
             modifiers: modifiers,
             annotations: annotations,
             documentation: documentation,
-            isGeneric: isGeneric
+            isGeneric: isGeneric,
+            implements: implements
         )
     }
 
@@ -5708,7 +5713,53 @@ import Foundation
 public typealias AttributeList = [String: [Attribute]]
 
 /// Defines Swift type
-public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
+public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, DynamicMemberLookup {
+    public subscript(dynamicMember member: String) -> Any? {
+        switch member {
+            case "implements":
+                return implements
+            case "name":
+                return name
+            case "kind":
+                return kind
+            case "based":
+                return based
+            case "supertype":
+                return supertype
+            case "accessLevel":
+                return accessLevel
+            case "storedVariables":
+                return storedVariables
+            case "variables":
+                return variables
+            case "allVariables":
+                return allVariables
+            case "allMethods":
+                return allMethods
+            case "annotations":
+                return annotations
+            case "methods":
+                return methods
+            case "containedType":
+                return containedType
+            case "computedVariables":
+                return computedVariables
+            case "inherits":
+                return inherits
+            case "inheritedTypes":
+                return inheritedTypes
+            case "subscripts":
+                return subscripts
+            case "rawSubscripts":
+                return rawSubscripts
+            case "allSubscripts":
+                return allSubscripts
+            case "genericRequirements":
+                return genericRequirements
+            default:
+                fatalError("unable to lookup: \\(member) in \\(self)")
+        }
+    }
 
     /// :nodoc:
     public var module: String?
@@ -5732,7 +5783,6 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
     }
 
     // All local typealiases
-    // sourcery: skipJSExport
     /// :nodoc:
     public var typealiases: [String: Typealias] {
         didSet {
@@ -5746,7 +5796,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
 
     // sourcery: forceEquality
     /// Kind of type declaration, i.e. `enum`, `struct`, `class`, `protocol` or `extension`
-    public var kind: String { return isExtension ? "extension" : "unknown" }
+    public var kind: String { isExtension ? "extension" : "unknown" }
 
     /// Type access level, i.e. `internal`, `private`, `fileprivate`, `public`, `open`
     public let accessLevel: String
@@ -6049,6 +6099,13 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         }
     }
 
+    /// list of generic requirements
+    public var genericRequirements: [GenericRequirement] {
+        didSet {
+            isGeneric = isGeneric || !genericRequirements.isEmpty
+        }
+    }
+
     /// File name where the type was defined
     public var fileName: String?
 
@@ -6063,12 +6120,13 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
                 inheritedTypes: [String] = [],
                 containedTypes: [Type] = [],
                 typealiases: [Typealias] = [],
+                genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
                 documentation: [String] = [],
-                isGeneric: Bool = false) {
-
+                isGeneric: Bool = false,
+                implements: [String: Type] = [:]) {
         self.localName = name
         self.accessLevel = accessLevel.rawValue
         self.isExtension = isExtension
@@ -6085,7 +6143,8 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         self.annotations = annotations
         self.documentation = documentation
         self.isGeneric = isGeneric
-
+        self.genericRequirements = genericRequirements
+        self.implements = implements
         super.init()
         containedTypes.forEach {
             containedType[$0.localName] = $0
@@ -6147,7 +6206,8 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         string += "parentTypes = \\(String(describing: self.parentTypes)), "
         string += "attributes = \\(String(describing: self.attributes)), "
         string += "modifiers = \\(String(describing: self.modifiers)), "
-        string += "fileName = \\(String(describing: self.fileName))"
+        string += "fileName = \\(String(describing: self.fileName)), "
+        string += "genericRequirements = \\(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -6177,6 +6237,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
         results.append(contentsOf: DiffableResult(identifier: "modifiers").trackDifference(actual: self.modifiers, expected: castObject.modifiers))
         results.append(contentsOf: DiffableResult(identifier: "fileName").trackDifference(actual: self.fileName, expected: castObject.fileName))
+        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         return results
     }
 
@@ -6202,6 +6263,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         hasher.combine(self.attributes)
         hasher.combine(self.modifiers)
         hasher.combine(self.fileName)
+        hasher.combine(self.genericRequirements)
         hasher.combine(kind)
         return hasher.finalize()
     }
@@ -6230,6 +6292,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
         if self.modifiers != rhs.modifiers { return false }
         if self.fileName != rhs.fileName { return false }
         if self.kind != rhs.kind { return false }
+        if self.genericRequirements != rhs.genericRequirements { return false }
         return true
     }
 
@@ -6258,6 +6321,12 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
                 fatalError()
              }; self.accessLevel = accessLevel
             self.isGeneric = aDecoder.decode(forKey: "isGeneric")
+            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
+                withVaList(["genericRequirements"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.genericRequirements = genericRequirements
             guard let localName: String = aDecoder.decode(forKey: "localName") else {
                 withVaList(["localName"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
@@ -6387,6 +6456,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
             aCoder.encode(self.modifiers, forKey: "modifiers")
             aCoder.encode(self.path, forKey: "path")
             aCoder.encode(self.fileName, forKey: "fileName")
+            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -5713,7 +5713,7 @@ import Foundation
 public typealias AttributeList = [String: [Attribute]]
 
 /// Defines Swift type
-public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, DynamicMemberLookup {
+public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
     public subscript(dynamicMember member: String) -> Any? {
         switch member {
             case "implements":

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -21,6 +21,7 @@ class GeneratorSpec: QuickSpec {
                 let fooType = Class(name: "Foo", variables: [Variable(name: "intValue", typeName: TypeName(name: "Int"))], inheritedTypes: ["NSObject", "Decodable", "AlternativeProtocol"])
                 let fooSubclassType = Class(name: "FooSubclass", inheritedTypes: ["Foo", "ProtocolBasedOnKnownProtocol"], annotations: ["foo": NSNumber(value: 2), "smth": ["bar": NSNumber(value: 2)] as NSObject])
                 let barType = Struct(name: "Bar", inheritedTypes: ["KnownProtocol", "Decodable"], annotations: ["bar": NSNumber(value: true)])
+                let fooBarBuzzType = Struct(name: "FooBarBuzz", inheritedTypes: ["KnownProtocol", "Decodable"], annotations: ["bar": NSNumber(value: true)])
 
                 let complexType = Struct(name: "Complex", accessLevel: .public, isExtension: false, variables: [])
                 let fooVar = Variable(name: "foo", typeName: TypeName(name: "Foo"), accessLevel: (read: .public, write: .private), isComputed: false, definedInTypeName: TypeName(name: "Complex"))
@@ -124,7 +125,7 @@ class GeneratorSpec: QuickSpec {
                 expect(generate("Found {{ types.implementing.NSObject.count|default:\"0\" }} types")).to(equal("Found 0 types"))
                 expect(generate("Found {{ types.implementing.Bar.count|default:\"0\" }} types")).to(equal("Found 0 types"))
 
-                expect(generate("{{ types.all|implements:\"KnownProtocol\"|count }}")).to(equal("7"))
+                expect(generate("{{ types.all|implements:\"KnownProtocol\"|count }}")).to(equal("8"))
             }
 
             it("feeds types.inheriting specific class") {

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -125,7 +125,7 @@ class GeneratorSpec: QuickSpec {
                 expect(generate("Found {{ types.implementing.NSObject.count|default:\"0\" }} types")).to(equal("Found 0 types"))
                 expect(generate("Found {{ types.implementing.Bar.count|default:\"0\" }} types")).to(equal("Found 0 types"))
 
-                expect(generate("{{ types.all|implements:\"KnownProtocol\"|count }}")).to(equal("8"))
+                expect(generate("{{ types.all|implements:\"KnownProtocol\"|count }}")).to(equal("7"))
             }
 
             it("feeds types.inheriting specific class") {


### PR DESCRIPTION
Resolves #1087 

## Context

This PR adds `implements` to `Type` & co, so that it is now possible to preserve information about protocol requirements during deserialization of variables and method-related types.

In particular, for cases like:

```swift
struct GenericStruct<T>: Equatable where T: Equatable {
  func method(_ arg: T) {}
}
```

method's argument type's `actualTypeName` is resolved to `(Equatable)` instead of simply `T`. 
_Before this PR, it was resolved to `nil`._

Let's also consider the following use case with protocol composition:

```swift
struct GenericStruct<T>: Equatable where T: Equatable, T: Codable {
  let value: T
}
```

here, variable's type is resolved as a `ProtocolComposition` type with `Codable` and `Equatable` `Protocol` instances bound together, that is, `actualTypeName` becomes `(Codable & Equatable)` respectively.