### PR TITLE
Make AutoMockable Generate Compilable Swift Code

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/MethodParameter+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/MethodParameter+SwiftSyntax.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 import SourceryRuntime
 
 extension MethodParameter {
-    convenience init(_ node: FunctionParameterSyntax, annotationsParser: AnnotationsParser) {
+    convenience init(_ node: FunctionParameterSyntax, index: Int, annotationsParser: AnnotationsParser) {
         let firstName = node.firstName.text.trimmed.nilIfNotValidParameterName
 
         let typeName = TypeName(node.type)
@@ -16,6 +16,7 @@ extension MethodParameter {
         self.init(
           argumentLabel: firstName,
           name: node.secondName?.text.trimmed ?? firstName ?? "",
+          index: index,
           typeName: typeName,
           type: nil,
           defaultValue: node.defaultValue?.value.description.trimmed,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
@@ -24,7 +24,13 @@ public struct Signature {
     }
 
     public init(parameters: FunctionParameterListSyntax?, output: TypeName?, asyncKeyword: String?, throwsOrRethrowsKeyword: String?, annotationsParser: AnnotationsParser) {
-        input = parameters?.map { MethodParameter($0, annotationsParser: annotationsParser) } ?? []
+        var methodParameters: [MethodParameter] = []
+        if let parameters {
+            for (idx, param) in parameters.enumerated() {
+                methodParameters.append(MethodParameter(param, index: idx, annotationsParser: annotationsParser))
+            }
+        }
+        input = methodParameters
         self.output = output
         self.asyncKeyword = asyncKeyword
         self.throwsOrRethrowsKeyword = throwsOrRethrowsKeyword

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
@@ -83,8 +83,12 @@ extension Subscript {
             return nil
         } ?? []
 
+        var parameters: [MethodParameter] = []
+        for (idx, param) in node.parameterClause.parameters.enumerated() {
+            parameters.append(MethodParameter(param, index: idx, annotationsParser: annotationsParser))
+        }
         self.init(
-          parameters: node.parameterClause.parameters.map { MethodParameter($0, annotationsParser: annotationsParser) },
+          parameters: parameters,
           returnTypeName: TypeName(node.returnClause.type),
           accessLevel: (read: readAccess, write: isWritable ? writeAccess : .none),
           isAsync: hadAsync,

--- a/SourceryRuntime/Sources/macOS/AST/MethodParameter.swift
+++ b/SourceryRuntime/Sources/macOS/AST/MethodParameter.swift
@@ -36,11 +36,15 @@ public class MethodParameter: NSObject, SourceryModel, Typed, Annotated, Diffabl
     /// Annotations, that were created with // sourcery: annotation1, other = "annotation value", alterantive = 2
     public var annotations: Annotations = [:]
 
+    /// Method parameter index in the argument list
+    public var index: Int
+
     /// :nodoc:
-    public init(argumentLabel: String?, name: String = "", typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false, isVariadic: Bool = false) {
+    public init(argumentLabel: String?, name: String = "", index: Int, typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false, isVariadic: Bool = false) {
         self.typeName = typeName
         self.argumentLabel = argumentLabel
         self.name = name
+        self.index = index
         self.type = type
         self.defaultValue = defaultValue
         self.annotations = annotations
@@ -49,10 +53,11 @@ public class MethodParameter: NSObject, SourceryModel, Typed, Annotated, Diffabl
     }
 
     /// :nodoc:
-    public init(name: String = "", typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false, isVariadic: Bool = false) {
+    public init(name: String = "", index: Int, typeName: TypeName, type: Type? = nil, defaultValue: String? = nil, annotations: [String: NSObject] = [:], isInout: Bool = false, isVariadic: Bool = false) {
         self.typeName = typeName
         self.argumentLabel = name
         self.name = name
+        self.index = index
         self.type = type
         self.defaultValue = defaultValue
         self.annotations = annotations
@@ -88,7 +93,8 @@ public class MethodParameter: NSObject, SourceryModel, Typed, Annotated, Diffabl
         string.append("typeAttributes = \(String(describing: self.typeAttributes)), ")
         string.append("defaultValue = \(String(describing: self.defaultValue)), ")
         string.append("annotations = \(String(describing: self.annotations)), ")
-        string.append("asSource = \(String(describing: self.asSource))")
+        string.append("asSource = \(String(describing: self.asSource)), ")
+        string.append("index = \(String(describing: self.index))")
         return string
     }
 
@@ -105,6 +111,7 @@ public class MethodParameter: NSObject, SourceryModel, Typed, Annotated, Diffabl
         results.append(contentsOf: DiffableResult(identifier: "isVariadic").trackDifference(actual: self.isVariadic, expected: castObject.isVariadic))
         results.append(contentsOf: DiffableResult(identifier: "defaultValue").trackDifference(actual: self.defaultValue, expected: castObject.defaultValue))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
+        results.append(contentsOf: DiffableResult(identifier: "index").trackDifference(actual: self.index, expected: castObject.index))
         return results
     }
 
@@ -152,6 +159,7 @@ public class MethodParameter: NSObject, SourceryModel, Typed, Annotated, Diffabl
                 }
                 fatalError()
              }; self.typeName = typeName
+            self.index = aDecoder.decode(forKey: "index")
             self.`inout` = aDecoder.decode(forKey: "`inout`")
             self.isVariadic = aDecoder.decode(forKey: "isVariadic")
             self.type = aDecoder.decode(forKey: "type")
@@ -168,6 +176,7 @@ public class MethodParameter: NSObject, SourceryModel, Typed, Annotated, Diffabl
         public func encode(with aCoder: NSCoder) {
             aCoder.encode(self.argumentLabel, forKey: "argumentLabel")
             aCoder.encode(self.name, forKey: "name")
+            aCoder.encode(self.index, forKey: "index")
             aCoder.encode(self.typeName, forKey: "typeName")
             aCoder.encode(self.`inout`, forKey: "`inout`")
             aCoder.encode(self.isVariadic, forKey: "isVariadic")

--- a/SourceryTests/GeneratorSpec.swift
+++ b/SourceryTests/GeneratorSpec.swift
@@ -36,9 +36,9 @@ class GeneratorSpec: QuickSpec {
                 ]
 
                 complexType.rawMethods = [
-                    Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "Int"))], accessLevel: .public, definedInTypeName: TypeName(name: "Complex")),
-                    Method(name: "foo2(some: Int)", selectorName: "foo2(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "Float"))], isStatic: true, definedInTypeName: TypeName(name: "Complex")),
-                    Method(name: "foo3(some: Int)", selectorName: "foo3(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "Int"))], isClass: true, definedInTypeName: TypeName(name: "Complex"))
+                    Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int"))], accessLevel: .public, definedInTypeName: TypeName(name: "Complex")),
+                    Method(name: "foo2(some: Int)", selectorName: "foo2(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Float"))], isStatic: true, definedInTypeName: TypeName(name: "Complex")),
+                    Method(name: "foo3(some: Int)", selectorName: "foo3(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int"))], isClass: true, definedInTypeName: TypeName(name: "Complex"))
                 ]
 
                 let complexTypeExtension = Type(name: "Complex", isExtension: true, variables: [])
@@ -47,14 +47,14 @@ class GeneratorSpec: QuickSpec {
                     Variable(name: "tupleFromExtension", typeName: .buildTuple(.Int, TypeName(name: "Bar")), isComputed: true, definedInTypeName: TypeName(name: "Complex"))
                 ]
                 complexTypeExtension.rawMethods = [
-                    Method(name: "fooFromExtension(some: Int)", selectorName: "fooFromExtension(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Complex")),
-                    Method(name: "foo2FromExtension(some: Int)", selectorName: "foo2FromExtension(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "Float"))], definedInTypeName: TypeName(name: "Complex"))
+                    Method(name: "fooFromExtension(some: Int)", selectorName: "fooFromExtension(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Complex")),
+                    Method(name: "foo2FromExtension(some: Int)", selectorName: "foo2FromExtension(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Float"))], definedInTypeName: TypeName(name: "Complex"))
                 ]
 
                 let knownProtocol = Protocol(name: "KnownProtocol", variables: [
                     Variable(name: "protocolVariable", typeName: TypeName(name: "Int"), isComputed: true, definedInTypeName: TypeName(name: "KnownProtocol"))
                     ], methods: [
-                        Method(name: "foo(some: String)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "String"))], accessLevel: .public, definedInTypeName: TypeName(name: "KnownProtocol"))
+                        Method(name: "foo(some: String)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "String"))], accessLevel: .public, definedInTypeName: TypeName(name: "KnownProtocol"))
                     ])
 
                 let innerOptionsType = Type(name: "InnerOptions", accessLevel: .public, variables: [

--- a/SourceryTests/Models/MethodSpec.swift
+++ b/SourceryTests/Models/MethodSpec.swift
@@ -15,7 +15,7 @@ class MethodSpec: QuickSpec {
             var sut: SourceryMethod?
 
             beforeEach {
-                sut = Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Bar"))
+                sut = Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Bar"))
             }
 
             afterEach {
@@ -69,7 +69,7 @@ class MethodSpec: QuickSpec {
 
                 context("given same items") {
                     it("is equal") {
-                        expect(sut).to(equal(Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Bar"))))
+                        expect(sut).to(equal(Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Bar"))))
                     }
                 }
 
@@ -77,11 +77,11 @@ class MethodSpec: QuickSpec {
                     var mockMethodParameters: [MethodParameter]!
 
                     beforeEach {
-                        mockMethodParameters = [MethodParameter(name: "some", typeName: TypeName(name: "Int"))]
+                        mockMethodParameters = [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int"))]
                     }
 
                     it("is not equal") {
-                        expect(sut).toNot(equal(Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Baz"))))
+                        expect(sut).toNot(equal(Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Baz"))))
                         expect(sut).toNot(equal(Method(name: "bar(some: Int)", selectorName: "bar(some:)", parameters: mockMethodParameters, returnTypeName: TypeName(name: "Void"), accessLevel: .internal, isStatic: false, isClass: false, isFailableInitializer: false, annotations: [:])))
                         expect(sut).toNot(equal(Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: [], returnTypeName: TypeName(name: "Void"), accessLevel: .internal, isStatic: false, isClass: false, isFailableInitializer: false, annotations: [:])))
                         expect(sut).toNot(equal(Method(name: "foo(some: Int)", selectorName: "foo(some:)", parameters: mockMethodParameters, returnTypeName: TypeName(name: "String"), accessLevel: .internal, isStatic: false, isClass: false, isFailableInitializer: false, annotations: [:])))
@@ -102,7 +102,7 @@ class MethodSpec: QuickSpec {
 
             context("given default initializer parameters") {
                 beforeEach {
-                    sut = MethodParameter(typeName: TypeName(name: "Int"))
+                    sut = MethodParameter(index: 0, typeName: TypeName(name: "Int"))
                 }
 
                 it("has empty name") {
@@ -132,7 +132,7 @@ class MethodSpec: QuickSpec {
 
             context("given method parameter with attributes") {
                 beforeEach {
-                    sut = MethodParameter(typeName: TypeName(name: "ConversationApiResponse", attributes: ["escaping": [Attribute(name: "escaping")]]))
+                    sut = MethodParameter(index: 0, typeName: TypeName(name: "ConversationApiResponse", attributes: ["escaping": [Attribute(name: "escaping")]]))
                 }
 
                 it("returns unwrapped type name") {
@@ -143,7 +143,7 @@ class MethodSpec: QuickSpec {
 
             context("when inout") {
                 beforeEach {
-                    sut = MethodParameter(typeName: TypeName(name: "Bar"), isInout: true)
+                    sut = MethodParameter(index: 0, typeName: TypeName(name: "Bar"), isInout: true)
                 }
 
                 it("is inout") {
@@ -153,21 +153,21 @@ class MethodSpec: QuickSpec {
 
             describe("when testing equality") {
                 beforeEach {
-                    sut = MethodParameter(name: "foo", typeName: TypeName(name: "Int"))
+                    sut = MethodParameter(name: "foo", index: 0, typeName: TypeName(name: "Int"))
                 }
 
                 context("given same items") {
                     it("is equal") {
-                        expect(sut).to(equal(MethodParameter(name: "foo", typeName: TypeName(name: "Int"))))
+                        expect(sut).to(equal(MethodParameter(name: "foo", index: 0, typeName: TypeName(name: "Int"))))
                     }
                 }
 
                 context("given different items") {
                     it("is not equal") {
-                        expect(sut).toNot(equal(MethodParameter(name: "bar", typeName: TypeName(name: "Int"))))
-                        expect(sut).toNot(equal(MethodParameter(argumentLabel: "bar", name: "foo", typeName: TypeName(name: "Int"))))
-                        expect(sut).toNot(equal(MethodParameter(name: "foo", typeName: TypeName(name: "String"))))
-                        expect(sut).toNot(equal(MethodParameter(name: "foo", typeName: TypeName(name: "String"), isInout: true)))
+                        expect(sut).toNot(equal(MethodParameter(name: "bar", index: 0, typeName: TypeName(name: "Int"))))
+                        expect(sut).toNot(equal(MethodParameter(argumentLabel: "bar", name: "foo", index: 0, typeName: TypeName(name: "Int"))))
+                        expect(sut).toNot(equal(MethodParameter(name: "foo", index: 0, typeName: TypeName(name: "String"))))
+                        expect(sut).toNot(equal(MethodParameter(name: "foo", index: 0, typeName: TypeName(name: "String"), isInout: true)))
                     }
                 }
 

--- a/SourceryTests/Models/TypedSpec.generated.swift
+++ b/SourceryTests/Models/TypedSpec.generated.swift
@@ -144,40 +144,40 @@ class TypedSpec: QuickSpec {
 
 #if canImport(ObjectiveC)
             it("can report optional via KVC") {
-                expect(MethodParameter(typeName: typeName("Int?")).value(forKeyPath: "isOptional") as? Bool).to(equal(true))
-                expect(MethodParameter(typeName: typeName("Int!")).value(forKeyPath: "isOptional") as? Bool).to(equal(true))
-                expect(MethodParameter(typeName: typeName("Int?")).value(forKeyPath: "isImplicitlyUnwrappedOptional") as? Bool).to(equal(false))
-                expect(MethodParameter(typeName: typeName("Int!")).value(forKeyPath: "isImplicitlyUnwrappedOptional") as? Bool).to(equal(true))
-                expect(MethodParameter(typeName: typeName("Int?")).value(forKeyPath: "unwrappedTypeName") as? String).to(equal("Int"))
+                expect(MethodParameter(index: 0, typeName: typeName("Int?")).value(forKeyPath: "isOptional") as? Bool).to(equal(true))
+                expect(MethodParameter(index: 0, typeName: typeName("Int!")).value(forKeyPath: "isOptional") as? Bool).to(equal(true))
+                expect(MethodParameter(index: 0, typeName: typeName("Int?")).value(forKeyPath: "isImplicitlyUnwrappedOptional") as? Bool).to(equal(false))
+                expect(MethodParameter(index: 0, typeName: typeName("Int!")).value(forKeyPath: "isImplicitlyUnwrappedOptional") as? Bool).to(equal(true))
+                expect(MethodParameter(index: 0, typeName: typeName("Int?")).value(forKeyPath: "unwrappedTypeName") as? String).to(equal("Int"))
             }
 
             it("can report tuple type via KVC") {
-                let sut = MethodParameter(typeName: typeName("(Int, Int)"))
+                let sut = MethodParameter(index: 0, typeName: typeName("(Int, Int)"))
                 expect(sut.value(forKeyPath: "isTuple") as? Bool).to(equal(true))
             }
 
             it("can report closure type via KVC") {
-                let sut = MethodParameter(typeName: typeName("(Int) -> (Int)"))
+                let sut = MethodParameter(index: 0, typeName: typeName("(Int) -> (Int)"))
                 expect(sut.value(forKeyPath: "isClosure") as? Bool).to(equal(true))
             }
 
             it("can report array type via KVC") {
-                let sut = MethodParameter(typeName: typeName("[Int]"))
+                let sut = MethodParameter(index: 0, typeName: typeName("[Int]"))
                 expect(sut.value(forKeyPath: "isArray") as? Bool).to(equal(true))
             }
 
             it("can report set type via KVC") {
-                let sut = MethodParameter(typeName: typeName("Set<Int>"))
+                let sut = MethodParameter(index: 0, typeName: typeName("Set<Int>"))
                 expect(sut.value(forKeyPath: "isSet") as? Bool).to(equal(true))
             }
 
             it("can report dictionary type via KVC") {
-                let sut = MethodParameter(typeName: typeName("[Int: Int]"))
+                let sut = MethodParameter(index: 0, typeName: typeName("[Int: Int]"))
                 expect(sut.value(forKeyPath: "isDictionary") as? Bool).to(equal(true))
             }
 
             it("can report actual type name via KVC") {
-                let sut = MethodParameter(typeName: typeName("Alias"))
+                let sut = MethodParameter(index: 0, typeName: typeName("Alias"))
                 expect(sut.value(forKeyPath: "actualTypeName") as? TypeName).to(equal(typeName("Alias")))
 
                 sut.typeName.actualTypeName = typeName("Int")

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -434,11 +434,13 @@ class ParserComposerSpec: QuickSpec {
                         beforeEach {
                             method = Method(name: "fooMethod(bar: String)", selectorName: "fooMethod(bar:)",
                                             parameters: [MethodParameter(name: "bar",
+                                                                         index: 0,
                                                                          typeName: TypeName(name: "String"))],
                                             returnTypeName: TypeName(name: "Void"),
                                             definedInTypeName: TypeName(name: "Foo"))
                             defaultedMethod = Method(name: "fooMethod(bar: String = \"Baz\")", selectorName: "fooMethod(bar:)",
                                                      parameters: [MethodParameter(name: "bar",
+                                                                                  index: 0,
                                                                                   typeName: TypeName(name: "String"),
                                                                                   defaultValue: "\"Baz\"")],
                                                      returnTypeName: TypeName(name: "Void"),
@@ -569,6 +571,7 @@ class ParserComposerSpec: QuickSpec {
                                                                                 definedInTypeName: TypeName(name: "Foo"))],
                                                            methods: [Method(name: "init?(rawValue: String)", selectorName: "init(rawValue:)",
                                                                             parameters: [MethodParameter(name: "rawValue",
+                                                                                                         index: 0,
                                                                                                          typeName: TypeName(name: "String"))],
                                                                             returnTypeName: TypeName(name: "Foo?"),
                                                                             isStatic: true,
@@ -593,7 +596,7 @@ class ParserComposerSpec: QuickSpec {
                                                                                 isStatic: false,
                                                                                 definedInTypeName: TypeName(name: "Foo"))],
                                                            methods: [Method(name: "init?(rawValue: RawValue)", selectorName: "init(rawValue:)",
-                                                                            parameters: [MethodParameter(name: "rawValue", typeName: TypeName(name: "RawValue"))],
+                                                                            parameters: [MethodParameter(name: "rawValue", index: 0, typeName: TypeName(name: "RawValue"))],
                                                                             returnTypeName: TypeName(name: "Foo?"),
                                                                             isStatic: true,
                                                                             isFailableInitializer: true,
@@ -617,7 +620,7 @@ class ParserComposerSpec: QuickSpec {
                                                                                 isStatic: false,
                                                                                 definedInTypeName: TypeName(name: "Foo"))],
                                                            methods: [Method(name: "init?(rawValue: RawValue)", selectorName: "init(rawValue:)",
-                                                                            parameters: [MethodParameter(name: "rawValue", typeName: TypeName(name: "RawValue"))],
+                                                                            parameters: [MethodParameter(name: "rawValue", index: 0, typeName: TypeName(name: "RawValue"))],
                                                                             returnTypeName: TypeName(name: "Foo?"),
                                                                             isStatic: true,
                                                                             isFailableInitializer: true,
@@ -1382,7 +1385,7 @@ class ParserComposerSpec: QuickSpec {
 
                     context("given method parameter") {
                         it("replaces method parameter type alias with actual type") {
-                            let expectedMethodParameter = MethodParameter(name: "foo", typeName: TypeName(name: "FooAlias", actualTypeName: TypeName(name: "Foo")), type: Class(name: "Foo"))
+                            let expectedMethodParameter = MethodParameter(name: "foo", index: 0, typeName: TypeName(name: "FooAlias", actualTypeName: TypeName(name: "Foo")), type: Class(name: "Foo"))
 
                             let types = parse("typealias FooAlias = Foo; class Foo {}; class Bar { func some(foo: FooAlias) }")
                             let methodParameter = types.first?.methods.first?.parameters.first
@@ -1398,7 +1401,7 @@ class ParserComposerSpec: QuickSpec {
                                 TupleElement(name: "0", typeName: TypeName(name: "Foo"), type: Class(name: "Foo")),
                                 TupleElement(name: "1", typeName: TypeName(name: "Int"))
                                 ])
-                            let expectedMethodParameter = MethodParameter(name: "foo", typeName: TypeName(name: "(FooAlias, Int)", actualTypeName: expectedActualTypeName, tuple: expectedActualTypeName.tuple))
+                            let expectedMethodParameter = MethodParameter(name: "foo", index: 0, typeName: TypeName(name: "(FooAlias, Int)", actualTypeName: expectedActualTypeName, tuple: expectedActualTypeName.tuple))
 
                             let types = parse("typealias FooAlias = Foo; class Foo {}; class Bar { func some(foo: (FooAlias, Int)) }")
                             let methodParameter = types.first?.methods.first?.parameters.first
@@ -1415,7 +1418,7 @@ class ParserComposerSpec: QuickSpec {
                                 TupleElement(name: "0", typeName: TypeName(name: "Foo"), type: Class(name: "Foo")),
                                 TupleElement(name: "1", typeName: TypeName(name: "Int"))
                                 ])
-                            let expectedMethodParameter = MethodParameter(name: "foo", typeName: TypeName(name: "GlobalAlias", actualTypeName: expectedActualTypeName, tuple: expectedActualTypeName.tuple))
+                            let expectedMethodParameter = MethodParameter(name: "foo", index: 0, typeName: TypeName(name: "GlobalAlias", actualTypeName: expectedActualTypeName, tuple: expectedActualTypeName.tuple))
 
                             let types = parse("typealias GlobalAlias = (Foo, Int); class Foo {}; class Bar { func some(foo: GlobalAlias) }")
                             let methodParameter = types.first?.methods.first?.parameters.first

--- a/SourceryTests/Parsing/FileParser_MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_MethodsSpec.swift
@@ -34,8 +34,8 @@ class FileParserMethodsSpec: QuickSpec {
                     """)[0].methods
 
                     expect(methods[0]).to(equal(Method(name: "fooInOut(some: Int, anotherSome: inout String)", selectorName: "fooInOut(some:anotherSome:)", parameters: [
-                        MethodParameter(name: "some", typeName: TypeName(name: "Int")),
-                        MethodParameter(name: "anotherSome", typeName: TypeName(name: "inout String"), isInout: true)
+                        MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int")),
+                        MethodParameter(name: "anotherSome", index: 1, typeName: TypeName(name: "inout String"), isInout: true)
                     ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))))
                 }
                 
@@ -49,8 +49,8 @@ class FileParserMethodsSpec: QuickSpec {
                     )[0].methods.first
                     
                     expect(method).to(equal(Method(name: "fooInOut(some: Int, anotherSome: (inout String) -> Void)", selectorName: "fooInOut(some:anotherSome:)", parameters: [
-                        MethodParameter(name: "some", typeName: TypeName(name: "Int")),
-                        MethodParameter(name: "anotherSome", typeName: TypeName.buildClosure(ClosureParameter(typeName: TypeName.String, isInout: true), returnTypeName: .Void))
+                        MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int")),
+                        MethodParameter(name: "anotherSome", index: 1, typeName: TypeName.buildClosure(ClosureParameter(typeName: TypeName.String, isInout: true), returnTypeName: .Void))
                     ], returnTypeName: .Void, definedInTypeName: TypeName(name: "Foo"))))
                 }
                 
@@ -64,8 +64,8 @@ class FileParserMethodsSpec: QuickSpec {
                     )[0].methods.first
                     
                     expect(method).to(equal(Method(name: "fooAsync(some: Int, anotherSome: (String) async -> Void)", selectorName: "fooAsync(some:anotherSome:)", parameters: [
-                        MethodParameter(name: "some", typeName: TypeName(name: "Int")),
-                        MethodParameter(name: "anotherSome", typeName: TypeName(name: "(String) async -> Void", closure: ClosureType(name: "(String) async -> Void", parameters: [ClosureParameter(typeName: TypeName(name: "String"))], returnTypeName: .Void, asyncKeyword: "async")))
+                        MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int")),
+                        MethodParameter(name: "anotherSome", index: 1, typeName: TypeName(name: "(String) async -> Void", closure: ClosureType(name: "(String) async -> Void", parameters: [ClosureParameter(typeName: TypeName(name: "String"))], returnTypeName: .Void, asyncKeyword: "async")))
                     ], returnTypeName: .Void, definedInTypeName: TypeName(name: "Foo"))))
                 }
 
@@ -91,7 +91,7 @@ class FileParserMethodsSpec: QuickSpec {
                                             Method(name: "setClosure(_ closure: @escaping () -> Void)",
                                                    selectorName: "setClosure(_:)",
                                                    parameters: [
-                                                    MethodParameter(argumentLabel: nil, name: "closure", typeName: .buildClosure(TypeName(name: "Void"), attributes: ["escaping": [Attribute(name: "escaping")]]), type: nil, defaultValue: nil, annotations: [:], isInout: false)
+                                                    MethodParameter(argumentLabel: nil, name: "closure", index: 0, typeName: .buildClosure(TypeName(name: "Void"), attributes: ["escaping": [Attribute(name: "escaping")]]), type: nil, defaultValue: nil, annotations: [:], isInout: false)
                                                    ],
                                                    returnTypeName: TypeName(name: "Void"),
                                                    attributes: [:],
@@ -111,7 +111,7 @@ class FileParserMethodsSpec: QuickSpec {
                     """)[0].methods
                     expect(methods[0]).to(equal(Method(name: "init()", selectorName: "init", parameters: [], returnTypeName: TypeName(name: "Foo"), throws: true, isStatic: true, definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[1]).to(equal(Method(name: "bar(some: Int)", selectorName: "bar(some:)", parameters: [
-                        MethodParameter(name: "some", typeName: TypeName(name: "Int"))
+                        MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int"))
                         ], returnTypeName: TypeName(name: "Bar"), throws: true, definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[2]).to(equal(Method(name: "foo()", selectorName: "foo", returnTypeName: TypeName(name: "Foo"), attributes: ["discardableResult": [Attribute(name: "discardableResult")]], definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[3]).to(equal(Method(name: "fooBar()", selectorName: "fooBar", returnTypeName: TypeName(name: "Void"), throws: false, rethrows: true, definedInTypeName: TypeName(name: "Foo"))))
@@ -119,8 +119,8 @@ class FileParserMethodsSpec: QuickSpec {
                     expect(methods[5]).to(equal(Method(name: "fooAsync()", selectorName: "fooAsync", returnTypeName: TypeName(name: "Void"), isAsync: true, definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[6]).to(equal(Method(name: "barAsync()", selectorName: "barAsync", returnTypeName: TypeName(name: "Void"), isAsync: true, throws: true, definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[7]).to(equal(Method(name: "fooInOut(some: Int, anotherSome: inout String)", selectorName: "fooInOut(some:anotherSome:)", parameters: [
-                        MethodParameter(name: "some", typeName: TypeName(name: "Int")),
-                        MethodParameter(name: "anotherSome", typeName: TypeName(name: "inout String"), isInout: true)
+                        MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int")),
+                        MethodParameter(name: "anotherSome", index: 1, typeName: TypeName(name: "inout String"), isInout: true)
                         ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))))
                 }
 
@@ -183,7 +183,7 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(bar: Int) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(bar: Int)", selectorName: "foo(bar:)", parameters: [
-                                    MethodParameter(name: "bar", typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Foo"))
+                                    MethodParameter(name: "bar", index: 0, typeName: TypeName(name: "Int"))], definedInTypeName: TypeName(name: "Foo"))
                                 ])
                             ]))
                     }
@@ -192,7 +192,7 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(bar: Int...) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(bar: Int...)", selectorName: "foo(bar:)", parameters: [
-                                        MethodParameter(name: "bar", typeName: TypeName(name: "Int"), isVariadic: true)], definedInTypeName: TypeName(name: "Foo"))
+                                        MethodParameter(name: "bar", index: 0, typeName: TypeName(name: "Int"), isVariadic: true)], definedInTypeName: TypeName(name: "Foo"))
                                 ])
                             ]))
                     }
@@ -202,7 +202,7 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(type).to(equal(
                             Protocol(name: "Foo", methods: [
                                 Method(name: "someMethod(aValue: Set<Int>)", selectorName: "someMethod(aValue:)", parameters: [
-                                    MethodParameter(name: "aValue", typeName: .buildSet(of: .Int))], definedInTypeName: TypeName(name: "Foo"))
+                                    MethodParameter(name: "aValue", index: 0, typeName: .buildSet(of: .Int))], definedInTypeName: TypeName(name: "Foo"))
                                 ])
                             ))
                     }
@@ -211,8 +211,8 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo( bar:   Int,   foo : String  ) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(bar: Int, foo: String)", selectorName: "foo(bar:foo:)", parameters: [
-                                    MethodParameter(name: "bar", typeName: TypeName(name: "Int")),
-                                    MethodParameter(name: "foo", typeName: TypeName(name: "String"))
+                                    MethodParameter(name: "bar", index: 0, typeName: TypeName(name: "Int")),
+                                    MethodParameter(name: "foo", index: 1, typeName: TypeName(name: "String"))
                                     ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))
                                 ])
                             ]))
@@ -223,12 +223,12 @@ class FileParserMethodsSpec: QuickSpec {
                             .to(equal([
                                 Class(name: "Foo", methods: [
                                     Method(name: "foo(bar: [String: String], foo: (String, String) -> Void, other: Optional<String>)", selectorName: "foo(bar:foo:other:)", parameters: [
-                                        MethodParameter(name: "bar", typeName: TypeName(name: "[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName(name: "String"), keyTypeName: TypeName(name: "String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName(name: "String")), GenericTypeParameter(typeName: TypeName(name: "String"))]))),
-                                        MethodParameter(name: "foo", typeName: TypeName(name: "(String, String) -> Void", closure: ClosureType(name: "(String, String) -> Void", parameters: [
+                                        MethodParameter(name: "bar", index: 0, typeName: TypeName(name: "[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName(name: "String"), keyTypeName: TypeName(name: "String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName(name: "String")), GenericTypeParameter(typeName: TypeName(name: "String"))]))),
+                                        MethodParameter(name: "foo", index: 1, typeName: TypeName(name: "(String, String) -> Void", closure: ClosureType(name: "(String, String) -> Void", parameters: [
                                             ClosureParameter(typeName: TypeName(name: "String")),
                                             ClosureParameter(typeName: TypeName(name: "String"))
                                             ], returnTypeName: TypeName(name: "Void")))),
-                                        MethodParameter(name: "other", typeName: TypeName(name: "Optional<String>"))
+                                        MethodParameter(name: "other", index: 2, typeName: TypeName(name: "Optional<String>"))
                                         ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))
                                     ])
                                 ]))
@@ -238,9 +238,9 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(bar Bar: Int, _ foo: Int, fooBar: (_ a: Int, _ b: Int) -> ()) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(bar Bar: Int, _ foo: Int, fooBar: (_ a: Int, _ b: Int) -> ())", selectorName: "foo(bar:_:fooBar:)", parameters: [
-                                    MethodParameter(argumentLabel: "bar", name: "Bar", typeName: TypeName(name: "Int")),
-                                    MethodParameter(argumentLabel: nil, name: "foo", typeName: TypeName(name: "Int")),
-                                    MethodParameter(name: "fooBar", typeName: TypeName(name: "(_ a: Int, _ b: Int) -> ()", closure: ClosureType(name: "(_ a: Int, _ b: Int) -> ()", parameters: [
+                                    MethodParameter(argumentLabel: "bar", name: "Bar", index: 0, typeName: TypeName(name: "Int")),
+                                    MethodParameter(argumentLabel: nil, name: "foo", index: 1, typeName: TypeName(name: "Int")),
+                                    MethodParameter(name: "fooBar", index: 2, typeName: TypeName(name: "(_ a: Int, _ b: Int) -> ()", closure: ClosureType(name: "(_ a: Int, _ b: Int) -> ()", parameters: [
                                         ClosureParameter(argumentLabel: nil, name: "a", typeName: TypeName(name: "Int")),
                                         ClosureParameter(argumentLabel: nil, name: "b", typeName: TypeName(name: "Int"))
                                         ], returnTypeName: TypeName(name: "()"))))
@@ -253,7 +253,7 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(a: Int) { let handler = { (b:Int) in } } }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(a: Int)", selectorName: "foo(a:)", parameters: [
-                                    MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName(name: "Int"))
+                                    MethodParameter(argumentLabel: "a", name: "a", index: 0, typeName: TypeName(name: "Int"))
                                     ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))
                                 ])
                             ]))
@@ -264,7 +264,7 @@ class FileParserMethodsSpec: QuickSpec {
                         expect(parse("class Foo { func foo(a: inout Int) {} }")).to(equal([
                             Class(name: "Foo", methods: [
                                 Method(name: "foo(a: inout Int)", selectorName: "foo(a:)", parameters: [
-                                    MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName(name: "inout Int"), isInout: true)
+                                    MethodParameter(argumentLabel: "a", name: "a", index: 0, typeName: TypeName(name: "inout Int"), isInout: true)
                                     ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))
                                 ])
                             ]))
@@ -275,7 +275,7 @@ class FileParserMethodsSpec: QuickSpec {
                             expect(parse("class Foo { func foo(a: Int? = nil) {} }")).to(equal([
                                 Class(name: "Foo", methods: [
                                     Method(name: "foo(a: Int? = nil)", selectorName: "foo(a:)", parameters: [
-                                        MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName(name: "Int?"), defaultValue: "nil")
+                                        MethodParameter(argumentLabel: "a", name: "a", index: 0, typeName: TypeName(name: "Int?"), defaultValue: "nil")
                                         ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))
                                     ])
                                 ]))
@@ -285,7 +285,7 @@ class FileParserMethodsSpec: QuickSpec {
                             expect(parse("class Foo { func foo(a: Int? = \n\t{ return nil } \n\t ) {} }")).to(equal([
                                 Class(name: "Foo", methods: [
                                     Method(name: "foo(a: Int? = { return nil })", selectorName: "foo(a:)", parameters: [
-                                        MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName(name: "Int?"), defaultValue: "{ return nil }")
+                                        MethodParameter(argumentLabel: "a", name: "a", index: 0, typeName: TypeName(name: "Int?"), defaultValue: "{ return nil }")
                                         ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))
                                     ])
                                 ]))
@@ -307,12 +307,12 @@ class FileParserMethodsSpec: QuickSpec {
                                 Class(name: "Foo", methods: [
                                     Method(name: "foo(bar: [String: String], foo: (String, String) -> Void, other: Optional<String>)",
                                            selectorName: "foo(bar:foo:other:)", parameters: [
-                                        MethodParameter(name: "bar", typeName: TypeName(name: "[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName(name: "String"), keyTypeName: TypeName(name: "String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName(name: "String")), GenericTypeParameter(typeName: TypeName(name: "String"))]))),
-                                        MethodParameter(name: "foo", typeName: TypeName(name: "(String, String) -> Void", closure: ClosureType(name: "(String, String) -> Void", parameters: [
+                                        MethodParameter(name: "bar", index: 0, typeName: TypeName(name: "[String: String]", dictionary: DictionaryType(name: "[String: String]", valueTypeName: TypeName(name: "String"), keyTypeName: TypeName(name: "String")), generic: GenericType(name: "Dictionary", typeParameters: [GenericTypeParameter(typeName: TypeName(name: "String")), GenericTypeParameter(typeName: TypeName(name: "String"))]))),
+                                        MethodParameter(name: "foo", index: 1, typeName: TypeName(name: "(String, String) -> Void", closure: ClosureType(name: "(String, String) -> Void", parameters: [
                                             ClosureParameter(typeName: TypeName(name: "String")),
                                             ClosureParameter(typeName: TypeName(name: "String"))
                                             ], returnTypeName: TypeName(name: "Void")))),
-                                        MethodParameter(name: "other", typeName: TypeName(name: "Optional<String>"))
+                                        MethodParameter(name: "other", index: 2, typeName: TypeName(name: "Optional<String>"))
                                         ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))
                                     ])
                                 ]))
@@ -468,12 +468,12 @@ class FileParserMethodsSpec: QuickSpec {
                     expect(parse("class Foo {\n //sourcery: foo\nfunc foo(\n// sourcery: annotationA\na: Int,\n// sourcery: annotationB\nb: Int) {}\n//sourcery: bar\nfunc bar(\n// sourcery: annotationA\na: Int,\n// sourcery: annotationB\nb: Int) {} }")).to(equal([
                         Class(name: "Foo", methods: [
                             Method(name: "foo(a: Int, b: Int)", selectorName: "foo(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName(name: "Int"), annotations: ["annotationA": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName(name: "Int"), annotations: ["annotationB": NSNumber(value: true)])
+                                MethodParameter(name: "a", index: 0, typeName: TypeName(name: "Int"), annotations: ["annotationA": NSNumber(value: true)]),
+                                MethodParameter(name: "b", index: 1, typeName: TypeName(name: "Int"), annotations: ["annotationB": NSNumber(value: true)])
                                 ], annotations: ["foo": NSNumber(value: true)], definedInTypeName: TypeName(name: "Foo")),
                             Method(name: "bar(a: Int, b: Int)", selectorName: "bar(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName(name: "Int"), annotations: ["annotationA": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName(name: "Int"), annotations: ["annotationB": NSNumber(value: true)])
+                                MethodParameter(name: "a", index: 0, typeName: TypeName(name: "Int"), annotations: ["annotationA": NSNumber(value: true)]),
+                                MethodParameter(name: "b", index: 1, typeName: TypeName(name: "Int"), annotations: ["annotationB": NSNumber(value: true)])
                                 ], annotations: ["bar": NSNumber(value: true)], definedInTypeName: TypeName(name: "Foo"))
                             ])
                         ]))
@@ -483,12 +483,12 @@ class FileParserMethodsSpec: QuickSpec {
                     expect(parse("class Foo {\n//sourcery:begin:func\n //sourcery: foo\nfunc foo(/* sourcery: annotationA */a: Int, /* sourcery: annotationB*/b: Int) {}\n//sourcery: bar\nfunc bar(/* sourcery: annotationA */a: Int, /* sourcery: annotationB*/b: Int) {}\n//sourcery:end}")).to(equal([
                         Class(name: "Foo", methods: [
                             Method(name: "foo(a: Int, b: Int)", selectorName: "foo(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName(name: "Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName(name: "Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
+                                MethodParameter(name: "a", index: 0, typeName: TypeName(name: "Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
+                                MethodParameter(name: "b", index: 1, typeName: TypeName(name: "Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
                                 ], annotations: ["foo": NSNumber(value: true), "func": NSNumber(value: true)], definedInTypeName: TypeName(name: "Foo")),
                             Method(name: "bar(a: Int, b: Int)", selectorName: "bar(a:b:)", parameters: [
-                                MethodParameter(name: "a", typeName: TypeName(name: "Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
-                                MethodParameter(name: "b", typeName: TypeName(name: "Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
+                                MethodParameter(name: "a", index: 0, typeName: TypeName(name: "Int"), annotations: ["annotationA": NSNumber(value: true), "func": NSNumber(value: true)]),
+                                MethodParameter(name: "b", index: 1, typeName: TypeName(name: "Int"), annotations: ["annotationB": NSNumber(value: true), "func": NSNumber(value: true)])
                                 ], annotations: ["bar": NSNumber(value: true), "func": NSNumber(value: true)], definedInTypeName: TypeName(name: "Foo"))
                             ])
                         ]))
@@ -507,10 +507,10 @@ class FileParserMethodsSpec: QuickSpec {
                     expect(parsed).to(equal([
                         Class(name: "Foo", methods: [
                             Method(name: "foo(paramA: String, paramB: String, paramC: String, paramD: String)", selectorName: "foo(paramA:paramB:paramC:paramD:)", parameters: [
-                                MethodParameter(name: "paramA", typeName: TypeName(name: "String"), annotations: ["anAnnotation": "PARAM A AND METHOD ONLY" as NSString]),
-                                MethodParameter(name: "paramB", typeName: TypeName(name: "String"), annotations: ["testAnnotation": "PARAM B ONLY" as NSString]),
-                                MethodParameter(name: "paramC", typeName: TypeName(name: "String"), annotations: ["anotherAnnotation": "PARAM C ONLY" as NSString]),
-                                MethodParameter(name: "paramD", typeName: TypeName(name: "String"), annotations: [:]),
+                                MethodParameter(name: "paramA", index: 0, typeName: TypeName(name: "String"), annotations: ["anAnnotation": "PARAM A AND METHOD ONLY" as NSString]),
+                                MethodParameter(name: "paramB", index: 1, typeName: TypeName(name: "String"), annotations: ["testAnnotation": "PARAM B ONLY" as NSString]),
+                                MethodParameter(name: "paramC", index: 2, typeName: TypeName(name: "String"), annotations: ["anotherAnnotation": "PARAM C ONLY" as NSString]),
+                                MethodParameter(name: "paramD", index: 3, typeName: TypeName(name: "String"), annotations: [:]),
                             ], annotations: ["anAnnotation": "PARAM A AND METHOD ONLY" as NSString], definedInTypeName: TypeName(name: "Foo"))
                         ])]))
                 }

--- a/SourceryTests/Parsing/FileParser_SubscriptsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_SubscriptsSpec.swift
@@ -37,8 +37,8 @@ class FileParserSubscriptsSpec: QuickSpec {
                     expect(subscripts?.first).to(equal(
                         Subscript(
                             parameters: [
-                                MethodParameter(argumentLabel: nil, name: "index", typeName: TypeName(name: "Int")),
-                                MethodParameter(argumentLabel: "a", name: "a", typeName: TypeName(name: "String"))
+                                MethodParameter(argumentLabel: nil, name: "index", index: 0, typeName: TypeName(name: "Int")),
+                                MethodParameter(argumentLabel: "a", name: "a", index: 1, typeName: TypeName(name: "String"))
                             ],
                             returnTypeName: TypeName(name: "Int"),
                             accessLevel: (.private, .private),
@@ -54,7 +54,7 @@ class FileParserSubscriptsSpec: QuickSpec {
                     expect(subscripts?.last).to(equal(
                         Subscript(
                             parameters: [
-                                MethodParameter(argumentLabel: "b", name: "b", typeName: TypeName(name: "Int"))
+                                MethodParameter(argumentLabel: "b", name: "b", index: 0, typeName: TypeName(name: "Int"))
                             ],
                             returnTypeName: TypeName(name: "String"),
                             accessLevel: (.public, .private),

--- a/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
@@ -30,7 +30,7 @@ class TypeNameSpec: QuickSpec {
                     func myFunc(_ arg: \(functionArgumentType)) {}
                   }
                   """
-                guard let parser = try? makeParser(for: wrappedCode) else { fail(); return MethodParameter(name: "", typeName: TypeName(name: "")) }
+                guard let parser = try? makeParser(for: wrappedCode) else { fail(); return MethodParameter(name: "", index: 0, typeName: TypeName(name: "")) }
                 let result = try? parser.parse()
                 let methodParameter = result?.types.first?.methods.first?.parameters.first
                 return methodParameter

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -59,7 +59,7 @@ import {{ import }}
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: ({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic true %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic true %}{% if not forloop.last %}, {% elif param.typeName.isClosure and param.typeName.closure.returnTypeName.name|contains:"any " %}{% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName true %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ '&' if param.typeName.name | hasPrefix:"inout " }}{% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -85,11 +85,11 @@ import {{ import }}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{{ ')' if param.isClosure }})?{% endfor %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureTupleVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureTupleVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureTupleVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureTupleVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType  or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName false %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
     {% endif %}
     {% call methodClosureDeclaration method %}
 
@@ -104,7 +104,7 @@ import {{ import }}
     {{ value }}
     {% endfor %}
     {% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName %}{% endif %} {
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName false %}{% endif %} {
         {% call swiftifyMethodName method %}CallsCount += 1
         {% call methodReceivedParameters method %}
         {% if method.throws %}
@@ -155,20 +155,20 @@ import {{ import }}
 {% endmacro %}
 
 {% macro mockOptionalVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %}
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName false %}
 {% endmacro %}
 
 {% macro mockNonOptionalArrayOrDictionaryVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName false %} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
 {% endmacro %}
 
 {% macro mockNonOptionalVariable variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} {
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName false %} {
         get { return {% call underlyingMockedVariableName variable %} }
         set(value) { {% call underlyingMockedVariableName variable %} = value }
     }
-    {% set wrappedTypeName %}{% if variable.typeName.isProtocolComposition %}({% call existentialVariableTypeName variable.typeName %}){% else %}{% call existentialVariableTypeName variable.typeName %}{% endif %}{% endset %}
-    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: ({% call existentialVariableTypeName wrappedTypeName %})!
+    {% set wrappedTypeName %}{% if variable.typeName.isProtocolComposition %}({% call existentialVariableTypeName variable.typeName false %}){% else %}{% call existentialVariableTypeName variable.typeName false %}{% endif %}{% endset %}
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: ({% call existentialVariableTypeName wrappedTypeName false %})!
 {% endmacro %}
 
 {% macro variableThrowableErrorDeclaration variable %}
@@ -182,7 +182,7 @@ import {{ import }}
 {% endmacro %}
 
 {% macro variableClosureDeclaration variable %}
-    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}-> {% call existentialVariableTypeName variable.typeName %})?
+    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}-> {% call existentialVariableTypeName variable.typeName true %})?
 {% endmacro %}
 
 {% macro variableClosureName variable %}{% call mockedVariableName variable %}Closure{% endmacro %}
@@ -193,7 +193,7 @@ import {{ import }}
         return {% call mockedVariableName variable %}CallsCount > 0
     }
 
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %} {
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName false %} {
         get {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}{
             {% call mockedVariableName variable %}CallsCount += 1
             {% if variable.throws %}
@@ -206,7 +206,7 @@ import {{ import }}
             }
         }
     }
-    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName %}{{ '!' if not variable.isOptional }}
+    {% call accessLevel variable.readAccess %}var {% call underlyingMockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName false %}{{ '!' if not variable.isOptional }}
     {% if variable.throws %}
         {% call variableThrowableErrorDeclaration variable %}
     {% endif %}
@@ -215,7 +215,8 @@ import {{ import }}
 
 {% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
 {% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
-{% macro existentialVariableTypeName typeName -%}
+{# Swift does not support closures with implicitly unwrapped optional return value type. That is why existentialVariableTypeName.isNotAllowedToBeImplicitlyUnwrappedOptional should be true in such case #}
+{% macro existentialVariableTypeName typeName isNotAllowedToBeImplicitlyUnwrappedOptional -%}
     {%- if typeName|contains:"<" and typeName|contains:">" -%}
         {{ typeName }}
     {%- elif typeName|contains:"any " and typeName|contains:"!"  -%}
@@ -232,6 +233,8 @@ import {{ import }}
         ({{ typeName | replace:"some","(some" | replace:"?",")?" }})
     {%- elif typeName.isClosure -%}
         ({{ typeName }})
+    {%- elif isNotAllowedToBeImplicitlyUnwrappedOptional -%}
+        {{ typeName | replace:"!","" }}
     {%- else -%}
         {{ typeName }}
     {%- endif -%}

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -44,8 +44,8 @@ import {{ import }}
         {% endfor -%}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
-        {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {{ param.name }}{% endfor %}
-        {% call swiftifyMethodName method %}ReceivedInvocations.append({% for param in method.parameters %}{{ param.name }}){% endfor %}
+        {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}{% endfor %}
+        {% call swiftifyMethodName method %}ReceivedInvocations.append({% for param in method.parameters %}{% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}){% endfor %}
     {% else %}
     {% if not method.parameters.count == 0 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
@@ -62,7 +62,7 @@ import {{ import }}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: ({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic true %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
 {% endmacro %}
 
-{% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ '&' if param.typeName.name | hasPrefix:"inout " }}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
+{% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ '&' if param.typeName.name | hasPrefix:"inout " }}{% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 
 {% macro mockMethod method %}
     //MARK: - {{ method.shortName }}
@@ -287,7 +287,7 @@ import {{ import }}
         {{ typeName }}
     {%- endif -%}
 {%- endmacro %}
-{% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {{ param.name }}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% call existentialParameterTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}
+{% macro methodName method %}func {{ method.shortName}}({%- for param in method.parameters %}{% if param.argumentLabel == nil %}_ {% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}{%elif param.argumentLabel == param.name%}{{ param.name }}{%else%}{{ param.argumentLabel }} {{ param.name }}{% endif %}: {% if param.typeName.isClosure and param.typeName.closure.parameters.count > 1 %}({% endif %}{% call existentialParameterTypeName param.typeName param.isVariadic %}{% if not forloop.last %}, {% endif %}{% endfor -%}){% endmacro %}
 
 {% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
 {% call accessLevel type.accessLevel %}class {{ type.name }}Mock: {{ type.name }} {

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -59,7 +59,7 @@ import {{ import }}
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic true %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: ({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic true %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ '&' if param.typeName.name | hasPrefix:"inout " }}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -272,7 +272,7 @@ import {{ import }}
     {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
         ({{ typeName.unwrappedTypeName | replace:"any","(any" | replace:"?",")?" }})?
     {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
-        {{ typeName | replace:"any","(any" | replace:"?",")?" }}
+        {{ typeName | replace:"any","(any" | replace:"?",")?" }})
     {%- elif typeName|contains:"any " and typeName.isOptional -%}
         {{ typeName | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"some " and typeName|contains:"!" -%}

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -269,6 +269,35 @@ import {{ import }}
         {{ name|replace:"some ","any " }}
     {%- endif -%}
 {%- endmacro %}
+{# Swift does not support tuples with variadic parameters. That is why existentialClosureVariableTypeName.isVariadic should be false when typeName is a closure #}
+{% macro existentialClosureTupleVariableTypeName typeName isVariadic keepInout -%}
+    {% set name %}
+        {%- if keepInout -%}
+            {{ typeName }}
+        {%- else -%}
+            {{ typeName | replace:"inout ","" }}
+        {%- endif -%}
+    {% endset %}
+    {%- if typeName|contains:"any " and typeName|contains:"!" -%}
+        {{ name | replace:"any","(any" | replace:"!",")?" }}
+    {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
+        ({{ typeName.unwrappedTypeName| replace:"inout ","" | replace:"any","(any" | replace:"?",")?" }})?
+    {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
+        {{ name | replace:"any","(any" | replace:"?",")?" }}
+    {%- elif typeName|contains:"any " and typeName|contains:"?" -%}
+        {{ name | replace:"any","(any" | replace:"?",")?" }}
+    {%- elif typeName|contains:"some " and typeName|contains:"!" -%}
+        {{ name | replace:"some","(any" | replace:"!",")?" }}
+    {%- elif typeName|contains:"some " and typeName.isClosure and typeName|contains:"?" -%}
+        {{ name | replace:"some","(any" | replace:"?",")?" }}
+    {%- elif typeName|contains:"some " and typeName|contains:"?" -%}
+        {{ name | replace:"some","(any" | replace:"?",")?" }}
+    {%- elif isVariadic -%}
+        [{{ name }}]
+    {%- else -%}
+        {{ name|replace:"some ","any " }}
+    {%- endif -%}
+{%- endmacro %}
 {% macro existentialParameterTypeName typeName isVariadic -%}
     {%- if typeName|contains:"any " and typeName|contains:"?," and typeName|contains:">?" -%}
         {{ typeName | replace:"any","(any" | replace:"?,",")?," }}

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -248,7 +248,9 @@ import {{ import }}
         {{ name | replace:"any","(any" | replace:"!",")?" }}
     {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
         ({{ typeName.unwrappedTypeName| replace:"inout ","" | replace:"any","(any" | replace:"?",")?" }})?
-    {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
+    {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" and typeName.closure.parameters.count > 1 -%}
+        {{ name | replace:"any","(any" | replace:"?",")?" | replace:") ->",")) ->" }}
+    {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" and typeName.closure.parameters.count > 1 -%}
         {{ name | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"any " and typeName|contains:"?" -%}
         {{ name | replace:"any","(any" | replace:"?",")?" }}
@@ -271,8 +273,12 @@ import {{ import }}
         {{ typeName | replace:"any","(any" | replace:"!",")!" }}
     {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
         ({{ typeName.unwrappedTypeName | replace:"any","(any" | replace:"?",")?" }})?
-    {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
+    {%- elif typeName|contains:"any " and typeName.isClosure and typeName.closure.parameters.count > 1 and typeName.closure.returnTypeName.name|contains:"any " and typeName|contains:"?" -%}
+        {{ typeName | replace:"any","(any" | replace:"?",")?" | replace:") ->",")) ->" }})
+    {%- elif typeName|contains:"any " and typeName.isClosure and typeName.closure.returnTypeName.name|contains:"any " and typeName|contains:"?" -%}
         {{ typeName | replace:"any","(any" | replace:"?",")?" }})
+    {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
+        {{ typeName | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"any " and typeName.isOptional -%}
         {{ typeName | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"some " and typeName|contains:"!" -%}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -83,6 +83,10 @@ protocol MultiNonEscapingClosureProtocol: AutoMockable {
     func executeClosure(name: String, _ closure: () -> Void)
 }
 
+protocol MultiExistentialArgumentsClosureProtocol: AutoMockable {
+    func execute(completion: ((any StubWithSomeNameProtocol)?, any StubWithSomeNameProtocol) -> (any StubWithSomeNameProtocol)?)
+}
+
 /// sourcery: AutoMockable
 protocol AnnotatedProtocol {
     func sayHelloWith(name: String)

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -83,6 +83,10 @@ protocol MultiNonEscapingClosureProtocol: AutoMockable {
     func executeClosure(name: String, _ closure: () -> Void)
 }
 
+protocol MultiExistentialArgumentsClosureProtocol: AutoMockable {
+    func execute(completion: ((any StubWithSomeNameProtocol)?, any StubWithSomeNameProtocol) -> (any StubWithSomeNameProtocol)?)
+}
+
 /// sourcery: AutoMockable
 protocol AnnotatedProtocol {
     func sayHelloWith(name: String)

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.1.4 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -707,8 +707,8 @@ class ExampleVarargMock: ExampleVararg {
     var stringKeyStringArgsCVarArgStringCalled: Bool {
         return stringKeyStringArgsCVarArgStringCallsCount > 0
     }
-    var stringKeyStringArgsCVarArgStringReceivedArguments: (key: String, args: CVarArg...)?
-    var stringKeyStringArgsCVarArgStringReceivedInvocations: [(key: String, args: CVarArg...)] = []
+    var stringKeyStringArgsCVarArgStringReceivedArguments: (key: String, args: [CVarArg])?
+    var stringKeyStringArgsCVarArgStringReceivedInvocations: [(key: String, args: [CVarArg])] = []
     var stringKeyStringArgsCVarArgStringReturnValue: String!
     var stringKeyStringArgsCVarArgStringClosure: ((String, CVarArg...) -> String)?
 
@@ -939,7 +939,7 @@ class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOpt
         return implicitReturnStringCallsCount > 0
     }
     var implicitReturnStringReturnValue: String!
-    var implicitReturnStringClosure: (() -> String!)?
+    var implicitReturnStringClosure: (() -> String)?
 
     func implicitReturn() -> String! {
         implicitReturnStringCallsCount += 1
@@ -1016,6 +1016,26 @@ class MultiClosureProtocolMock: MultiClosureProtocol {
         setClosureNameStringClosureEscapingVoidVoidReceivedArguments = (name: name, closure: closure)
         setClosureNameStringClosureEscapingVoidVoidReceivedInvocations.append((name: name, closure: closure))
         setClosureNameStringClosureEscapingVoidVoidClosure?(name, closure)
+    }
+
+
+}
+class MultiExistentialArgumentsClosureProtocolMock: MultiExistentialArgumentsClosureProtocol {
+
+
+
+
+    //MARK: - execute
+
+    var executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidCallsCount = 0
+    var executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidCalled: Bool {
+        return executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidCallsCount > 0
+    }
+    var executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidClosure: ((((any StubWithSomeNameProtocol)?, (any StubWithSomeNameProtocol)) -> (any StubWithSomeNameProtocol)?) -> Void)?
+
+    func execute(completion: (((any StubWithSomeNameProtocol)?, (any StubWithSomeNameProtocol)) -> (any StubWithSomeNameProtocol)?)) {
+        executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidCallsCount += 1
+        executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidClosure?(completion)
     }
 
 
@@ -1519,12 +1539,12 @@ class StaticMethodProtocolMock: StaticMethodProtocol {
     static var staticFunctionStringStringReturnValue: String!
     static var staticFunctionStringStringClosure: ((String) -> String)?
 
-    static func staticFunction(_ : String) -> String {
+    static func staticFunction(_ arg0: String) -> String {
         staticFunctionStringStringCallsCount += 1
-        staticFunctionStringStringReceived = 
-        staticFunctionStringStringReceivedInvocations.append()
+        staticFunctionStringStringReceived = arg0
+        staticFunctionStringStringReceivedInvocations.append(arg0)
         if let staticFunctionStringStringClosure = staticFunctionStringStringClosure {
-            return staticFunctionStringStringClosure()
+            return staticFunctionStringStringClosure(arg0)
         } else {
             return staticFunctionStringStringReturnValue
         }

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.1.4 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -707,8 +707,8 @@ class ExampleVarargMock: ExampleVararg {
     var stringKeyStringArgsCVarArgStringCalled: Bool {
         return stringKeyStringArgsCVarArgStringCallsCount > 0
     }
-    var stringKeyStringArgsCVarArgStringReceivedArguments: (key: String, args: CVarArg...)?
-    var stringKeyStringArgsCVarArgStringReceivedInvocations: [(key: String, args: CVarArg...)] = []
+    var stringKeyStringArgsCVarArgStringReceivedArguments: (key: String, args: [CVarArg])?
+    var stringKeyStringArgsCVarArgStringReceivedInvocations: [(key: String, args: [CVarArg])] = []
     var stringKeyStringArgsCVarArgStringReturnValue: String!
     var stringKeyStringArgsCVarArgStringClosure: ((String, CVarArg...) -> String)?
 
@@ -939,7 +939,7 @@ class ImplicitlyUnwrappedOptionalReturnValueProtocolMock: ImplicitlyUnwrappedOpt
         return implicitReturnStringCallsCount > 0
     }
     var implicitReturnStringReturnValue: String!
-    var implicitReturnStringClosure: (() -> String!)?
+    var implicitReturnStringClosure: (() -> String)?
 
     func implicitReturn() -> String! {
         implicitReturnStringCallsCount += 1
@@ -1016,6 +1016,26 @@ class MultiClosureProtocolMock: MultiClosureProtocol {
         setClosureNameStringClosureEscapingVoidVoidReceivedArguments = (name: name, closure: closure)
         setClosureNameStringClosureEscapingVoidVoidReceivedInvocations.append((name: name, closure: closure))
         setClosureNameStringClosureEscapingVoidVoidClosure?(name, closure)
+    }
+
+
+}
+class MultiExistentialArgumentsClosureProtocolMock: MultiExistentialArgumentsClosureProtocol {
+
+
+
+
+    //MARK: - execute
+
+    var executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidCallsCount = 0
+    var executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidCalled: Bool {
+        return executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidCallsCount > 0
+    }
+    var executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidClosure: ((((any StubWithSomeNameProtocol)?, (any StubWithSomeNameProtocol)) -> (any StubWithSomeNameProtocol)?) -> Void)?
+
+    func execute(completion: (((any StubWithSomeNameProtocol)?, (any StubWithSomeNameProtocol)) -> (any StubWithSomeNameProtocol)?)) {
+        executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidCallsCount += 1
+        executeCompletionAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolAnyStubWithSomeNameProtocolVoidClosure?(completion)
     }
 
 
@@ -1519,12 +1539,12 @@ class StaticMethodProtocolMock: StaticMethodProtocol {
     static var staticFunctionStringStringReturnValue: String!
     static var staticFunctionStringStringClosure: ((String) -> String)?
 
-    static func staticFunction(_ : String) -> String {
+    static func staticFunction(_ arg0: String) -> String {
         staticFunctionStringStringCallsCount += 1
-        staticFunctionStringStringReceived =
-        staticFunctionStringStringReceivedInvocations.append()
+        staticFunctionStringStringReceived = arg0
+        staticFunctionStringStringReceivedInvocations.append(arg0)
         if let staticFunctionStringStringClosure = staticFunctionStringStringClosure {
-            return staticFunctionStringStringClosure()
+            return staticFunctionStringStringClosure(arg0)
         } else {
             return staticFunctionStringStringReturnValue
         }
@@ -1676,4 +1696,3 @@ class VariablesProtocolMock: VariablesProtocol {
 
 
 }
-


### PR DESCRIPTION
Resolves: #1267

## Context

This PR fixes a number of issues, the main focus is to make `AutoMockable.generated.swift` file a compilable Swift source code file.

For this, the following issues were addressed:

1. Implicitly unwrapped return value for generated var - closure - was disabled (`var xxx: (() -> String!)?` is not a compilable Swift code)
2. generated code for functions without any parameter label now automatically names arguments as "arg0, arg1..." (`func xxx(_: String)` would not generate compilable code)
3. Tuples are not allowed to contain CVarArg (...) in its subtypes (`(key: String, value: String...)` is not a compilable Swift code)

Aside these issues, now closures which contain multiple arguments and arguments within are marked with `any` keyword, now have balanced parentheses, and all other examples/use cases were left untouched.

This PR is heavily inspired by the work of @AliouSARR and @pocketal from #1266 , and their invaluable work was a basis for this PR.