### PR TITLE
Enable Single Print when Generating Based on Swifttemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Inside a project/package that uses this command plugin, right-click the project 
 - `--help` - Display help information
 - `--cacheBasePath` - Base path to the cache directory. Can be overriden by the config file.
 - `--buildPath` - Path to directory used when building from .swifttemplate files. This defaults to system temp directory
+- `--hideVersionHeader` [default: false] - Stop adding the Sourcery version to the generated files headers.
 
 ### Configuration file
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -19,8 +19,7 @@ import XcodeProj
 public class Sourcery {
     public static let version: String = SourceryVersion.current.value
     public static let generationMarker: String = "// Generated using Sourcery"
-    public static let generationHeader = "\(Sourcery.generationMarker) \(Sourcery.version) — https://github.com/krzysztofzablocki/Sourcery\n"
-        + "// DO NOT EDIT\n"
+    public let generationHeader: String
 
     enum Error: Swift.Error {
         case containsMergeConflictMarkers
@@ -34,6 +33,7 @@ public class Sourcery {
     fileprivate let buildPath: Path?
     fileprivate let prune: Bool
     fileprivate let serialParse: Bool
+    fileprivate var hideVersionHeader: Bool
 
     fileprivate var status = ""
     fileprivate var templatesPaths = Paths(include: [])
@@ -47,7 +47,7 @@ public class Sourcery {
     fileprivate var fileAnnotatedContent: [Path: [String]] = [:]
 
     /// Creates Sourcery processor
-  public init(verbose: Bool = false, watcherEnabled: Bool = false, cacheDisabled: Bool = false, cacheBasePath: Path? = nil, buildPath: Path? = nil, prune: Bool = false, serialParse: Bool = false, arguments: [String: NSObject] = [:]) {
+  public init(verbose: Bool = false, watcherEnabled: Bool = false, cacheDisabled: Bool = false, cacheBasePath: Path? = nil, buildPath: Path? = nil, prune: Bool = false, serialParse: Bool = false, hideVersionHeader: Bool = false, arguments: [String: NSObject] = [:]) {
         self.verbose = verbose
         self.arguments = arguments
         self.watcherEnabled = watcherEnabled
@@ -56,6 +56,14 @@ public class Sourcery {
         self.buildPath = buildPath
         self.prune = prune
         self.serialParse = serialParse
+        self.hideVersionHeader = hideVersionHeader
+
+        var prefix = Sourcery.generationMarker
+        if !hideVersionHeader {
+          prefix += " \(Sourcery.version)"
+        }
+        self.generationHeader = "\(prefix) — https://github.com/krzysztofzablocki/Sourcery\n"
+        + "// DO NOT EDIT\n"
     }
 
     /// Processes source files and generates corresponding code.
@@ -613,7 +621,7 @@ extension Sourcery {
         let resultIsEmpty = result.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         var result = result
         if !resultIsEmpty, outputPath.extension == "swift" {
-            result = Sourcery.generationHeader + result
+            result = generationHeader + result
         }
 
         if isDryRun {

--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -117,8 +117,9 @@ func runCLI() {
         	"""),
         Option<Path>("ejsPath", default: "", description: "Path to EJS file for JavaScript templates."),
         Option<Path>("cacheBasePath", default: "", description: "Base path to Sourcery's cache directory"),
-        Option<Path>("buildPath", default: "", description: "Sets a custom build path")
-    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, ejsPath, cacheBasePath, buildPath in
+        Option<Path>("buildPath", default: "", description: "Sets a custom build path"),
+        Flag("hideVersionHeader", description: "Do not include Sourcery version in the generated files headers.")
+    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, ejsPath, cacheBasePath, buildPath, hideVersionHeader in
         do {
             Log.stackMessages = isDryRun
             switch (quiet, verboseLogging) {
@@ -205,6 +206,7 @@ func runCLI() {
                                         buildPath: buildPath.string.isEmpty ? nil : buildPath,
                                         prune: prune,
                                         serialParse: serialParse,
+                                        hideVersionHeader: hideVersionHeader,
                                         arguments: configuration.args)
 
                 if isDryRun, watcherEnabled {
@@ -299,8 +301,9 @@ func runCLI() {
         	via `argument.<name>`. To pass in string you should use escaped quotes (\\").
         	"""),
         Option<Path>("cacheBasePath", default: "", description: "Base path to Sourcery's cache directory"),
-        Option<Path>("buildPath", default: "", description: "Sets a custom build path")
-    ) { disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, cacheBasePath, buildPath in
+        Option<Path>("buildPath", default: "", description: "Sets a custom build path"),
+        Flag("hideVersionHeader", description: "Do not include Sourcery version in the generated files headers.")
+    ) { disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, cacheBasePath, buildPath, hideVersionHeader in
         do {
             Log.stackMessages = isDryRun
             switch (quiet, verboseLogging) {
@@ -382,6 +385,7 @@ func runCLI() {
                                         buildPath: buildPath.string.isEmpty ? nil : buildPath,
                                         prune: prune,
                                         serialParse: serialParse,
+                                        hideVersionHeader: hideVersionHeader,
                                         arguments: configuration.args)
 
                 return try sourcery.processFiles(

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -63,20 +63,26 @@ open class SwiftTemplate {
 
         var includedFiles: [Path] = []
         var outputFile = [String]()
+        outputFile.append(
+"""
+var bufferStr = ""
+"""
+        )
         for command in commands {
             switch command {
             case let .includeFile(path):
                 includedFiles.append(path)
             case let .output(code):
-                outputFile.append("print(\"\\(" + code + ")\", terminator: \"\");")
+                outputFile.append("bufferStr.append(\"\\(" + code + ")\");")
             case let .controlFlow(code):
                 outputFile.append("\(code)")
             case let .outputEncoded(code):
                 if !code.isEmpty {
-                    outputFile.append(("print(\"") + code.stringEncoded + "\", terminator: \"\");")
+                    outputFile.append(("bufferStr.append(\"") + code.stringEncoded + "\");")
                 }
             }
         }
+        outputFile.append("print(\"\\(bufferStr)\", terminator: \"\");")
 
         let contents = outputFile.joined(separator: "\n")
         let code = """
@@ -259,7 +265,6 @@ open class SwiftTemplate {
         let compilationResult = try Process.runCommand(path: "/usr/bin/env",
                                                        arguments: arguments,
                                                        currentDirectoryPath: buildDir)
-
         if compilationResult.exitCode != EXIT_SUCCESS {
             throw [compilationResult.output, compilationResult.error]
                 .filter { !$0.isEmpty }

--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -63,26 +63,28 @@ open class SwiftTemplate {
 
         var includedFiles: [Path] = []
         var outputFile = [String]()
-        outputFile.append(
-"""
-var bufferStr = ""
-"""
-        )
+        var hasContents = false
         for command in commands {
             switch command {
             case let .includeFile(path):
                 includedFiles.append(path)
             case let .output(code):
-                outputFile.append("bufferStr.append(\"\\(" + code + ")\");")
+                outputFile.append("sourceryBuffer.append(\"\\(" + code + ")\");")
+                hasContents = true
             case let .controlFlow(code):
                 outputFile.append("\(code)")
+                hasContents = true
             case let .outputEncoded(code):
                 if !code.isEmpty {
-                    outputFile.append(("bufferStr.append(\"") + code.stringEncoded + "\");")
+                    outputFile.append(("sourceryBuffer.append(\"") + code.stringEncoded + "\");")
+                    hasContents = true
                 }
             }
         }
-        outputFile.append("print(\"\\(bufferStr)\", terminator: \"\");")
+        if hasContents {
+            outputFile.insert("var sourceryBuffer = \"\";", at: 0)
+        }
+        outputFile.append("print(\"\\(sourceryBuffer)\", terminator: \"\");")
 
         let contents = outputFile.joined(separator: "\n")
         let code = """

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -174,7 +174,7 @@ class SwiftTemplateTests: QuickSpec {
                     }
                     .to(throwError(closure: { (error) in
                         let path = Path.cleanTemporaryDir(name: "build").parent() + "SwiftTemplate/version/Sources/SwiftTemplate/main.swift"
-                        expect("\(error)").to(contain("\(path):10:11: error: missing argument for parameter #1 in call\nprint(\"\\( )\", terminator: \"\");\n          ^\n"))
+                        expect("\(error)").to(contain("\(path):11:27: error: missing argument for parameter #1 in call\nsourceryBuffer.append(\"\\( )\");\n                          ^\n"))
                     }))
             }
 
@@ -194,7 +194,7 @@ class SwiftTemplateTests: QuickSpec {
                     try Generator.generate(.init(path: nil, module: nil, types: [], functions: []), types: Types(types: []), functions: [], template: SwiftTemplate(path: templatePath))
                     }
                     .to(throwError(closure: { (error) in
-                        expect("\(error)").to(contain("\(templatePath): SwiftTemplate/main.swift:10: Fatal error: Template not implemented"))
+                        expect("\(error)").to(contain("\(templatePath): SwiftTemplate/main.swift:11: Fatal error: Template not implemented"))
                     }))
             }
 


### PR DESCRIPTION
## Brief

Enables a single point of output into STDOUT during codegen from swifttemplate

## Context

This PR changes the way `swifttemplate` files are processed, and makes it possible to generate code in `swifttemplate` using async/await or other concurrency.

## Technical Details

For a use case when there are a lot of types to be processed in a for-loop, it is important to allow use of concurrency upon processing each type. Currently, Sourcery only allows code generation using a single-threaded model, where the contents of `swifttemplate` are processed and `print` statements are inserted in every single point where `Sourcery` would generate output after template parsing.

Now, it would be possible to use `async/await` within `swifttemplate` for processing types and other facilities of processed swift code (AST), and only output the contents once in the very end.

## Example

let's consider the following code in `swifttemplate`:

```swift
1 <%_ for type in types.all
2                 where (type is Struct || type is Enum)
3                && (type.implements["AutoDecodable"] != nil || type.implements["AutoEncodable"] != nil) { -%>
4    <%_ let codingKeys = codingKeysFor(type) -%>
5    <%_ if let codingKeysType = type.containedType["CodingKeys"] as? Enum, codingKeys.generated.count > 0 { -%>
6 // sourcery:inline:auto:<%= codingKeysType.name %>.AutoCodable
7        <%_ for key in codingKeys.generated { -%>
8        case <%= key %>
9        <%_ } -%>
10 // sourcery:end
11 <%_ } -%>
```

here, line `1` would iterate over all types, that is, it might be a collection of 100000 types, and sequentially process each one of them.
But what if we do not need this sequential processing, and instead could leverage all of the M*-SoC CPUs, to process types in the codebase?
What if sourcery is run on a Linux machine with 128 CPUs? No possibility to leverage all those CPUs at once.

Now, with this PR, the following is possible, but let's first consider how the given example emits Swift code exactly:

- line `6` is printed as `// sourcery:inline:auto:TypeName.name.AutoCodable` as a comment in the generated source file
- line `10` is printed as `// sourcery:end` as a comment in the generated source file

This is happening using `print` statement emitted into the intermittent source file that SwiftTemplate binary uses to process the input.
Now, using `print` statement is inefficient on its own:

1. `swifttemplate` file might include dozens of these statements, all put throughtout the generated intermittent file
2. `print` is expensive in terms of File I/O compared to a in-memory buffer which is printed just once

This PR introduces that buffer named `sourceryBuffer`, and the following code is now possible:

```swift
1 <%
2 func generateAsync(_ type: Type) async -> String {
3  var sourceryBuffer = ""
4  if (type is Struct || type is Enum),
5    (type.implements["AutoDecodable"] != nil || type.implements["AutoEncodable"] != nil) {
6    let codingKeys = codingKeysFor(type)
7    if let codingKeysType = type.containedType["CodingKeys"] as? Enum, codingKeys.generated.count > 0 { -%>
8 <%_ // sourcery:inline:auto:<%= codingKeysType.name %>.AutoCodable -%>
9    <%_ for key in codingKeys.generated { -%>
10    <%_ case <%= key %> -%>
11    <%_ } -%>
12 <%_ // sourcery:end -%>
13    <%_ } -%>
14  }
15  return sourceryBuffer
16 }
17 -%>
18
19 let content = try await withThrowingTaskGroup(of: String.self) { group in
20     for type in all {
21         group.addTask {
22            await generateAsync(type)
23         }
24     }
25     var fullContent = ""
26     for try await content in group {
27         fullContent.append(content)
28     }
29     return fullContent
30 }
31 <%= content -%>
```