### PR TITLE
Disabled Optimization During Generated Code Verification

### DIFF
--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -242,6 +242,7 @@ open class SwiftTemplate {
             "swift",
             "build",
             "-c", "release",
+            "-Xswiftc", "-Onone",
             "-Xswiftc", "-suppress-warnings",
             "--disable-sandbox"
         ]
@@ -250,6 +251,7 @@ open class SwiftTemplate {
             "swift",
             "build",
             "-c", "release",
+            "-Xswiftc", "-Onone",
             "-Xswiftc", "-suppress-warnings",
             "--disable-sandbox"
         ]


### PR DESCRIPTION
## Context

SwiftTemplate uses `swift` compiler to verify generated code.
Verification does not generate `binary` for use, rather, a successful result of the generation is all what matters for all use cases of `Sourcery` executable.

For code verification, we want to use `-c release` to not make compiler generate additional "debug code" metadata, but we definitely do not want to use optimization during this compilation process.