### PR TITLE
[Bugfix][AutoMockable.stencil]- Avoid side effect

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -59,7 +59,7 @@ import {{ import }}
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic true %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ '&' if param.typeName.name | hasPrefix:"inout " }}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -82,11 +82,11 @@ import {{ import }}
         {% endfor -%}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}{{ ')' if param.isClosure }})?{% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{{ ')' if param.isClosure }})?{% endfor %}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName| replace:"inout ","" param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName| replace:"inout ","" param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName| replace:"inout ","" param.isVariadic %}{% else %}{% call existentialClosureVariableTypeName param.typeName| replace:"inout ","" param.isVariadic %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
@@ -236,25 +236,32 @@ import {{ import }}
         {{ typeName }}
     {%- endif -%}
 {%- endmacro %}
-{% macro existentialClosureVariableTypeName typeName isVariadic -%}
+{% macro existentialClosureVariableTypeName typeName isVariadic keepInout -%}
+    {% set name %}
+        {%- if keepInout -%}
+            {{ typeName }}
+        {%- else -%}
+            {{ typeName | replace:"inout ","" }}
+        {%- endif -%}
+    {% endset %}
     {%- if typeName|contains:"any " and typeName|contains:"!" -%}
-        {{ typeName | replace:"any","(any" | replace:"!",")?" }}
+        {{ name | replace:"any","(any" | replace:"!",")?" }}
     {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
-        ({{ typeName.unwrappedTypeName | replace:"any","(any" | replace:"?",")?" }})?
+        ({{ typeName.unwrappedTypeName| replace:"inout ","" | replace:"any","(any" | replace:"?",")?" }})?
     {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
-        {{ typeName | replace:"any","(any" | replace:"?",")?" }}
+        {{ name | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"any " and typeName|contains:"?" -%}
-        {{ typeName | replace:"any","(any" | replace:"?",")?" }}
+        {{ name | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"some " and typeName|contains:"!" -%}
-        {{ typeName | replace:"some","(any" | replace:"!",")?" }}
+        {{ name | replace:"some","(any" | replace:"!",")?" }}
     {%- elif typeName|contains:"some " and typeName.isClosure and typeName|contains:"?" -%}
-        {{ typeName | replace:"some","(any" | replace:"?",")?" }}
+        {{ name | replace:"some","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"some " and typeName|contains:"?" -%}
-        {{ typeName | replace:"some","(any" | replace:"?",")?" }}
+        {{ name | replace:"some","(any" | replace:"?",")?" }}
     {%- elif isVariadic -%}
-        {{ typeName }}...
+        {{ name }}...
     {%- else -%}
-        {{ typeName|replace:"some ","any " }}
+        {{ name|replace:"some ","any " }}
     {%- endif -%}
 {%- endmacro %}
 {% macro existentialParameterTypeName typeName isVariadic -%}


### PR DESCRIPTION
# Context
Following the merge of #1290, `existentialClosureVariableTypeName` could become ambiguous in the future as `typeName.isClosure` will always be evaluated to empty string in his body. Type seems to be loosed because of the addition of `| replace:"inout ",""` l.88 & 89.

We can reproduce that by adding:
```
...
{% macro existentialClosureVariableTypeName typeName -%}
    -{{ typeName.isClosure }}- // 👈 This
    {%- if typeName|contains:"any " and typeName|contains:"!" -%}
        {{ typeName | replace:"any","(any" | replace:"!",")?" }}
...
```
and observe and compare what happens on the generated mocks.
This will produce:
```
// Now
public var executeParamInoutStringBarIntVoidReceivedArguments: (param: --inout String, bar: --Int)?
public var executeParamInoutStringBarIntVoidReceivedInvocations: [(param: --inout String, bar: --Int)] = []

// After merging this PR
public var executeParamInoutStringBarIntVoidReceivedArguments: (param: -0-inout String, bar: -0-Int)?
public var executeParamInoutStringBarIntVoidReceivedInvocations: [(param: -0-inout String, bar: -0-Int)] = []
```
# In this PR
Even if it works today (at least test guaranteed that) there is high chance to be a headache for future developers when maintaining the file. Passing the `keepInout` boolean into the function and resolve the strategy inside it, should avoid such confusion.