### PR TITLE
[Bug] Annotations aren't being extracted from initializers

### DIFF
--- a/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
+++ b/SourceryFramework/Sources/Parsing/Utils/AnnotationsParser.swift
@@ -199,8 +199,10 @@ public struct AnnotationsParser {
         if prefix.isEmpty {
             shouldUsePositionBeforeTrailing = true
             (prefix, sourceLine) = findPrefix(positionBeforeTrailingTrivia, shouldUsePositionBeforeTrailing)
-            if shouldUsePositionBeforeTrailing {
+            if shouldUsePositionBeforeTrailing && !prefix.isEmpty {
                 position = positionBeforeTrailingTrivia
+            } else {
+                shouldUsePositionBeforeTrailing = false
             }
         }
         guard !prefix.isEmpty else { return ([:], shouldUsePositionBeforeTrailing) }

--- a/SourceryTests/Parsing/FileParser_MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_MethodsSpec.swift
@@ -456,6 +456,20 @@ class FileParserMethodsSpec: QuickSpec {
                         ]))
                 }
 
+                it("extracts method annotations from initializers") {
+                    expect(parse("""
+                    class Foo {
+                        // sourcery: annotation
+                        init() {
+                        }
+                    }
+                    """)).to(equal([
+                        Class(name: "Foo", methods: [
+                                Method(name: "init()", selectorName: "init", returnTypeName: TypeName(name: "Foo"), isStatic: true, annotations: ["annotation": NSNumber(value: true)], definedInTypeName: TypeName(name: "Foo"))
+                            ])
+                        ]))
+                }
+
                 it("extracts method inline annotations") {
                     expect(parse("class Foo {\n /* sourcery: annotation */func foo() {} }")).to(equal([
                         Class(name: "Foo", methods: [


### PR DESCRIPTION
# Bug Report

After updating to 2.1.8, we found that some annotations are no longer being picked up.. I reproduced this bug in the tests with the following example:

```swift
class Foo {
    // sourcery: annotation
    init() {
    }
}
```

```
failed - idx 0: rawMethods idx 0: annotations Different count, expected: 1, received: 0
Missing keys: annotation
```

What is strange is that this does not fail when the `init()` trailing brace is on the same line. For example, this works:

```swift
class Foo {
    // sourcery: annotation
    init() {}
}
```

I tried to replicate this with the `foo()` function test above, but the issue didn't surface

# Bug Fix

Currently I don't have a fix.. I'm going to try and dig in later on if I get a chance.