### PR TITLE
Enable Quotes when parsing arguments in property wrapper parameters

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Attribute+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Attribute+SwiftSyntax.swift
@@ -12,9 +12,9 @@ extension Attribute {
               let components = part.split(separator: ":", maxSplits: 1)
               switch components.count {
               case 2:
-                  arguments[components[0].trimmed] = components[1].replacingOccurrences(of: "\"", with: "").trimmed as NSString
+                  arguments[components[0].trimmed] = components[1].trimmed as NSString
               case 1:
-                  arguments["\(idx)"] = components[0].replacingOccurrences(of: "\"", with: "").trimmed as NSString
+                  arguments["\(idx)"] = components[0].trimmed as NSString
               default:
                   Log.astError("Unrecognized attribute format \(attribute.arguments?.description ?? "")")
                   return

--- a/SourceryRuntime/Sources/Common/AST/Attribute.swift
+++ b/SourceryRuntime/Sources/Common/AST/Attribute.swift
@@ -23,7 +23,8 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
     public init(name: String, arguments: [String: NSObject] = [:], description: String? = nil) {
         self.name = name
         self.arguments = arguments
-        self._description = description ?? "@\(name)"
+        let argumentDescription = arguments.map { "\($0.key): \($0.value is String ? "\"" : "")\($0.value)\($0.value is String ? "\"" : "")" }.joined(separator: ", ")
+        self._description = description ?? "@\(name)\(!argumentDescription.isEmpty ? "(" : "")\(argumentDescription)\(!argumentDescription.isEmpty ? ")" : "")"
     }
 
     /// TODO: unify `asSource` / `description`?
@@ -33,7 +34,7 @@ public class Attribute: NSObject, AutoCoding, AutoEquatable, AutoDiffable, AutoJ
 
     /// Attribute description that can be used in a template.
     public override var description: String {
-        return _description
+        _description
     }
 
     /// :nodoc:


### PR DESCRIPTION
Resolves #1043 

## Context

The logic at fault is, when Attribute is parsed from `AttributeSyntax`, for some reason `"` is replaced with an empty string - unsure why this was applied during initial implementation, when `swift-syntax` was integrated. As far as I can see, the behaviour changes a little, **but** it changes in a correct manner, that is, the reported issue is fixed.

I suspect there was an assumption made initially that quotes did not look good, especially when writing unit tests; however, as practice shows, they are needed.

```swift
extension Attribute {
    convenience init(_ attribute: AttributeSyntax) {
             ...
              let components = part.split(separator: ":", maxSplits: 1)
              switch components.count {
              case 2:
                  arguments[components[0].trimmed] = components[1].replacingOccurrences(of: "\"", with: "").trimmed as NSString
              case 1:
                  arguments["\(idx)"] = components[0].replacingOccurrences(of: "\"", with: "").trimmed as NSString
              ...
    }
   ...
}
```