### PR TITLE
Expand --serialParse flag to also apply to Composer.uniqueTypesAndFunctions

### DIFF
--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -405,7 +405,7 @@ extension Sourcery {
         let uniqueTypeStart = currentTimestamp()
 
         // ! All files have been scanned, time to join extensions with base class
-        let (types, functions, typealiases) = Composer.uniqueTypesAndFunctions(parserResult)
+        let (types, functions, typealiases) = Composer.uniqueTypesAndFunctions(parserResult, serial: serialParse)
 
 
         let filesThatHadToBeParsed = allResults

--- a/SourceryRuntime/Sources/Common/Array+Parallel.swift
+++ b/SourceryRuntime/Sources/Common/Array+Parallel.swift
@@ -24,9 +24,9 @@ public extension Array {
         }
     }
 
-    func parallelPerform(transform: (Element) -> Void) {
+    func parallelPerform(_ work: (Element) -> Void) {
         DispatchQueue.concurrentPerform(iterations: count) { idx in
-            transform(self[idx])
+            work(self[idx])
         }
     }
 }

--- a/SourceryRuntime/Sources/Common/TemplateContext.swift
+++ b/SourceryRuntime/Sources/Common/TemplateContext.swift
@@ -48,7 +48,7 @@ public final class TemplateContext: NSObject, SourceryModel, NSCoding, Diffable 
         let fileParserResultCopy: FileParserResult? = nil
 //      fileParserResultCopy = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(NSKeyedArchiver.archivedData(withRootObject: parserResult)) as? FileParserResult
 
-        let composed = Composer.uniqueTypesAndFunctions(parserResult)
+        let composed = Composer.uniqueTypesAndFunctions(parserResult, serial: false)
         self.types = .init(types: composed.types, typealiases: composed.typealiases)
         self.functions = composed.functions
 


### PR DESCRIPTION
This PR expands the `--serialParse` flag to also apply to `Composer.uniqueTypesAndFunctions`, so it also performs work serially instead of concurrently.

This is a follow-up to https://github.com/krzysztofzablocki/Sourcery/pull/1063. 

Eric posted that PR to work around a concurrency-related crash we hit in Sourcery when running it on Airbnb's app codebase. Since then, we've internally been using a custom build of Sourcery with that change _plus_ an additional change that updates `Composer.uniqueTypesAndFunctions` to also be serial. I've confirmed that we still occasionally see concurrency-related crashes without that additional change.

The `--serialParse` flag was introduced as a way to work around concurrency-related crashes. Since it is possible to hit concurrency-related crashes in `Composer.uniqueTypesAndFunctions`, it seems reasonable to expand the `--serialParse` option to also disable concurrency within that method. This resolves the crashes we hit internally when trying to adopt Sourcery 2.1.7.

