### PR TITLE
Substitute underlying type from typealias

### DIFF
--- a/SourceryRuntime/Sources/Composer/Composer.swift
+++ b/SourceryRuntime/Sources/Composer/Composer.swift
@@ -192,6 +192,14 @@ public enum Composer {
         types.forEach { typesByName[$0.globalName] = $0 }
 
         var processed = [String: Bool]()
+        for type in typesByName.values where !type.typealiases.isEmpty {
+            for alias in type.typealiases {
+                let actualTypeName = alias.value.typeName.name
+                let registeredType = typesByName[actualTypeName]
+                let nameToBeAdded = alias.value.name
+                typesByName[nameToBeAdded] = registeredType
+            }
+        }
         types.forEach { type in
             if let type = type as? Class, let supertype = type.inheritedTypes.first.flatMap({ typesByName[$0] }) as? Class {
                 type.supertype = supertype

--- a/SourceryRuntime/Sources/Composer/Composer.swift
+++ b/SourceryRuntime/Sources/Composer/Composer.swift
@@ -192,14 +192,6 @@ public enum Composer {
         types.forEach { typesByName[$0.globalName] = $0 }
 
         var processed = [String: Bool]()
-        for type in typesByName.values where !type.typealiases.isEmpty {
-            for alias in type.typealiases {
-                let actualTypeName = alias.value.typeName.name
-                let registeredType = typesByName[actualTypeName]
-                let nameToBeAdded = alias.value.name
-                typesByName[nameToBeAdded] = registeredType
-            }
-        }
         types.forEach { type in
             if let type = type as? Class, let supertype = type.inheritedTypes.first.flatMap({ typesByName[$0] }) as? Class {
                 type.supertype = supertype

--- a/SourceryRuntime/Sources/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Composer/ParserResultsComposed.swift
@@ -513,8 +513,8 @@ internal struct ParserResultsComposed {
         var resolvedIdentifier = finalLookup.generic?.name ?? finalLookup.unwrappedTypeName
         for alias in resolvedTypealiases {
             /// iteratively replace all typealiases from the resolvedIdentifier to get to the actual type name requested
-            if resolvedIdentifier.contains(alias.value.name) {
-                resolvedIdentifier.replace(alias.value.name, with: alias.value.typeName.name)
+            if resolvedIdentifier.contains(alias.value.name), let range = resolvedIdentifier.range(of: alias.value.name) {
+                resolvedIdentifier = resolvedIdentifier.replacingCharacters(in: range, with: alias.value.typeName.name)
             }
         }
         // should we cache resolved typenames?

--- a/SourceryRuntime/Sources/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Composer/ParserResultsComposed.swift
@@ -518,6 +518,21 @@ internal struct ParserResultsComposed {
             }
         }
         // should we cache resolved typenames?
+        if unique[resolvedIdentifier] == nil {
+            // peek into typealiases, if any of them contain the same typeName
+            // this is done after the initial attempt in order to prioritise local (recognized) types first
+            // before even trying to substitute the requested type with any typealias
+            for alias in resolvedTypealiases {
+                /// iteratively replace all typealiases from the resolvedIdentifier to get to the actual type name requested,
+                /// ignoring namespacing
+                if resolvedIdentifier == alias.value.aliasName {
+                    resolvedIdentifier = alias.value.typeName.name
+                    typeName.actualTypeName = alias.value.typeName
+                    break
+                }
+            }
+        }
+
         return unique[resolvedIdentifier]
     }
 

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -5087,8 +5087,8 @@ internal struct ParserResultsComposed {
         var resolvedIdentifier = finalLookup.generic?.name ?? finalLookup.unwrappedTypeName
         for alias in resolvedTypealiases {
             /// iteratively replace all typealiases from the resolvedIdentifier to get to the actual type name requested
-            if resolvedIdentifier.contains(alias.value.name) {
-                resolvedIdentifier.replace(alias.value.name, with: alias.value.typeName.name)
+            if resolvedIdentifier.contains(alias.value.name), let range = resolvedIdentifier.range(of: alias.value.name) {
+                resolvedIdentifier = resolvedIdentifier.replacingCharacters(in: range, with: alias.value.typeName.name)
             }
         }
         // should we cache resolved typenames?

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -4284,7 +4284,7 @@ internal struct ParserResultsComposed {
         return modules[moduleName]?[typeName]
     }
 
-    func resolveType(typeName: TypeName, containingType: Type?) -> Type? {
+    func resolveType(typeName: TypeName, containingType: Type?, method: Method? = nil) -> Type? {
         let resolveTypeWithName = { (typeName: TypeName) -> Type? in
             return self.resolveType(typeName: typeName, containingType: containingType)
         }
@@ -4325,6 +4325,7 @@ internal struct ParserResultsComposed {
                                                    array: lookupName.array,
                                                    dictionary: lookupName.dictionary,
                                                    closure: lookupName.closure,
+                                                   set: lookupName.set,
                                                    generic: lookupName.generic
                 )
             }
@@ -4348,6 +4349,7 @@ internal struct ParserResultsComposed {
                                                    array: array,
                                                    dictionary: lookupName.dictionary,
                                                    closure: lookupName.closure,
+                                                   set: lookupName.set,
                                                    generic: typeName.generic
                 )
             }
@@ -4375,6 +4377,7 @@ internal struct ParserResultsComposed {
                                                    array: lookupName.array,
                                                    dictionary: dictionary,
                                                    closure: lookupName.closure,
+                                                   set: lookupName.set,
                                                    generic: dictionary.asGeneric
                 )
             }
@@ -4400,6 +4403,7 @@ internal struct ParserResultsComposed {
                                                    array: lookupName.array,
                                                    dictionary: lookupName.dictionary,
                                                    closure: closure,
+                                                   set: lookupName.set,
                                                    generic: lookupName.generic
                 )
             }
@@ -4435,6 +4439,7 @@ internal struct ParserResultsComposed {
                                                    array: lookupName.array, // TODO: asArray
                                                    dictionary: lookupName.dictionary, // TODO: asDictionary
                                                    closure: lookupName.closure,
+                                                   set: lookupName.set,
                                                    generic: generic
                 )
             }
@@ -4444,10 +4449,79 @@ internal struct ParserResultsComposed {
             typeName.actualTypeName = aliasedName
         }
 
-        let finalLookup = typeName.actualTypeName ?? typeName
-        let resolvedIdentifier = finalLookup.generic?.name ?? finalLookup.unwrappedTypeName
+        let hasGenericRequirements = containingType?.genericRequirements.isEmpty == false
+        || (method != nil && method?.genericRequirements.isEmpty == false)
 
+        if hasGenericRequirements {
+            // we should consider if we are looking up return type of a method with generic constraints
+            // where `typeName` passed would include `... where ...` suffix
+            let typeNameForLookup = typeName.name.split(separator: " ").first!
+            let genericRequirements: [GenericRequirement]
+            if let requirements = containingType?.genericRequirements, !requirements.isEmpty {
+                genericRequirements = requirements
+            } else {
+                genericRequirements = method?.genericRequirements ?? []
+            }
+            let relevantRequirements = genericRequirements.filter {
+                // matched type against a generic requirement name
+                // thus type should be replaced with a protocol composition
+                $0.leftType.name == typeNameForLookup
+            }
+            if relevantRequirements.count > 1 {
+                // compose protocols into `ProtocolComposition` and generate TypeName
+                var implements: [String: Type] = [:]
+                relevantRequirements.forEach {
+                    implements[$0.rightType.typeName.name] = $0.rightType.type
+                }
+                let composedProtocols = ProtocolComposition(
+                    inheritedTypes: relevantRequirements.map { $0.rightType.typeName.unwrappedTypeName },
+                    isGeneric: true,
+                    composedTypes: relevantRequirements.compactMap { $0.rightType.type },
+                    implements: implements
+                )
+                typeName.actualTypeName = TypeName(name: "(\\(relevantRequirements.map { $0.rightType.typeName.unwrappedTypeName }.joined(separator: " & ")))", isProtocolComposition: true)
+                return composedProtocols
+            } else if let protocolRequirement = relevantRequirements.first {
+                // create TypeName off a single generic's protocol requirement
+                typeName.actualTypeName = TypeName(name: "(\\(protocolRequirement.rightType.typeName))")
+                return protocolRequirement.rightType.type
+            }
+        }
+
+        // try to peek into typealias, maybe part of the typeName is a composed identifier from a type and typealias
+        // i.e.
+        // enum Module {
+        //   typealias ID = MyView
+        // }
+        // class MyView {
+        //   class ID: String {}
+        // }
+        //
+        // let variable: Module.ID.ID // should be resolved as MyView.ID type
+        let finalLookup = typeName.actualTypeName ?? typeName
+        var resolvedIdentifier = finalLookup.generic?.name ?? finalLookup.unwrappedTypeName
+        for alias in resolvedTypealiases {
+            /// iteratively replace all typealiases from the resolvedIdentifier to get to the actual type name requested
+            if resolvedIdentifier.contains(alias.value.name) {
+                resolvedIdentifier.replace(alias.value.name, with: alias.value.typeName.name)
+            }
+        }
         // should we cache resolved typenames?
+        if unique[resolvedIdentifier] == nil {
+            // peek into typealiases, if any of them contain the same typeName
+            // this is done after the initial attempt in order to prioritise local (recognized) types first
+            // before even trying to substitute the requested type with any typealias
+            for alias in resolvedTypealiases {
+                /// iteratively replace all typealiases from the resolvedIdentifier to get to the actual type name requested,
+                /// ignoring namespacing
+                if resolvedIdentifier == alias.value.aliasName {
+                    resolvedIdentifier = alias.value.typeName.name
+                    typeName.actualTypeName = alias.value.typeName
+                    break
+                }
+            }
+        }
+
         return unique[resolvedIdentifier]
     }
 
@@ -4472,6 +4546,8 @@ internal struct ParserResultsComposed {
         dictionary?.name = aliased.name
         let array = typeName.array.map { ArrayType(name: $0.name, elementTypeName: $0.elementTypeName, elementType: $0.elementType) }
         array?.name = aliased.name
+        let set = typeName.set.map { SetType(name: $0.name, elementTypeName: $0.elementTypeName, elementType: $0.elementType) }
+        set?.name = aliased.name
 
         return TypeName(name: aliased.name,
                         isOptional: typeName.isOptional,
@@ -4480,6 +4556,7 @@ internal struct ParserResultsComposed {
                         array: aliased.typealias?.typeName.array ?? array,
                         dictionary: aliased.typealias?.typeName.dictionary ?? dictionary,
                         closure: aliased.typealias?.typeName.closure ?? typeName.closure,
+                        set: aliased.typealias?.typeName.set ?? set,
                         generic: aliased.typealias?.typeName.generic ?? generic
         )
     }

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -4502,8 +4502,8 @@ internal struct ParserResultsComposed {
         var resolvedIdentifier = finalLookup.generic?.name ?? finalLookup.unwrappedTypeName
         for alias in resolvedTypealiases {
             /// iteratively replace all typealiases from the resolvedIdentifier to get to the actual type name requested
-            if resolvedIdentifier.contains(alias.value.name) {
-                resolvedIdentifier.replace(alias.value.name, with: alias.value.typeName.name)
+            if resolvedIdentifier.contains(alias.value.name), let range = resolvedIdentifier.range(of: alias.value.name) {
+                resolvedIdentifier = resolvedIdentifier.replacingCharacters(in: range, with: alias.value.typeName.name)
             }
         }
         // should we cache resolved typenames?


### PR DESCRIPTION
Resolves #831 

## Context

This PR adds a type by name lookup for recognizing types hidden "behind" a typealias.

Using the following template, wrong results were produced:

```swift
<%
let foo = types.structs.first { $0.name == "Foo" }!

let bar = foo.instanceVariables.first { $0.name == "bar" }!
print(bar.type.name)
print(bar.typeName)
print(bar.typeName.actualTypeName)
%>
```

Query|Before|After
:-:|:-:|:-:
print(bar.type)|nil|Optional(Int)
print(bar.typeName)|Bar|Bar
print(bar.typeName.actualTypeName)|nil|Optional(Int)





