### PR TITLE
Update SwiftSyntax dependency to 510.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "2c49d66d34dfd6f8130afdba889de77504b58ec0",
-        "version" : "508.0.1"
+        "revision" : "08a2f0a9a30e0f705f79c9cfaca1f68b71bdc775",
+        "version" : "510.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -258,7 +258,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
     .package(url: "https://github.com/art-divin/StencilSwiftKit.git", exact: "2.10.4"),
     .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.16.0"),
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
     .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
     .package(url: "https://github.com/art-divin/swift-package-manager.git", from: "1.0.3"),

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/AccessLevel+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/AccessLevel+SwiftSyntax.swift
@@ -4,15 +4,17 @@ import SwiftSyntax
 extension AccessLevel {
     init?(_ modifier: Modifier) {
         switch modifier.tokenKind {
-        case .publicKeyword:
+        case .keyword(.public):
             self = .public
-        case .privateKeyword:
+        case .keyword(.package):
+          self = .package
+        case .keyword(.private):
             self = .private
-        case .fileprivateKeyword:
+        case .keyword(.fileprivate):
             self = .fileprivate
-        case .internalKeyword:
+        case .keyword(.internal):
             self = .internal
-        case .contextualKeyword("open"), .identifier("open"):
+        case .keyword(.open), .identifier("open"):
             self = .open
         default:
             return nil

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Actor+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Actor+SwiftSyntax.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 
 extension Actor {
     convenience init(_ node: ActorDeclSyntax, parent: Type?, annotationsParser: AnnotationsParser) {
-        let modifiers = node.modifiers?.map(Modifier.init) ?? []
+        let modifiers = node.modifiers.map(Modifier.init) ?? []
 
         self.init(
           name: node.identifier.text.trimmingCharacters(in: .whitespaces),

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Attribute+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Attribute+SwiftSyntax.swift
@@ -21,32 +21,13 @@ extension Attribute {
               }
           }
 
-        self.init(name: attribute.attributeName.text.trimmed, arguments: arguments, description: attribute.withoutTrivia().description.trimmed)
-    }
-
-    convenience init(_ attribute: CustomAttributeSyntax) {
-        let nameText = attribute.tokens(viewMode: .fixedUp)
-            .first(where: \.tokenKind.isIdentifier)?
-            .text
-            .trimmed ?? ""
-
-        let arguments = attribute.argumentList?
-            .enumerated()
-            .reduce(into: [String: NSObject]()) { arguments, indexAndSyntax in
-                let (index, syntax) = indexAndSyntax
-                let (key, value) = syntax.keyAndValue
-                arguments[key ?? "\(index)"] = value as NSString
-            } ?? [:]
-
-        self.init(name: nameText, arguments: arguments, description: attribute.withoutTrivia().description.trimmed)
+        self.init(name: attribute.attributeName.description.trimmed, arguments: arguments,  description: attribute.withoutTrivia().description.trimmed)
     }
 
     static func from(_ attributes: AttributeListSyntax?) -> AttributeList {
         let array = attributes?
           .compactMap { syntax -> Attribute? in
             if let syntax = syntax.as(AttributeSyntax.self) {
-                return Attribute(syntax)
-            } else if let syntax = syntax.as(CustomAttributeSyntax.self) {
                 return Attribute(syntax)
             } else {
                 return nil

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Class+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Class+SwiftSyntax.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 
 extension Class {
     convenience init(_ node: ClassDeclSyntax, parent: Type?, annotationsParser: AnnotationsParser) {
-        let modifiers = node.modifiers?.map(Modifier.init) ?? []
+        let modifiers = node.modifiers.map(Modifier.init)
 
         let genericRequirements: [GenericRequirement] = node.genericWhereClause?.requirementList.compactMap { requirement in
             if let sameType = requirement.body.as(SameTypeRequirementSyntax.self) {

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Enum+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Enum+SwiftSyntax.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 
 extension Enum {
     convenience init(_ node: EnumDeclSyntax, parent: Type?, annotationsParser: AnnotationsParser) {
-        let modifiers = node.modifiers?.map(Modifier.init) ?? []
+        let modifiers = node.modifiers.map(Modifier.init)
 
         //let rawTypeName: String? = node.inheritanceClause?.inheritedTypeCollection.first?.typeName.description.trimmed ?? nil
         self.init(

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/EnumCase+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/EnumCase+SwiftSyntax.swift
@@ -20,14 +20,11 @@ extension EnumCase {
                       externalName = name ?? "\(idx)"
                   }
 
-                  var collectedAnnotations = Annotations()
-                  if let typeSyntax = param.type {
-                      collectedAnnotations = annotationsParser.annotations(fromToken: typeSyntax)
-                  }
+                  let collectedAnnotations = annotationsParser.annotations(fromToken: param.type)
 
                   return AssociatedValue(localName: name,
                                          externalName: externalName,
-                                         typeName: param.type.map { TypeName($0) } ?? TypeName.unknown(description: parent.description.trimmed),
+                                         typeName: TypeName(param.type) ?? TypeName.unknown(description: parent.description.trimmed),
                                          type: nil,
                                          defaultValue: defaultValue,
                                          annotations: collectedAnnotations
@@ -35,8 +32,8 @@ extension EnumCase {
               }
         }
 
-        let rawValue: String? = {
-            var value = node.rawValue?.withEqual(nil).withTrailingTrivia(.zero).description.trimmed
+        let rawValue: String? = { () -> String? in
+            var value = node.rawValue?.value.withoutTrivia().description.trimmed
             if let unwrapped = value, unwrapped.hasPrefix("\""), unwrapped.hasSuffix("\""), unwrapped.count > 2 {
                 let substring = unwrapped[unwrapped.index(after: unwrapped.startIndex) ..< unwrapped.index(before: unwrapped.endIndex)]
                 value = String(substring)
@@ -44,9 +41,9 @@ extension EnumCase {
             return value
         }()
 
-        let modifiers = parent.modifiers?.map(Modifier.init) ?? []
+        let modifiers = parent.modifiers.map(Modifier.init)
         let indirect = modifiers.contains(where: {
-            $0.tokenKind == TokenKind.contextualKeyword("indirect")
+            $0.tokenKind == .keyword(.indirect)
         })
 
         self.init(

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
@@ -29,7 +29,7 @@ extension SourceryMethod {
             parameters: signature.input.parameterList,
             output: nil,
             asyncKeyword: nil,
-            throwsOrRethrowsKeyword: signature.throwsOrRethrowsKeyword?.description.trimmed,
+            throwsOrRethrowsKeyword: signature.effectSpecifiers?.throwsSpecifier?.description.trimmed,
             annotationsParser: annotationsParser
           ),
           modifiers: node.modifiers,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/MethodParameter+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/MethodParameter+SwiftSyntax.swift
@@ -3,9 +3,9 @@ import SourceryRuntime
 
 extension MethodParameter {
     convenience init(_ node: FunctionParameterSyntax, annotationsParser: AnnotationsParser) {
-        let firstName = node.firstName?.text.trimmed.nilIfNotValidParameterName
+        let firstName = node.firstName.text.trimmed.nilIfNotValidParameterName
 
-        let typeName = node.type.map { TypeName($0) } ?? TypeName.unknown(description: node.description.trimmed)
+        let typeName = TypeName(node.type)
         let specifiers = TypeName.specifiers(from: node.type)
         
         if specifiers.isInOut {
@@ -21,7 +21,7 @@ extension MethodParameter {
           defaultValue: node.defaultArgument?.value.description.trimmed,
           annotations: node.firstToken.map { annotationsParser.annotations(fromToken: $0) } ?? [:],
           isInout: specifiers.isInOut,
-          isVariadic: node.type?.as(PackExpansionTypeSyntax.self)?.ellipsis != nil
+          isVariadic: node.ellipsis != nil
         )
     }
 }

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Modifier+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Modifier+SwiftSyntax.swift
@@ -41,9 +41,9 @@ extension Array where Element == Modifier {
         var isClass: Bool = false
 
         forEach { modifier in
-            if modifier.tokenKind == .staticKeyword {
+            if modifier.tokenKind == .keyword(.static) {
                 isStatic = true
-            } else if modifier.tokenKind == .classKeyword {
+            } else if modifier.tokenKind == .keyword(.class) {
                 isClass = true
             }
 

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Protocol+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Protocol+SwiftSyntax.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 
 extension SourceryProtocol {
     convenience init(_ node: ProtocolDeclSyntax, parent: Type?, annotationsParser: AnnotationsParser) {
-        let modifiers = node.modifiers?.map(Modifier.init) ?? []
+        let modifiers = node.modifiers.map(Modifier.init) ?? []
 
         let genericRequirements: [GenericRequirement] = node.genericWhereClause?.requirementList.compactMap { requirement in
             if let sameType = requirement.body.as(SameTypeRequirementSyntax.self) {

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
@@ -17,8 +17,8 @@ public struct Signature {
     public init(_ node: FunctionSignatureSyntax, annotationsParser: AnnotationsParser) {
         self.init(parameters: node.input.parameterList,
                   output: node.output.map { TypeName($0.returnType) },
-                  asyncKeyword: node.asyncOrReasyncKeyword?.text,
-                  throwsOrRethrowsKeyword: node.throwsOrRethrowsKeyword?.description.trimmed,
+                  asyncKeyword: node.effectSpecifiers?.asyncSpecifier?.text,
+                  throwsOrRethrowsKeyword: node.effectSpecifiers?.throwsSpecifier?.description.trimmed,
                   annotationsParser: annotationsParser
         )
     }

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Struct+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Struct+SwiftSyntax.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 
 extension Struct {
     convenience init(_ node: StructDeclSyntax, parent: Type?, annotationsParser: AnnotationsParser) {
-        let modifiers = node.modifiers?.map(Modifier.init) ?? []
+        let modifiers = node.modifiers.map(Modifier.init)
 
         let genericRequirements: [GenericRequirement] = node.genericWhereClause?.requirementList.compactMap { requirement in
             if let sameType = requirement.body.as(SameTypeRequirementSyntax.self) {

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -148,12 +148,12 @@ extension TypeName {
                   name: node.secondName?.text.trimmed ?? firstName,
                   typeName: typeName,
                   isInout: specifiers.isInOut,
-                  isVariadic: node.type.as(PackExpansionTypeSyntax.self)?.ellipsis != nil
+                  isVariadic: node.ellipsis != nil
                 )
             }
-            let returnTypeName = TypeName(typeIdentifier.returnType)
-            let asyncKeyword = typeIdentifier.fixedAsyncKeyword.map { $0.text.trimmed }
-            let throwsOrRethrows = typeIdentifier.fixedThrowsOrRethrowsKeyword.map { $0.text.trimmed }
+            let returnTypeName = TypeName(typeIdentifier.returnClause.type)
+            let asyncKeyword = typeIdentifier.effectSpecifiers?.asyncSpecifier.map { $0.text.trimmed }
+            let throwsOrRethrows = typeIdentifier.effectSpecifiers?.throwsSpecifier.map { $0.text.trimmed }
             let name = "\(elements.asSource)\(asyncKeyword != nil ? " \(asyncKeyword!)" : "")\(throwsOrRethrows != nil ? " \(throwsOrRethrows!)" : "") -> \(returnTypeName.asSource)"
             self.init(
                 name: name,
@@ -199,7 +199,7 @@ extension TypeName {
 
         var isInOut = false
         if let typeIdentifier = type.as(AttributedTypeSyntax.self), let specifier = typeIdentifier.specifier {
-            if specifier.tokenKind == .inoutKeyword {
+            if specifier.tokenKind == .keyword(.inout) {
                 isInOut = true
             } else {
                 assertionFailure("Unhandled specifier")

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/Syntax+Extensions.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/Syntax+Extensions.swift
@@ -12,7 +12,8 @@ public extension TriviaPiece {
              .carriageReturns,
              .carriageReturnLineFeeds,
              .unexpectedText,
-             .shebang:
+             .backslashes,
+             .pounds:
             return nil
         case .lineComment(let comment),
              .blockComment(let comment),
@@ -22,62 +23,6 @@ public extension TriviaPiece {
         }
     }
 }
-
-// seems to be bug in SwiftSyntax
-public protocol AsyncThrowsFixup {
-    var asyncKeyword: TokenSyntax? { get }
-    var throwsKeyword: TokenSyntax? { get }
-
-    var fixedAsyncKeyword: TokenSyntax? { get }
-    var fixedThrowsKeyword: TokenSyntax? { get }
-}
-
-public protocol AsyncReThrowsFixup {
-    var asyncKeyword: TokenSyntax? { get }
-    var throwsOrRethrowsKeyword: TokenSyntax? { get }
-
-    var fixedAsyncKeyword: TokenSyntax? { get }
-    var fixedThrowsOrRethrowsKeyword: TokenSyntax? { get }
-}
-
-
-public extension AsyncThrowsFixup {
-    var fixedAsyncKeyword: TokenSyntax? {
-        if asyncKeyword?.tokenKind == .throwsKeyword {
-            return nil
-        }
-
-        return asyncKeyword
-    }
-
-    var fixedThrowsKeyword: TokenSyntax? {
-        if asyncKeyword?.tokenKind == .throwsKeyword && throwsKeyword == nil {
-            return asyncKeyword
-        } else {
-            return throwsKeyword
-        }
-    }
-}
-
-public extension AsyncReThrowsFixup {
-    var fixedAsyncKeyword: TokenSyntax? {
-        if asyncKeyword?.tokenKind == .throwsKeyword {
-            return nil
-        }
-
-        return asyncKeyword
-    }
-
-    var fixedThrowsOrRethrowsKeyword: TokenSyntax? {
-        if asyncKeyword?.tokenKind == .throwsKeyword && throwsOrRethrowsKeyword == nil {
-            return asyncKeyword
-        } else {
-            return throwsOrRethrowsKeyword
-        }
-    }
-}
-extension AccessorListSyntax.Element: AsyncThrowsFixup {}
-extension FunctionTypeSyntax: AsyncReThrowsFixup {}
 
 protocol IdentifierSyntax: SyntaxProtocol {
     var identifier: TokenSyntax { get }
@@ -100,3 +45,10 @@ extension TypealiasDeclSyntax: IdentifierSyntax {}
 extension OperatorDeclSyntax: IdentifierSyntax {}
 
 extension EnumCaseElementSyntax: IdentifierSyntax {}
+
+extension SyntaxProtocol {
+  func withoutTrivia() -> Self {
+    with(\.leadingTrivia, [])
+      .with(\.trailingTrivia, [])
+  }
+}

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/SyntaxTreeCollector.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/SyntaxTreeCollector.swift
@@ -123,7 +123,7 @@ class SyntaxTreeCollector: SyntaxVisitor {
 
     public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
         startVisitingType(node) { parent in
-            let modifiers = node.modifiers?.map(Modifier.init) ?? []
+            let modifiers = node.modifiers.map(Modifier.init)
             let base = modifiers.baseModifiers(parent: nil)
 
             return Type(
@@ -204,7 +204,7 @@ class SyntaxTreeCollector: SyntaxVisitor {
     public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
         let localName = node.identifier.text.trimmed
         let typeName = TypeName(node.initializer.value)
-        let modifiers = node.modifiers?.map(Modifier.init) ?? []
+        let modifiers = node.modifiers.map(Modifier.init)
         let baseModifiers = modifiers.baseModifiers(parent: visitingType)
         let annotations = annotationsParser.annotations(from: node)
         let documentation = annotationsParser.documentation(from: node)

--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -99,15 +99,11 @@ public struct AnnotationsParser {
     }
 
     private func from(location: SwiftSyntax.SourceLocation) -> Annotations {
-        guard let lineNumber = location.line, let column = location.column else {
-            return [:]
-        }
-
         var stop = false
-        var annotations = inlineFrom(line: (lineNumber, column), stop: &stop)
+        var annotations = inlineFrom(line: (location.line, location.column), stop: &stop)
         guard !stop else { return annotations }
 
-        let reversedArray = lines[0..<lineNumber-1].reversed()
+        let reversedArray = lines[0..<location.line-1].reversed()
         for line in reversedArray {
             line.annotations.forEach { annotation in
                 AnnotationsParser.append(key: annotation.key, value: annotation.value, to: &annotations)
@@ -122,7 +118,7 @@ public struct AnnotationsParser {
             }
         }
 
-        lines[lineNumber-1].annotations.forEach { annotation in
+      lines[location.line-1].annotations.forEach { annotation in
             AnnotationsParser.append(key: annotation.key, value: annotation.value, to: &annotations)
         }
 
@@ -130,13 +126,12 @@ public struct AnnotationsParser {
     }
 
     private func documentationFrom(location: SwiftSyntax.SourceLocation) -> Documentation {
-        guard parseDocumentation,
-            let lineNumber = location.line, let column = location.column else {
+      guard parseDocumentation else {
             return []
         }
 
         // Inline documentation not currently supported
-        _ = column
+        _ = location.column
 
         // var stop = false
         // var documentation = inlineDocumentationFrom(line: (lineNumber, column), stop: &stop)
@@ -144,7 +139,7 @@ public struct AnnotationsParser {
 
         var documentation: Documentation = []
 
-        for line in lines[0..<lineNumber-1].reversed() {
+        for line in lines[0..<location.line-1].reversed() {
             if line.type == .documentationComment {
                 var clearedLine = line.content.trimmingCharacters(in: .whitespaces)
                 clearedLine = clearedLine.trimmingPrefix("///")


### PR DESCRIPTION
This PR updates the SwiftSyntax dependency from 508.0.1 to 510.0.0. This should add support for parsing syntax that was added in Swift 5.9 / Swift 5.10.

For example, within Airbnb we've sometimes seen parsing failures in Sourcery when trying to use if / switch expressions. These were added in Swift 5.9 so are not supported by SwiftSyntax 508.0.1. I believe updating to a more recent version of SwiftSyntax should fix this issue.

SwiftSyntax 509.0.0 included a lot of breaking changes. This PR fixes all the breaking changes, so everything compiles. 

As far as I can tell locally, the tests still pass after these changes.