### PR TITLE
[Bugfix][AutoMockable.stencil]- inout with multiple parameters & optional any parameter in completion handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Sourcery CHANGELOG
+## 2.1.8
+## Changes
+- Fix: Function with completion as parameter that contains itself an optional any parameter produces wrong mock ([#1290](https://github.com/krzysztofzablocki/Sourcery/pull/1290))
+- Fix: Function with inout parameter when function has more than one parameter produces wrong mock ([#1290](https://github.com/krzysztofzablocki/Sourcery/pull/1290))
+
 ## 2.1.7
 ## Changes
 - Podspec updates - set correct filepath for Sourcery

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -85,8 +85,8 @@ import {{ import }}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{{ ')' if param.isClosure }})?{% endfor %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName| replace:"inout ","" param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName| replace:"inout ","" param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName| replace:"inout ","" param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName| replace:"inout ","" param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
@@ -239,6 +239,8 @@ import {{ import }}
 {% macro existentialClosureVariableTypeName typeName isVariadic -%}
     {%- if typeName|contains:"any " and typeName|contains:"!" -%}
         {{ typeName | replace:"any","(any" | replace:"!",")?" }}
+    {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
+        ({{ typeName.unwrappedTypeName | replace:"any","(any" | replace:"?",")?" }})?
     {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
         {{ typeName | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"any " and typeName|contains:"?" -%}
@@ -260,6 +262,8 @@ import {{ import }}
         {{ typeName | replace:"any","(any" | replace:"?,",")?," }}
     {%- elif typeName|contains:"any " and typeName|contains:"!" -%}
         {{ typeName | replace:"any","(any" | replace:"!",")!" }}
+    {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
+        ({{ typeName.unwrappedTypeName | replace:"any","(any" | replace:"?",")?" }})?
     {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
         {{ typeName | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"any " and typeName.isOptional -%}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -211,6 +211,13 @@ protocol HouseProtocol: AutoMockable {
     var f4Publisher: GenericType<any PersonProtocol, any PersonProtocol, any PersonProtocol>? { get }
 }
 
+protocol FunctionWithNullableCompletionThatHasNullableAnyParameterProtocol: AutoMockable {
+    func add(
+        _ request: Int,
+         withCompletionHandler completionHandler: (((any Error)?) -> Void)?
+    )
+}
+
 // sourcery: AutoMockable
 protocol ExampleVararg {
     func string(key: String, args: CVarArg...) -> String
@@ -244,4 +251,5 @@ public protocol ProtocolWithMethodWithGenericParameters {
 // sourcery: AutoMockable
 public protocol ProtocolWithMethodWithInoutParameter {
     func execute(param: inout String)
+    func execute(param: inout String, bar: Int)
 }

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -211,6 +211,13 @@ protocol HouseProtocol: AutoMockable {
     var f4Publisher: GenericType<any PersonProtocol, any PersonProtocol, any PersonProtocol>? { get }
 }
 
+protocol FunctionWithNullableCompletionThatHasNullableAnyParameterProtocol: AutoMockable {
+    func add(
+        _ request: Int,
+         withCompletionHandler completionHandler: (((any Error)?) -> Void)?
+    )
+}
+
 // sourcery: AutoMockable
 protocol ExampleVararg {
     func string(key: String, args: CVarArg...) -> String
@@ -244,4 +251,5 @@ public protocol ProtocolWithMethodWithGenericParameters {
 // sourcery: AutoMockable
 public protocol ProtocolWithMethodWithInoutParameter {
     func execute(param: inout String)
+    func execute(param: inout String, bar: Int)
 }

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -888,6 +888,26 @@ class FunctionWithMultilineDeclarationMock: FunctionWithMultilineDeclaration {
 
 
 }
+class FunctionWithNullableCompletionThatHasNullableAnyParameterProtocolMock: FunctionWithNullableCompletionThatHasNullableAnyParameterProtocol {
+
+
+
+
+    //MARK: - add
+
+    var addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCallsCount = 0
+    var addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCalled: Bool {
+        return addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCallsCount > 0
+    }
+    var addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidClosure: ((Int, ((((any Error)?) -> Void))?) -> Void)?
+
+    func add(_ request: Int, withCompletionHandler completionHandler: ((((any Error)?) -> Void))?) {
+        addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCallsCount += 1
+        addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidClosure?(request, completionHandler)
+    }
+
+
+}
 class HouseProtocolMock: HouseProtocol {
 
 
@@ -1091,6 +1111,23 @@ public class ProtocolWithMethodWithInoutParameterMock: ProtocolWithMethodWithIno
         executeParamInoutStringVoidReceivedParam = param
         executeParamInoutStringVoidReceivedInvocations.append(param)
         executeParamInoutStringVoidClosure?(&param)
+    }
+
+    //MARK: - execute
+
+    public var executeParamInoutStringBarIntVoidCallsCount = 0
+    public var executeParamInoutStringBarIntVoidCalled: Bool {
+        return executeParamInoutStringBarIntVoidCallsCount > 0
+    }
+    public var executeParamInoutStringBarIntVoidReceivedArguments: (param: String, bar: Int)?
+    public var executeParamInoutStringBarIntVoidReceivedInvocations: [(param: String, bar: Int)] = []
+    public var executeParamInoutStringBarIntVoidClosure: ((inout String, Int) -> Void)?
+
+    public func execute(param: inout String, bar: Int) {
+        executeParamInoutStringBarIntVoidCallsCount += 1
+        executeParamInoutStringBarIntVoidReceivedArguments = (param: param, bar: bar)
+        executeParamInoutStringBarIntVoidReceivedInvocations.append((param: param, bar: bar))
+        executeParamInoutStringBarIntVoidClosure?(&param, bar)
     }
 
 

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -888,6 +888,26 @@ class FunctionWithMultilineDeclarationMock: FunctionWithMultilineDeclaration {
 
 
 }
+class FunctionWithNullableCompletionThatHasNullableAnyParameterProtocolMock: FunctionWithNullableCompletionThatHasNullableAnyParameterProtocol {
+
+
+
+
+    //MARK: - add
+
+    var addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCallsCount = 0
+    var addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCalled: Bool {
+        return addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCallsCount > 0
+    }
+    var addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidClosure: ((Int, ((((any Error)?) -> Void))?) -> Void)?
+
+    func add(_ request: Int, withCompletionHandler completionHandler: ((((any Error)?) -> Void))?) {
+        addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCallsCount += 1
+        addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidClosure?(request, completionHandler)
+    }
+
+
+}
 class HouseProtocolMock: HouseProtocol {
 
 
@@ -1091,6 +1111,23 @@ public class ProtocolWithMethodWithInoutParameterMock: ProtocolWithMethodWithIno
         executeParamInoutStringVoidReceivedParam = param
         executeParamInoutStringVoidReceivedInvocations.append(param)
         executeParamInoutStringVoidClosure?(&param)
+    }
+
+    //MARK: - execute
+
+    public var executeParamInoutStringBarIntVoidCallsCount = 0
+    public var executeParamInoutStringBarIntVoidCalled: Bool {
+        return executeParamInoutStringBarIntVoidCallsCount > 0
+    }
+    public var executeParamInoutStringBarIntVoidReceivedArguments: (param: String, bar: Int)?
+    public var executeParamInoutStringBarIntVoidReceivedInvocations: [(param: String, bar: Int)] = []
+    public var executeParamInoutStringBarIntVoidClosure: ((inout String, Int) -> Void)?
+
+    public func execute(param: inout String, bar: Int) {
+        executeParamInoutStringBarIntVoidCallsCount += 1
+        executeParamInoutStringBarIntVoidReceivedArguments = (param: param, bar: bar)
+        executeParamInoutStringBarIntVoidReceivedInvocations.append((param: param, bar: bar))
+        executeParamInoutStringBarIntVoidClosure?(&param, bar)
     }
 
 


### PR DESCRIPTION
# Context
I noticed 2 bugs in mock generation. If a user have these kind of APIs:
```swift
public protocol ProtocolWithMethodWithInoutParameter {
    func execute(param: inout String, bar: Int) // 👈 `inout` parameter in a function that have more that one parameter.
}

protocol FunctionWithNullableCompletionThatHasNullableAnyParameterProtocol {
    func add(
        _ request: Int,
        withCompletionHandler completionHandler: (((any Error)?) -> Void)? // 👈 a completion with an optional that is annotated with `any` keyword.
    )
}
```
then it will produce:
```swift
public var executeParamInoutStringBarIntVoidReceivedArguments: (param: inout String, bar: Int)? // ❌ 'inout' may only be used on parameters
public var executeParamInoutStringBarIntVoidReceivedInvocations: [(param: inout String, bar: Int)] = [] // ❌ 'inout' may only be used on parameters

...

var addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidClosure: ((Int, (((any Error)?) -> Void))?) -> Void)? // ❌ Does not compile because parenthesis syntax is wrong 

func add(_ request: Int, withCompletionHandler completionHandler: (((any Error)?) -> Void))?) { // ❌ Does not compile because parenthesis syntax is wrong
     addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCallsCount += 1
     addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidClosure?(request, completionHandler)
}
```
# In this PR
I've updated the AutoMockable.stencil to support these 2 identified cases.

now it will produce:
```swift
public var executeParamInoutStringBarIntVoidReceivedArguments: (param: String, bar: Int)? // ✅
public var executeParamInoutStringBarIntVoidReceivedInvocations: [(param: String, bar: Int)] = [] // ✅

...
var addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidClosure: ((Int, ((((any Error)?) -> Void))?) -> Void)? // ✅

func add(_ request: Int, withCompletionHandler completionHandler: ((((any Error)?) -> Void))?) { // ✅
    addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidCallsCount += 1
    addRequestIntWithCompletionHandlerCompletionHandlerAnyErrorVoidVoidClosure?(request, completionHandler)
}
```
