### PR TITLE
Implemented Proper Protocol Composition Type Parsing

### DIFF
--- a/SourceryRuntime/Sources/Linux/AST/Type_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Type_Linux.swift
@@ -329,7 +329,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Sou
     public var inherits = [String: Type]()
 
     // sourcery: skipEquality, skipDescription
-    /// Protocols this type implements
+    /// Protocols this type implements. Does not contain classes in case where composition (`&`) is used in the declaration
     public var implements = [String: Type]()
 
     /// Contained types

--- a/SourceryRuntime/Sources/macOS/AST/Type.swift
+++ b/SourceryRuntime/Sources/macOS/AST/Type.swift
@@ -285,7 +285,7 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
     public var inherits = [String: Type]()
 
     // sourcery: skipEquality, skipDescription
-    /// Protocols this type implements
+    /// Protocols this type implements. Does not contain classes in case where composition (`&`) is used in the declaration
     public var implements: [String: Type] = [:]
 
     /// Contained types

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -1626,8 +1626,6 @@ class ParserComposerSpec: QuickSpec {
                         it("should deconstruct compositions of protocols and classes for implements and inherits") {
                             let expectedProtocol = Protocol(name: "Foo")
                             let expectedClass = Class(name: "Bar")
-                            let expectedProtocolComposition = ProtocolComposition(name: "GlobalComposition", inheritedTypes: ["Foo", "Bar"], composedTypeNames: [TypeName(name: "Foo"), TypeName(name: "Bar")])
-                            expectedProtocolComposition.inherits = ["Bar": expectedClass]
 
                             let type = parse("typealias GlobalComposition = Foo & Bar; protocol Foo {}; class Bar {}; class Implements: GlobalComposition {}").last as? Class
 

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -1590,6 +1590,39 @@ class ParserComposerSpec: QuickSpec {
                             ]))
                         }
 
+                        it("should deconstruct compositions of class and protocol for implements") {
+                            let expectedProtocol = Protocol(name: "Foo")
+                            let type = parse("protocol Foo {}; class Bar {}; class Implements: Bar & Foo {}").last as? Class
+
+                            expect(type?.implements).to(equal([
+                                expectedProtocol.name: expectedProtocol
+                            ]))
+                        }
+
+                        it("should deconstruct compositions of class and protocol for based") {
+                            let expectedProtocol = Protocol(name: "Foo")
+                            let expectedClass = Class(name: "Bar")
+                            let expectedProtocolComposition = ProtocolComposition(name: "Bar & Foo", inheritedTypes: ["Bar", "Foo"], composedTypeNames: [TypeName(name: "Bar"), TypeName(name: "Foo")], composedTypes: [expectedClass, expectedProtocol])
+
+                            let type = parse("protocol Foo {}; class Bar {}; class Implements: Bar & Foo {}").last as? Class
+
+                            expect(type?.based).to(equal([
+                                expectedClass.name: expectedClass.name,
+                                expectedProtocol.name: expectedProtocol.name,
+                                expectedProtocolComposition.name: expectedProtocolComposition.name
+                            ]))
+                        }
+
+                        it("should deconstruct compositions of class and protocol for inherits") {
+                            let expectedClass = Class(name: "Bar")
+
+                            let type = parse("protocol Foo {}; class Bar {}; class Implements: Bar & Foo {}").last as? Class
+
+                            expect(type?.inherits).to(equal([
+                                expectedClass.name: expectedClass
+                            ]))
+                        }
+
                         it("should deconstruct compositions of protocols and classes for implements and inherits") {
                             let expectedProtocol = Protocol(name: "Foo")
                             let expectedClass = Class(name: "Bar")
@@ -1599,8 +1632,7 @@ class ParserComposerSpec: QuickSpec {
                             let type = parse("typealias GlobalComposition = Foo & Bar; protocol Foo {}; class Bar {}; class Implements: GlobalComposition {}").last as? Class
 
                             expect(type?.implements).to(equal([
-                                expectedProtocol.name: expectedProtocol,
-                                expectedProtocolComposition.name: expectedProtocolComposition
+                                expectedProtocol.name: expectedProtocol
                             ]))
 
                             expect(type?.inherits).to(equal([


### PR DESCRIPTION
Resolves #815

## Context

Currently Sourcery does not properly parse types which are declared as a combination of a class and protocol.

```swift
1 protocol P {}
2 class C {}
3 class B: C {}
4 class A: C & P {}
```

here in this example, type `A` would not have `C` or `P` in its `implements`, `inherits`, `based` collections.

This PR adds this possibility for accessing types if the declaration is combining them, but also, this PR removes all `Class` instances from `implements` when such combination of `Class & Protocol` is used in the type declaration.
This behaviour is different from how it was working before, where `Class` instances were put into `implements` after parsing `ProtocolComposition`, which was against the documentation and common sense.