### PR TITLE
Add generic requirements to Method

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/GenericRequirement+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/GenericRequirement+SwiftSyntax.swift
@@ -6,7 +6,7 @@ extension GenericRequirement {
     convenience init(_ node: SameTypeRequirementSyntax) {
         let leftType = node.leftTypeIdentifier.description.trimmed
         let rightTypeName = TypeName(node.rightTypeIdentifier.description.trimmed)
-        let rightType = Type(name: rightTypeName.unwrappedTypeName)
+        let rightType = Type(name: rightTypeName.unwrappedTypeName, isGeneric: true)
         let protocolType = SourceryProtocol(name: rightTypeName.unwrappedTypeName, implements: [rightTypeName.unwrappedTypeName: rightType])
         self.init(leftType: .init(name: leftType), rightType: .init(typeName: rightTypeName, type: protocolType), relationship: .equals)
     }
@@ -14,7 +14,7 @@ extension GenericRequirement {
     convenience init(_ node: ConformanceRequirementSyntax) {
         let leftType = node.leftTypeIdentifier.description.trimmed
         let rightTypeName = TypeName(node.rightTypeIdentifier.description.trimmed)
-        let rightType = Type(name: rightTypeName.unwrappedTypeName)
+        let rightType = Type(name: rightTypeName.unwrappedTypeName, isGeneric: true)
         let protocolType = SourceryProtocol(name: rightTypeName.unwrappedTypeName, implements: [rightTypeName.unwrappedTypeName: rightType])
         self.init(leftType: .init(name: leftType), rightType: .init(typeName: rightTypeName, type: protocolType), relationship: .conformsTo)
     }

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
@@ -88,9 +88,16 @@ extension SourceryMethod {
         if let generics = genericParameterClause?.genericParameterList {
             fullName = funcName + "<\(generics.description.trimmed)>"
         }
-
+        var genericRequirements: [GenericRequirement] = []
         if let genericWhereClause = genericWhereClause {
-            // TODO: add generic requirement to method
+            genericRequirements = genericWhereClause.requirementList.compactMap { requirement in
+                if let sameType = requirement.body.as(SameTypeRequirementSyntax.self) {
+                    return GenericRequirement(sameType)
+                } else if let conformanceType = requirement.body.as(ConformanceRequirementSyntax.self) {
+                    return GenericRequirement(conformanceType)
+                }
+                return nil
+            }
             // TODO: TBR
             returnTypeName = TypeName(name: returnTypeName.name + " \(genericWhereClause.withoutTrivia().description.trimmed)",
                                       unwrappedTypeName: returnTypeName.unwrappedTypeName,
@@ -135,7 +142,8 @@ extension SourceryMethod {
           modifiers: modifiers.map(SourceryModifier.init),
           annotations: annotations,
           documentation: documentation,
-          definedInTypeName: typeName
+          definedInTypeName: typeName,
+          genericRequirements: genericRequirements
         )
     }
 

--- a/SourceryRuntime/Sources/AST/Method.swift
+++ b/SourceryRuntime/Sources/AST/Method.swift
@@ -172,6 +172,9 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     /// :nodoc:
     public var __parserData: Any?
 
+    /// list of generic requirements
+    public var genericRequirements: [GenericRequirement]
+
     /// :nodoc:
     public init(name: String,
                 selectorName: String? = nil,
@@ -188,8 +191,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
                 documentation: [String] = [],
-                definedInTypeName: TypeName? = nil) {
-
+                definedInTypeName: TypeName? = nil,
+                genericRequirements: [GenericRequirement] = []) {
         self.name = name
         self.selectorName = selectorName ?? name
         self.parameters = parameters
@@ -206,6 +209,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         self.annotations = annotations
         self.documentation = documentation
         self.definedInTypeName = definedInTypeName
+        self.genericRequirements = genericRequirements
     }
 
     /// :nodoc:
@@ -226,7 +230,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string += "documentation = \(String(describing: self.documentation)), "
         string += "definedInTypeName = \(String(describing: self.definedInTypeName)), "
         string += "attributes = \(String(describing: self.attributes)), "
-        string += "modifiers = \(String(describing: self.modifiers))"
+        string += "modifiers = \(String(describing: self.modifiers)), "
+        string += "genericRequirements = \(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -252,6 +257,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
         results.append(contentsOf: DiffableResult(identifier: "modifiers").trackDifference(actual: self.modifiers, expected: castObject.modifiers))
+        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         return results
     }
 
@@ -273,6 +279,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         hasher.combine(self.definedInTypeName)
         hasher.combine(self.attributes)
         hasher.combine(self.modifiers)
+        hasher.combine(self.genericRequirements)
         return hasher.finalize()
     }
 
@@ -295,6 +302,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         if self.definedInTypeName != rhs.definedInTypeName { return false }
         if self.attributes != rhs.attributes { return false }
         if self.modifiers != rhs.modifiers { return false }
+        if self.genericRequirements != rhs.genericRequirements { return false }
         return true
     }
 
@@ -365,6 +373,12 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 }
                 fatalError()
              }; self.modifiers = modifiers
+            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
+                withVaList(["genericRequirements"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.genericRequirements = genericRequirements
         }
 
         /// :nodoc:
@@ -387,6 +401,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             aCoder.encode(self.definedInType, forKey: "definedInType")
             aCoder.encode(self.attributes, forKey: "attributes")
             aCoder.encode(self.modifiers, forKey: "modifiers")
+            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 }

--- a/SourceryRuntime/Sources/AST/Method_Linux.swift
+++ b/SourceryRuntime/Sources/AST/Method_Linux.swift
@@ -44,6 +44,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 return actualReturnTypeName
             case "isDynamic":
                 return isDynamic
+            case "genericRequirements":
+                return genericRequirements
             default:
                 fatalError("unable to lookup: \(member) in \(self)")
         }
@@ -213,6 +215,9 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     /// :nodoc:
     public var __parserData: Any?
 
+    /// list of generic requirements
+    public var genericRequirements: [GenericRequirement]
+
     /// :nodoc:
     public init(name: String,
                 selectorName: String? = nil,
@@ -229,8 +234,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
                 documentation: [String] = [],
-                definedInTypeName: TypeName? = nil) {
-
+                definedInTypeName: TypeName? = nil,
+                genericRequirements: [GenericRequirement] = []) {
         self.name = name
         self.selectorName = selectorName ?? name
         self.parameters = parameters
@@ -247,6 +252,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         self.annotations = annotations
         self.documentation = documentation
         self.definedInTypeName = definedInTypeName
+        self.genericRequirements = genericRequirements
     }
 
     /// :nodoc:
@@ -268,6 +274,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string += "definedInTypeName = \(String(describing: self.definedInTypeName)), "
         string += "attributes = \(String(describing: self.attributes)), "
         string += "modifiers = \(String(describing: self.modifiers))"
+        string += "genericRequirements = \(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -293,6 +300,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
         results.append(contentsOf: DiffableResult(identifier: "modifiers").trackDifference(actual: self.modifiers, expected: castObject.modifiers))
+        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         return results
     }
 
@@ -314,6 +322,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         hasher.combine(self.definedInTypeName)
         hasher.combine(self.attributes)
         hasher.combine(self.modifiers)
+        hasher.combine(self.genericRequirements)
         return hasher.finalize()
     }
 
@@ -336,6 +345,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         if self.definedInTypeName != rhs.definedInTypeName { return false }
         if self.attributes != rhs.attributes { return false }
         if self.modifiers != rhs.modifiers { return false }
+        if self.genericRequirements != rhs.genericRequirements { return false }
         return true
     }
 
@@ -406,6 +416,12 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 }
                 fatalError()
              }; self.modifiers = modifiers
+            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
+                withVaList(["genericRequirements"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.genericRequirements = genericRequirements
         }
 
         /// :nodoc:
@@ -428,6 +444,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             aCoder.encode(self.definedInType, forKey: "definedInType")
             aCoder.encode(self.attributes, forKey: "attributes")
             aCoder.encode(self.modifiers, forKey: "modifiers")
+            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 }

--- a/SourceryRuntime/Sources/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Composer/ParserResultsComposed.swift
@@ -486,6 +486,7 @@ internal struct ParserResultsComposed {
                 }
                 let composedProtocols = ProtocolComposition(
                     inheritedTypes: relevantRequirements.map { $0.rightType.typeName.unwrappedTypeName },
+                    isGeneric: true,
                     composedTypes: relevantRequirements.compactMap { $0.rightType.type },
                     implements: implements
                 )

--- a/SourceryRuntime/Sources/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Composer/ParserResultsComposed.swift
@@ -295,7 +295,7 @@ internal struct ParserResultsComposed {
         return modules[moduleName]?[typeName]
     }
 
-    func resolveType(typeName: TypeName, containingType: Type?) -> Type? {
+    func resolveType(typeName: TypeName, containingType: Type?, method: Method? = nil) -> Type? {
         let resolveTypeWithName = { (typeName: TypeName) -> Type? in
             return self.resolveType(typeName: typeName, containingType: containingType)
         }
@@ -460,11 +460,23 @@ internal struct ParserResultsComposed {
             typeName.actualTypeName = aliasedName
         }
 
-        if let genericRequirements = containingType?.genericRequirements {
+        let hasGenericRequirements = containingType?.genericRequirements.isEmpty == false
+        || (method != nil && method?.genericRequirements.isEmpty == false)
+
+        if hasGenericRequirements {
+            // we should consider if we are looking up return type of a method with generic constraints
+            // where `typeName` passed would include `... where ...` suffix
+            let typeNameForLookup = typeName.name.split(separator: " ").first!
+            let genericRequirements: [GenericRequirement]
+            if let requirements = containingType?.genericRequirements, !requirements.isEmpty {
+                genericRequirements = requirements
+            } else {
+                genericRequirements = method?.genericRequirements ?? []
+            }
             let relevantRequirements = genericRequirements.filter {
                 // matched type against a generic requirement name
                 // thus type should be replaced with a protocol composition
-                $0.leftType.name == typeName.name
+                $0.leftType.name == typeNameForLookup
             }
             if relevantRequirements.count > 1 {
                 // compose protocols into `ProtocolComposition` and generate TypeName
@@ -477,7 +489,7 @@ internal struct ParserResultsComposed {
                     composedTypes: relevantRequirements.compactMap { $0.rightType.type },
                     implements: implements
                 )
-                typeName.actualTypeName = TypeName(name: "(\(composedProtocols.composedTypeNames.map { $0.name }.joined(separator: " & "))", isProtocolComposition: true)
+                typeName.actualTypeName = TypeName(name: "(\(relevantRequirements.map { $0.rightType.typeName.unwrappedTypeName }.joined(separator: " & ")))", isProtocolComposition: true)
                 return composedProtocols
             } else if let protocolRequirement = relevantRequirements.first {
                 // create TypeName off a single generic's protocol requirement

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -4257,6 +4257,9 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     /// :nodoc:
     public var __parserData: Any?
 
+    /// list of generic requirements
+    public var genericRequirements: [GenericRequirement]
+
     /// :nodoc:
     public init(name: String,
                 selectorName: String? = nil,
@@ -4273,8 +4276,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
                 documentation: [String] = [],
-                definedInTypeName: TypeName? = nil) {
-
+                definedInTypeName: TypeName? = nil,
+                genericRequirements: [GenericRequirement] = []) {
         self.name = name
         self.selectorName = selectorName ?? name
         self.parameters = parameters
@@ -4291,6 +4294,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         self.annotations = annotations
         self.documentation = documentation
         self.definedInTypeName = definedInTypeName
+        self.genericRequirements = genericRequirements
     }
 
     /// :nodoc:
@@ -4311,7 +4315,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string += "documentation = \\(String(describing: self.documentation)), "
         string += "definedInTypeName = \\(String(describing: self.definedInTypeName)), "
         string += "attributes = \\(String(describing: self.attributes)), "
-        string += "modifiers = \\(String(describing: self.modifiers))"
+        string += "modifiers = \\(String(describing: self.modifiers)), "
+        string += "genericRequirements = \\(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -4337,6 +4342,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
         results.append(contentsOf: DiffableResult(identifier: "modifiers").trackDifference(actual: self.modifiers, expected: castObject.modifiers))
+        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         return results
     }
 
@@ -4358,6 +4364,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         hasher.combine(self.definedInTypeName)
         hasher.combine(self.attributes)
         hasher.combine(self.modifiers)
+        hasher.combine(self.genericRequirements)
         return hasher.finalize()
     }
 
@@ -4380,6 +4387,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         if self.definedInTypeName != rhs.definedInTypeName { return false }
         if self.attributes != rhs.attributes { return false }
         if self.modifiers != rhs.modifiers { return false }
+        if self.genericRequirements != rhs.genericRequirements { return false }
         return true
     }
 
@@ -4450,6 +4458,12 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 }
                 fatalError()
              }; self.modifiers = modifiers
+            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
+                withVaList(["genericRequirements"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.genericRequirements = genericRequirements
         }
 
         /// :nodoc:
@@ -4472,6 +4486,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             aCoder.encode(self.definedInType, forKey: "definedInType")
             aCoder.encode(self.attributes, forKey: "attributes")
             aCoder.encode(self.modifiers, forKey: "modifiers")
+            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 }

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -3468,6 +3468,46 @@ public typealias SourceryMethod = Method
 
 /// Describes method
 public final class Method: NSObject, SourceryModel, Annotated, Documented, Definition, Diffable {
+    public subscript(dynamicMember member: String) -> Any? {
+        switch member {
+            case "definedInType":
+                return definedInType
+            case "shortName":
+                return shortName
+            case "name":
+                return name
+            case "selectorName":
+                return selectorName
+            case "callName":
+                return callName
+            case "parameters":
+                return parameters
+            case "throws":
+                return `throws`
+            case "isInitializer":
+                return isInitializer
+            case "accessLevel":
+                return accessLevel
+            case "isStatic":
+                return isStatic
+            case "returnTypeName":
+                return returnTypeName
+            case "isAsync":
+                return isAsync
+            case "attributes":
+                return attributes
+            case "isOptionalReturnType":
+                return isOptionalReturnType
+            case "actualReturnTypeName":
+                return actualReturnTypeName
+            case "isDynamic":
+                return isDynamic
+            case "genericRequirements":
+                return genericRequirements
+            default:
+                fatalError("unable to lookup: \\(member) in \\(self)")
+        }
+    }
 
     /// Full method name, including generic constraints, i.e. `foo<T>(bar: T)`
     public let name: String
@@ -3633,6 +3673,9 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     /// :nodoc:
     public var __parserData: Any?
 
+    /// list of generic requirements
+    public var genericRequirements: [GenericRequirement]
+
     /// :nodoc:
     public init(name: String,
                 selectorName: String? = nil,
@@ -3649,8 +3692,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 modifiers: [SourceryModifier] = [],
                 annotations: [String: NSObject] = [:],
                 documentation: [String] = [],
-                definedInTypeName: TypeName? = nil) {
-
+                definedInTypeName: TypeName? = nil,
+                genericRequirements: [GenericRequirement] = []) {
         self.name = name
         self.selectorName = selectorName ?? name
         self.parameters = parameters
@@ -3667,6 +3710,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         self.annotations = annotations
         self.documentation = documentation
         self.definedInTypeName = definedInTypeName
+        self.genericRequirements = genericRequirements
     }
 
     /// :nodoc:
@@ -3688,6 +3732,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string += "definedInTypeName = \\(String(describing: self.definedInTypeName)), "
         string += "attributes = \\(String(describing: self.attributes)), "
         string += "modifiers = \\(String(describing: self.modifiers))"
+        string += "genericRequirements = \\(String(describing: self.genericRequirements))"
         return string
     }
 
@@ -3713,6 +3758,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
         results.append(contentsOf: DiffableResult(identifier: "attributes").trackDifference(actual: self.attributes, expected: castObject.attributes))
         results.append(contentsOf: DiffableResult(identifier: "modifiers").trackDifference(actual: self.modifiers, expected: castObject.modifiers))
+        results.append(contentsOf: DiffableResult(identifier: "genericRequirements").trackDifference(actual: self.genericRequirements, expected: castObject.genericRequirements))
         return results
     }
 
@@ -3734,6 +3780,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         hasher.combine(self.definedInTypeName)
         hasher.combine(self.attributes)
         hasher.combine(self.modifiers)
+        hasher.combine(self.genericRequirements)
         return hasher.finalize()
     }
 
@@ -3756,6 +3803,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         if self.definedInTypeName != rhs.definedInTypeName { return false }
         if self.attributes != rhs.attributes { return false }
         if self.modifiers != rhs.modifiers { return false }
+        if self.genericRequirements != rhs.genericRequirements { return false }
         return true
     }
 
@@ -3826,6 +3874,12 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 }
                 fatalError()
              }; self.modifiers = modifiers
+            guard let genericRequirements: [GenericRequirement] = aDecoder.decode(forKey: "genericRequirements") else {
+                withVaList(["genericRequirements"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.genericRequirements = genericRequirements
         }
 
         /// :nodoc:
@@ -3848,6 +3902,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             aCoder.encode(self.definedInType, forKey: "definedInType")
             aCoder.encode(self.attributes, forKey: "attributes")
             aCoder.encode(self.modifiers, forKey: "modifiers")
+            aCoder.encode(self.genericRequirements, forKey: "genericRequirements")
         }
 // sourcery:end
 }

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -196,6 +196,7 @@ class ParserComposerSpec: QuickSpec {
                             expect(fooBar?.returnType?.implements["Equatable"]).toNot(beNil())
                             expect(fooBar?.returnType?.implements["Codable"]).toNot(beNil())
                             expect(fooBar?.returnType?.genericRequirements).toNot(beNil())
+                            expect(fooBar?.returnType?.isGeneric).to(beTrue())
                             expect(fooBar?.returnTypeName.actualTypeName?.name).to(contain("Equatable"))
                             expect(fooBar?.returnTypeName.actualTypeName?.name).to(contain("Codable"))
                             expect(fooBar?.returnTypeName.actualTypeName?.name).to(contain("&"))

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -152,6 +152,67 @@ class ParserComposerSpec: QuickSpec {
                                               """)
                             assertMethods(types)
                         }
+
+                        it("extracts method generic requirements properly") {
+                            let types = parse("""
+                                              class Foo {
+                                                  func fooBar<T>(bar: T) where T: Equatable { }
+                                              };
+                                              """)
+                            let fooType = types.first(where: { $0.name == "Foo" })
+                            let fooBar = fooType?.methods.last
+                            expect(fooBar?.name).to(equal("fooBar<T>(bar: T)"))
+                            expect(fooBar?.parameters.first?.type?.implements["Equatable"]).toNot(beNil())
+                            expect(fooBar?.parameters.first?.type?.implements["Codable"]).to(beNil())
+                            expect(fooBar?.parameters.first?.type?.genericRequirements).toNot(beNil())
+                        }
+
+                        it("extracts multiple method generic requirements properly") {
+                            let types = parse("""
+                                              class Foo {
+                                                  func fooBar<T>(bar: T) where T: Equatable, T: Codable { }
+                                              };
+                                              """)
+                            let fooType = types.first(where: { $0.name == "Foo" })
+                            let fooBar = fooType?.methods.last
+                            expect(fooBar?.name).to(equal("fooBar<T>(bar: T)"))
+                            expect(fooBar?.parameters.first?.type?.implements["Equatable"]).toNot(beNil())
+                            expect(fooBar?.parameters.first?.type?.implements["Codable"]).toNot(beNil())
+                            expect(fooBar?.parameters.first?.type?.genericRequirements).toNot(beNil())
+                            expect(fooBar?.parameters.first?.actualTypeName?.name).to(contain("Equatable"))
+                            expect(fooBar?.parameters.first?.actualTypeName?.name).to(contain("Codable"))
+                            expect(fooBar?.parameters.first?.actualTypeName?.name).to(contain("&"))
+                        }
+
+                        it("extracts multiple method generic requirements on return type properly") {
+                            let types = parse("""
+                                              class Foo {
+                                                enum TestEnum: String, Codable, Equatable { case abc, def }
+                                                func fooBar<T>(bar: T) -> T where T: Equatable, T: Codable { TestEnum.abc as! T }
+                                              };
+                                              """)
+                            let fooType = types.first(where: { $0.name == "Foo" })
+                            let fooBar = fooType?.methods.last
+                            expect(fooBar?.returnType?.implements["Equatable"]).toNot(beNil())
+                            expect(fooBar?.returnType?.implements["Codable"]).toNot(beNil())
+                            expect(fooBar?.returnType?.genericRequirements).toNot(beNil())
+                            expect(fooBar?.returnTypeName.actualTypeName?.name).to(contain("Equatable"))
+                            expect(fooBar?.returnTypeName.actualTypeName?.name).to(contain("Codable"))
+                            expect(fooBar?.returnTypeName.actualTypeName?.name).to(contain("&"))
+                        }
+
+                        it("extracts method generic requirements without protocol properly") {
+                            let types = parse("""
+                                              class Foo {
+                                                  func fooBar<T>(bar: T) { }
+                                              };
+                                              """)
+                            let fooType = types.first(where: { $0.name == "Foo" })
+                            let fooBar = fooType?.methods.last
+                            expect(fooBar?.name).to(equal("fooBar<T>(bar: T)"))
+                            expect(fooBar?.parameters.first?.type).to(beNil())
+                            expect(fooBar?.parameters.first?.actualTypeName?.name).to(equal("T"))
+                        }
                     }
 
                     context("given initializer") {

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -59,7 +59,7 @@ import {{ import }}
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic param.type %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName method.returnType %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ '&' if param.typeName.name | hasPrefix:"inout " }}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -82,14 +82,14 @@ import {{ import }}
         {% endfor -%}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic param.type %}{{ ')' if param.isClosure }})?{% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic param.type %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{{ ')' if param.isClosure }})?{% endfor %}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic param.type %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic param.type %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic param.type %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic param.type %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName method.returnType %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
     {% endif %}
     {% call methodClosureDeclaration method %}
 
@@ -104,7 +104,7 @@ import {{ import }}
     {{ value }}
     {% endfor %}
     {% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName method.returnType %}{% endif %} {
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName %}{% endif %} {
         {% call swiftifyMethodName method %}CallsCount += 1
         {% call methodReceivedParameters method %}
         {% if method.throws %}
@@ -155,20 +155,20 @@ import {{ import }}
 {% endmacro %}
 
 {% macro mockOptionalVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %}
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %}
 {% endmacro %}
 
 {% macro mockNonOptionalArrayOrDictionaryVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
 {% endmacro %}
 
 {% macro mockNonOptionalVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %} {
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} {
         get { return {% call underlyingMockedVariableName variable %} }
         set(value) { {% call underlyingMockedVariableName variable %} = value }
     }
-    {% set wrappedTypeName %}{% if variable.typeName.isProtocolComposition %}({% call existentialVariableTypeName variable.typeName variable.type %}){% else %}{% call existentialVariableTypeName variable.typeName variable.type %}{% endif %}{% endset %}
-    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: ({% call existentialVariableTypeName wrappedTypeName variable.type %})!
+    {% set wrappedTypeName %}{% if variable.typeName.isProtocolComposition %}({% call existentialVariableTypeName variable.typeName %}){% else %}{% call existentialVariableTypeName variable.typeName %}{% endif %}{% endset %}
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: ({% call existentialVariableTypeName wrappedTypeName %})!
 {% endmacro %}
 
 {% macro variableThrowableErrorDeclaration variable %}
@@ -182,7 +182,7 @@ import {{ import }}
 {% endmacro %}
 
 {% macro variableClosureDeclaration variable %}
-    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}-> {% call existentialVariableTypeName variable.typeName variable.type %})?
+    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}-> {% call existentialVariableTypeName variable.typeName %})?
 {% endmacro %}
 
 {% macro variableClosureName variable %}{% call mockedVariableName variable %}Closure{% endmacro %}
@@ -193,7 +193,7 @@ import {{ import }}
         return {% call mockedVariableName variable %}CallsCount > 0
     }
 
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %} {
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} {
         get {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}{
             {% call mockedVariableName variable %}CallsCount += 1
             {% if variable.throws %}
@@ -206,7 +206,7 @@ import {{ import }}
             }
         }
     }
-    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %}{{ '!' if not variable.isOptional }}
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %}{{ '!' if not variable.isOptional }}
     {% if variable.throws %}
         {% call variableThrowableErrorDeclaration variable %}
     {% endif %}
@@ -215,12 +215,7 @@ import {{ import }}
 
 {% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
 {% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
-{% macro existentialVariableTypeName typeName type -%}
-    {% set hasSameTypeInGenericRequirements %}
-        {%- for requirement in type.genericRequirements where requirement.leftType.name|contains:typeName.name %}
-            {{ true }}
-        {% endfor -%}
-    {% endset %}
+{% macro existentialVariableTypeName typeName -%}
     {%- if typeName|contains:"<" and typeName|contains:">" -%}
         {{ typeName }}
     {%- elif typeName|contains:"any " and typeName|contains:"!"  -%}
@@ -237,24 +232,11 @@ import {{ import }}
         ({{ typeName | replace:"some","(some" | replace:"?",")?" }})
     {%- elif typeName.isClosure -%}
         ({{ typeName }})
-    {%- elif hasSameTypeInGenericRequirements -%}
-        {%- for requirement in type.genericRequirements where requirement.leftType.name == typeName.name %}
-            {%- if not typeName.actualTypeName == nil -%}
-                {{ typeName.actualTypeName.name }}
-            {%- else -%}
-                {{ Any }}
-            {%- endif -%}
-        {% endfor -%}
     {%- else -%}
         {{ typeName }}
     {%- endif -%}
 {%- endmacro %}
-{% macro existentialClosureVariableTypeName typeName isVariadic type -%}
-    {% set hasSameTypeInGenericRequirements %}
-        {%- for requirement in type.genericRequirements where requirement.leftType.name|contains:typeName.name %}
-            {{ true }}
-        {% endfor -%}
-    {% endset %}
+{% macro existentialClosureVariableTypeName typeName isVariadic -%}
     {%- if typeName|contains:"any " and typeName|contains:"!" -%}
         {{ typeName | replace:"any","(any" | replace:"!",")?" }}
     {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
@@ -269,24 +251,11 @@ import {{ import }}
         {{ typeName | replace:"some","(any" | replace:"?",")?" }}
     {%- elif isVariadic -%}
         {{ typeName }}...
-    {%- elif hasSameTypeInGenericRequirements -%}
-        {%- for requirement in type.genericRequirements where requirement.leftType.name == typeName.name %}
-            {%- if not typeName.actualTypeName == nil -%}
-                {{ typeName.actualTypeName.name }}
-            {%- else -%}
-                {{ Any }}
-            {%- endif -%}
-        {% endfor -%}
     {%- else -%}
         {{ typeName|replace:"some ","any " }}
     {%- endif -%}
 {%- endmacro %}
-{% macro existentialParameterTypeName typeName isVariadic type -%}
-    {% set hasSameTypeInGenericRequirements %}
-        {%- for requirement in type.genericRequirements where requirement.leftType.name|contains:typeName.name %}
-            {{ true }}
-        {% endfor -%}
-    {% endset %}
+{% macro existentialParameterTypeName typeName isVariadic -%}
     {%- if typeName|contains:"any " and typeName|contains:"?," and typeName|contains:">?" -%}
         {{ typeName | replace:"any","(any" | replace:"?,",")?," }}
     {%- elif typeName|contains:"any " and typeName|contains:"!" -%}
@@ -303,19 +272,11 @@ import {{ import }}
         {{ typeName | replace:"some","(some" | replace:"?",")?" }}
     {%- elif isVariadic -%}
         {{ typeName }}...
-    {%- elif hasSameTypeInGenericRequirements -%}
-        {%- for requirement in type.genericRequirements where requirement.leftType.name == typeName.name %}
-            {%- if not typeName.actualTypeName == nil -%}
-                {{ typeName.actualTypeName.name }}
-            {%- else -%}
-                {{ Any }}
-            {%- endif -%}
-        {% endfor -%}
     {%- else -%}
-        {{ typeName|replace:"some ","any " }}
+        {{ typeName }}
     {%- endif -%}
 {%- endmacro %}
-{% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {{ param.name }}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% call existentialParameterTypeName param.typeName param.isVariadic param.type %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}
+{% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {{ param.name }}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% call existentialParameterTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}
 
 {% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
 {% call accessLevel type.accessLevel %}class {{ type.name }}Mock: {{ type.name }} {

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -59,7 +59,7 @@ import {{ import }}
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic param.type %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName method.returnType %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ '&' if param.typeName.name | hasPrefix:"inout " }}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -82,14 +82,14 @@ import {{ import }}
         {% endfor -%}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{{ ')' if param.isClosure }})?{% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic param.type %}{{ ')' if param.isClosure }})?{% endfor %}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic param.type %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic param.type %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic param.type %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic param.type %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic param.type %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName method.returnType %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
     {% endif %}
     {% call methodClosureDeclaration method %}
 
@@ -104,7 +104,7 @@ import {{ import }}
     {{ value }}
     {% endfor %}
     {% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName %}{% endif %} {
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName method.returnType %}{% endif %} {
         {% call swiftifyMethodName method %}CallsCount += 1
         {% call methodReceivedParameters method %}
         {% if method.throws %}
@@ -155,20 +155,20 @@ import {{ import }}
 {% endmacro %}
 
 {% macro mockOptionalVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %}
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %}
 {% endmacro %}
 
 {% macro mockNonOptionalArrayOrDictionaryVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
 {% endmacro %}
 
 {% macro mockNonOptionalVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} {
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %} {
         get { return {% call underlyingMockedVariableName variable %} }
         set(value) { {% call underlyingMockedVariableName variable %} = value }
     }
-    {% set wrappedTypeName %}{% if variable.typeName.isProtocolComposition %}({% call existentialVariableTypeName variable.typeName %}){% else %}{% call existentialVariableTypeName variable.typeName %}{% endif %}{% endset %}
-    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: ({% call existentialVariableTypeName wrappedTypeName %})!
+    {% set wrappedTypeName %}{% if variable.typeName.isProtocolComposition %}({% call existentialVariableTypeName variable.typeName variable.type %}){% else %}{% call existentialVariableTypeName variable.typeName variable.type %}{% endif %}{% endset %}
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: ({% call existentialVariableTypeName wrappedTypeName variable.type %})!
 {% endmacro %}
 
 {% macro variableThrowableErrorDeclaration variable %}
@@ -182,7 +182,7 @@ import {{ import }}
 {% endmacro %}
 
 {% macro variableClosureDeclaration variable %}
-    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}-> {% call existentialVariableTypeName variable.typeName %})?
+    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}-> {% call existentialVariableTypeName variable.typeName variable.type %})?
 {% endmacro %}
 
 {% macro variableClosureName variable %}{% call mockedVariableName variable %}Closure{% endmacro %}
@@ -193,7 +193,7 @@ import {{ import }}
         return {% call mockedVariableName variable %}CallsCount > 0
     }
 
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} {
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %} {
         get {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}{
             {% call mockedVariableName variable %}CallsCount += 1
             {% if variable.throws %}
@@ -206,7 +206,7 @@ import {{ import }}
             }
         }
     }
-    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %}{{ '!' if not variable.isOptional }}
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName variable.type %}{{ '!' if not variable.isOptional }}
     {% if variable.throws %}
         {% call variableThrowableErrorDeclaration variable %}
     {% endif %}
@@ -215,7 +215,12 @@ import {{ import }}
 
 {% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
 {% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
-{% macro existentialVariableTypeName typeName -%}
+{% macro existentialVariableTypeName typeName type -%}
+    {% set hasSameTypeInGenericRequirements %}
+        {%- for requirement in type.genericRequirements where requirement.leftType.name|contains:typeName.name %}
+            {{ true }}
+        {% endfor -%}
+    {% endset %}
     {%- if typeName|contains:"<" and typeName|contains:">" -%}
         {{ typeName }}
     {%- elif typeName|contains:"any " and typeName|contains:"!"  -%}
@@ -232,11 +237,24 @@ import {{ import }}
         ({{ typeName | replace:"some","(some" | replace:"?",")?" }})
     {%- elif typeName.isClosure -%}
         ({{ typeName }})
+    {%- elif hasSameTypeInGenericRequirements -%}
+        {%- for requirement in type.genericRequirements where requirement.leftType.name == typeName.name %}
+            {%- if not typeName.actualTypeName == nil -%}
+                {{ typeName.actualTypeName.name }}
+            {%- else -%}
+                {{ Any }}
+            {%- endif -%}
+        {% endfor -%}
     {%- else -%}
         {{ typeName }}
     {%- endif -%}
 {%- endmacro %}
-{% macro existentialClosureVariableTypeName typeName isVariadic -%}
+{% macro existentialClosureVariableTypeName typeName isVariadic type -%}
+    {% set hasSameTypeInGenericRequirements %}
+        {%- for requirement in type.genericRequirements where requirement.leftType.name|contains:typeName.name %}
+            {{ true }}
+        {% endfor -%}
+    {% endset %}
     {%- if typeName|contains:"any " and typeName|contains:"!" -%}
         {{ typeName | replace:"any","(any" | replace:"!",")?" }}
     {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
@@ -251,11 +269,24 @@ import {{ import }}
         {{ typeName | replace:"some","(any" | replace:"?",")?" }}
     {%- elif isVariadic -%}
         {{ typeName }}...
+    {%- elif hasSameTypeInGenericRequirements -%}
+        {%- for requirement in type.genericRequirements where requirement.leftType.name == typeName.name %}
+            {%- if not typeName.actualTypeName == nil -%}
+                {{ typeName.actualTypeName.name }}
+            {%- else -%}
+                {{ Any }}
+            {%- endif -%}
+        {% endfor -%}
     {%- else -%}
         {{ typeName|replace:"some ","any " }}
     {%- endif -%}
 {%- endmacro %}
-{% macro existentialParameterTypeName typeName isVariadic -%}
+{% macro existentialParameterTypeName typeName isVariadic type -%}
+    {% set hasSameTypeInGenericRequirements %}
+        {%- for requirement in type.genericRequirements where requirement.leftType.name|contains:typeName.name %}
+            {{ true }}
+        {% endfor -%}
+    {% endset %}
     {%- if typeName|contains:"any " and typeName|contains:"?," and typeName|contains:">?" -%}
         {{ typeName | replace:"any","(any" | replace:"?,",")?," }}
     {%- elif typeName|contains:"any " and typeName|contains:"!" -%}
@@ -272,11 +303,19 @@ import {{ import }}
         {{ typeName | replace:"some","(some" | replace:"?",")?" }}
     {%- elif isVariadic -%}
         {{ typeName }}...
+    {%- elif hasSameTypeInGenericRequirements -%}
+        {%- for requirement in type.genericRequirements where requirement.leftType.name == typeName.name %}
+            {%- if not typeName.actualTypeName == nil -%}
+                {{ typeName.actualTypeName.name }}
+            {%- else -%}
+                {{ Any }}
+            {%- endif -%}
+        {% endfor -%}
     {%- else -%}
-        {{ typeName }}
+        {{ typeName|replace:"some ","any " }}
     {%- endif -%}
 {%- endmacro %}
-{% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {{ param.name }}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% call existentialParameterTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}
+{% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {{ param.name }}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% call existentialParameterTypeName param.typeName param.isVariadic param.type %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}
 
 {% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
 {% call accessLevel type.accessLevel %}class {{ type.name }}Mock: {{ type.name }} {


### PR DESCRIPTION
Resolves #1029

## Context

`Method` does not support `genericRequirements` which might exist if method has generic constraints in its signature, i.e. `func method<T: Equatable>() -> T`.

This PR introduces `GenericRequirement`, both parsing and lookup / substitution for both method return type and arguments.

This PR does not resolve issues in `AutoMockable.stencil` which might appear if to mark a protocol with methods that have generic constraints as `AutoMockable`. This can be addressed in a separate PR based on the need.

This PR also introduces `isGeneric = true` to all types which have been found in `genericRequirements` collection taken either from a contained type or from a method signature.