### PR TITLE
Fix Closure Parameter CVarArg with Existential

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -239,6 +239,7 @@ import {{ import }}
         {{ typeName }}
     {%- endif -%}
 {%- endmacro %}
+{# Swift does not support closures with variadic parameters of existential types as arguments. That is why existentialClosureVariableTypeName.isVariadic should be false when typeName is a closure #}
 {% macro existentialClosureVariableTypeName typeName isVariadic keepInout -%}
     {% set name %}
         {%- if keepInout -%}
@@ -263,6 +264,8 @@ import {{ import }}
         {{ name | replace:"some","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"some " and typeName|contains:"?" -%}
         {{ name | replace:"some","(any" | replace:"?",")?" }}
+    {%- elif isVariadic and typeName|contains:"any " -%}
+        [({{ name }})]
     {%- elif isVariadic -%}
         {{ name }}...
     {%- else -%}
@@ -321,6 +324,8 @@ import {{ import }}
         {{ typeName | replace:"some","(some" | replace:"?",")?" }}
     {%- elif isVariadic -%}
         {{ typeName }}...
+    {%- elif typeName.isClosure and typeName.closure.parameters.count > 0 and typeName.closure.parameters.last.isVariadic -%}
+        {{ typeName }})
     {%- else -%}
         {{ typeName }}
     {%- endif -%}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -8,7 +8,11 @@
 
 import Foundation
 
-protocol AutoMockable {}
+public protocol AutoMockable {}
+protocol StubProtocol {}
+protocol StubWithAnyNameProtocol {}
+protocol StubWithSomeNameProtocol {}
+protocol PersonProtocol {}
 
 protocol BasicProtocol: AutoMockable {
     func loadConfiguration() -> String?
@@ -154,9 +158,6 @@ protocol StaticMethodProtocol: AutoMockable {
     static func staticFunction(_: String) -> String
 }
 
-protocol StubProtocol {}
-protocol StubWithAnyNameProtocol {}
-
 protocol AnyProtocol: AutoMockable {
     var a: any StubProtocol { get }
     var b: (any StubProtocol)? { get }
@@ -187,8 +188,6 @@ protocol AnyProtocol: AutoMockable {
     func z() -> any StubProtocol & CustomStringConvertible
 }
 
-protocol StubWithSomeNameProtocol {}
-
 protocol SomeProtocol: AutoMockable {
     func a(_ x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol)
     func b(x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol) async -> String
@@ -197,7 +196,6 @@ protocol SomeProtocol: AutoMockable {
     func d(_ x: (some StubWithSomeNameProtocol)?)
 }
 
-protocol PersonProtocol {}
 class GenericType<A, B, C>{}
 
 protocol HouseProtocol: AutoMockable {
@@ -225,6 +223,21 @@ protocol FunctionWithNullableCompletionThatHasNullableAnyParameterProtocol: Auto
 // sourcery: AutoMockable
 protocol ExampleVararg {
     func string(key: String, args: CVarArg...) -> String
+}
+
+// sourcery: AutoMockable
+protocol ExampleVarargTwo {
+  func toto(args: any StubWithSomeNameProtocol...)
+}
+
+// sourcery: AutoMockable
+protocol ExampleVarargThree {
+    func toto(arg: ((String, any Collection...) -> any Collection))
+}
+
+// sourcery: AutoMockable
+protocol ExampleVarargFour {
+    func toto(arg: ((String, any Collection...) -> Void))
 }
 
 // sourcery: AutoMockable

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -8,7 +8,11 @@
 
 import Foundation
 
-protocol AutoMockable {}
+public protocol AutoMockable {}
+protocol StubProtocol {}
+protocol StubWithAnyNameProtocol {}
+protocol StubWithSomeNameProtocol {}
+protocol PersonProtocol {}
 
 protocol BasicProtocol: AutoMockable {
     func loadConfiguration() -> String?
@@ -154,9 +158,6 @@ protocol StaticMethodProtocol: AutoMockable {
     static func staticFunction(_: String) -> String
 }
 
-protocol StubProtocol {}
-protocol StubWithAnyNameProtocol {}
-
 protocol AnyProtocol: AutoMockable {
     var a: any StubProtocol { get }
     var b: (any StubProtocol)? { get }
@@ -187,8 +188,6 @@ protocol AnyProtocol: AutoMockable {
     func z() -> any StubProtocol & CustomStringConvertible
 }
 
-protocol StubWithSomeNameProtocol {}
-
 protocol SomeProtocol: AutoMockable {
     func a(_ x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol)
     func b(x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol) async -> String
@@ -197,7 +196,6 @@ protocol SomeProtocol: AutoMockable {
     func d(_ x: (some StubWithSomeNameProtocol)?)
 }
 
-protocol PersonProtocol {}
 class GenericType<A, B, C>{}
 
 protocol HouseProtocol: AutoMockable {
@@ -225,6 +223,21 @@ protocol FunctionWithNullableCompletionThatHasNullableAnyParameterProtocol: Auto
 // sourcery: AutoMockable
 protocol ExampleVararg {
     func string(key: String, args: CVarArg...) -> String
+}
+
+// sourcery: AutoMockable
+protocol ExampleVarargTwo {
+  func toto(args: any StubWithSomeNameProtocol...)
+}
+
+// sourcery: AutoMockable
+protocol ExampleVarargThree {
+    func toto(arg: ((String, any Collection...) -> any Collection))
+}
+
+// sourcery: AutoMockable
+protocol ExampleVarargFour {
+    func toto(arg: ((String, any Collection...) -> Void))
 }
 
 // sourcery: AutoMockable

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -725,6 +725,70 @@ class ExampleVarargMock: ExampleVararg {
 
 
 }
+class ExampleVarargFourMock: ExampleVarargFour {
+
+
+
+
+    //MARK: - toto
+
+    var totoArgStringAnyCollectionVoidVoidCallsCount = 0
+    var totoArgStringAnyCollectionVoidVoidCalled: Bool {
+        return totoArgStringAnyCollectionVoidVoidCallsCount > 0
+    }
+    var totoArgStringAnyCollectionVoidVoidClosure: (((String, any Collection...) -> Void) -> Void)?
+
+    func toto(arg: ((String, any Collection...) -> Void)) {
+        totoArgStringAnyCollectionVoidVoidCallsCount += 1
+        totoArgStringAnyCollectionVoidVoidClosure?(arg)
+    }
+
+
+}
+class ExampleVarargThreeMock: ExampleVarargThree {
+
+
+
+
+    //MARK: - toto
+
+    var totoArgStringAnyCollectionAnyCollectionVoidCallsCount = 0
+    var totoArgStringAnyCollectionAnyCollectionVoidCalled: Bool {
+        return totoArgStringAnyCollectionAnyCollectionVoidCallsCount > 0
+    }
+    var totoArgStringAnyCollectionAnyCollectionVoidClosure: (((String, any Collection...) -> any Collection) -> Void)?
+
+    func toto(arg: ((String, any Collection...) -> any Collection)) {
+        totoArgStringAnyCollectionAnyCollectionVoidCallsCount += 1
+        totoArgStringAnyCollectionAnyCollectionVoidClosure?(arg)
+    }
+
+
+}
+class ExampleVarargTwoMock: ExampleVarargTwo {
+
+
+
+
+    //MARK: - toto
+
+    var totoArgsAnyStubWithSomeNameProtocolVoidCallsCount = 0
+    var totoArgsAnyStubWithSomeNameProtocolVoidCalled: Bool {
+        return totoArgsAnyStubWithSomeNameProtocolVoidCallsCount > 0
+    }
+    var totoArgsAnyStubWithSomeNameProtocolVoidReceivedArgs: ([(any StubWithSomeNameProtocol)])?
+    var totoArgsAnyStubWithSomeNameProtocolVoidReceivedInvocations: [([(any StubWithSomeNameProtocol)])] = []
+    var totoArgsAnyStubWithSomeNameProtocolVoidClosure: (([(any StubWithSomeNameProtocol)]) -> Void)?
+
+    func toto(args: any StubWithSomeNameProtocol...) {
+        totoArgsAnyStubWithSomeNameProtocolVoidCallsCount += 1
+        totoArgsAnyStubWithSomeNameProtocolVoidReceivedArgs = args
+        totoArgsAnyStubWithSomeNameProtocolVoidReceivedInvocations.append(args)
+        totoArgsAnyStubWithSomeNameProtocolVoidClosure?(args)
+    }
+
+
+}
 class ExtendableProtocolMock: ExtendableProtocol {
 
 

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -725,6 +725,70 @@ class ExampleVarargMock: ExampleVararg {
 
 
 }
+class ExampleVarargFourMock: ExampleVarargFour {
+
+
+
+
+    //MARK: - toto
+
+    var totoArgStringAnyCollectionVoidVoidCallsCount = 0
+    var totoArgStringAnyCollectionVoidVoidCalled: Bool {
+        return totoArgStringAnyCollectionVoidVoidCallsCount > 0
+    }
+    var totoArgStringAnyCollectionVoidVoidClosure: (((String, any Collection...) -> Void) -> Void)?
+
+    func toto(arg: ((String, any Collection...) -> Void)) {
+        totoArgStringAnyCollectionVoidVoidCallsCount += 1
+        totoArgStringAnyCollectionVoidVoidClosure?(arg)
+    }
+
+
+}
+class ExampleVarargThreeMock: ExampleVarargThree {
+
+
+
+
+    //MARK: - toto
+
+    var totoArgStringAnyCollectionAnyCollectionVoidCallsCount = 0
+    var totoArgStringAnyCollectionAnyCollectionVoidCalled: Bool {
+        return totoArgStringAnyCollectionAnyCollectionVoidCallsCount > 0
+    }
+    var totoArgStringAnyCollectionAnyCollectionVoidClosure: (((String, any Collection...) -> any Collection) -> Void)?
+
+    func toto(arg: ((String, any Collection...) -> any Collection)) {
+        totoArgStringAnyCollectionAnyCollectionVoidCallsCount += 1
+        totoArgStringAnyCollectionAnyCollectionVoidClosure?(arg)
+    }
+
+
+}
+class ExampleVarargTwoMock: ExampleVarargTwo {
+
+
+
+
+    //MARK: - toto
+
+    var totoArgsAnyStubWithSomeNameProtocolVoidCallsCount = 0
+    var totoArgsAnyStubWithSomeNameProtocolVoidCalled: Bool {
+        return totoArgsAnyStubWithSomeNameProtocolVoidCallsCount > 0
+    }
+    var totoArgsAnyStubWithSomeNameProtocolVoidReceivedArgs: ([(any StubWithSomeNameProtocol)])?
+    var totoArgsAnyStubWithSomeNameProtocolVoidReceivedInvocations: [([(any StubWithSomeNameProtocol)])] = []
+    var totoArgsAnyStubWithSomeNameProtocolVoidClosure: (([(any StubWithSomeNameProtocol)]) -> Void)?
+
+    func toto(args: any StubWithSomeNameProtocol...) {
+        totoArgsAnyStubWithSomeNameProtocolVoidCallsCount += 1
+        totoArgsAnyStubWithSomeNameProtocolVoidReceivedArgs = args
+        totoArgsAnyStubWithSomeNameProtocolVoidReceivedInvocations.append(args)
+        totoArgsAnyStubWithSomeNameProtocolVoidClosure?(args)
+    }
+
+
+}
 class ExtendableProtocolMock: ExtendableProtocol {
 
 


### PR DESCRIPTION
Resolves #1265

## Context

For special cases like:

```swift
// sourcery: AutoMockable
protocol ExampleVarargTwo {
  func toto(args: any StubWithSomeNameProtocol...)
}

// sourcery: AutoMockable
protocol ExampleVarargThree {
    func toto(arg: ((String, any Collection...) -> any Collection))
}

// sourcery: AutoMockable
protocol ExampleVarargFour {
    func toto(arg: ((String, any Collection...) -> Void))
}
```

Soucery does not handle variable arguments well enough, and misses one closing parenthesis in the method signature.
This PR addresses this by updating AutoMockable.stencil respectively.

This PR is heavily inspired by the work of @AliouSARR and @pocketal from https://github.com/krzysztofzablocki/Sourcery/pull/1266 , and their invaluable work was a basis for this PR.