### PR TITLE
Added support for multiline documentation comments

### DIFF
--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -279,7 +279,7 @@ public struct AnnotationsParser {
                     } else if isMacros {
                         type = .macros
                     }
-                    if isComment {
+                    if isComment || (type == .documentationComment) {
                         switch searchForAnnotations(commentLine: content) {
                         case let .begin(items):
                             type = .blockStart


### PR DESCRIPTION
Resolves #1056 

## Context

This PR enables Sourcery to understand multiline documentation comments, like:

```swift
/** 
 Documentation comment
*/
func something() {}

/** Documentation comment */
func something() {}

/** Documentation comment
*/
func something() {}

/** 
 Documentation comment */
func something() {}
```

, while keeping comments of type `/* comment */` as simple comment and not `documentationComment` to preserve functionality of documentation parser as it was before his PR.