### PR TITLE
Fixed Issue when Caching of SwiftTemplate Binary Failes

### DIFF
--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -202,16 +202,13 @@ open class SwiftTemplate {
                 Log.verbose("Reusing built SwiftTemplate binary for SwiftTemplate with cache key: \(hash)...")
             } else {
                 Log.verbose("Building new SwiftTemplate binary for SwiftTemplate...")
-                try? cachePath.delete() // clear old cache
-                try cachePath.mkdir()
                 do {
-                    try build().move(binaryPath)
+                    let path = try build()
+                    try? cachePath.delete() // clear old cache
+                    try? cachePath.mkdir()
+                    try? path.move(binaryPath)
                 } catch let error as NSError {
-                    if error.domain == "NSCocoaErrorDomain", error.code == 516 {
-                        Log.warning("This error can be ignored: Attempt to copy `SwiftTemplate` binary to \(binaryPath) failed. Probably multiple Sourcery processes trying to cache into the same directory.")
-                    } else {
-                        throw error
-                    }
+                    throw error
                 }
             }
         } else {

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -199,14 +199,10 @@ class SwiftTemplateTests: QuickSpec {
             }
 
             context("with existing cache") {
-                // beforeEach {
-                    
-                // }
-
                 context("and missing build dir") {
-#if canImport(ObjectiveC)
+//#if canImport(ObjectiveC)
                     expect { try Sourcery(cacheDisabled: false).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output, baseIndentation: 0) }.toNot(throwError())
-#endif
+//#endif
                     expect((try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))).to(equal(expectedResult))
                     guard let buildDir = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("SwiftTemplate").map({ Path($0.path) }) else {
                         fail("Could not create buildDir path")
@@ -227,6 +223,37 @@ class SwiftTemplateTests: QuickSpec {
 
                         let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
                         expect(result).to(equal(expectedResult))
+                    }
+
+                    it("generates the code asynchronously without throwing error") {
+                        let iterations = 2
+                        let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true) as [String]
+                        let path = paths[0]
+                        let caches = Path(path) + Path("Sourcery")
+                        try? caches.delete()
+                        @Sendable func generateCode() async throws -> Int {
+                            expect { try Sourcery(cacheDisabled: false).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output, baseIndentation: 0) }.toNot(throwError())
+                            let result = (try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))
+                            expect(result).to(equal(expectedResult))
+                            return 1
+                        }
+                        let semaphore = DispatchSemaphore(value: 0)
+                        Task {
+                            _ = try await withThrowingTaskGroup(of: Int.self) { taskGroup in
+                                for _ in 0 ..< iterations {
+                                    taskGroup.addTask {
+                                        try await generateCode()
+                                    }
+                                }
+                                var counter = 0
+                                for try await _ in taskGroup {
+                                    counter += 1
+                                }
+                                return counter
+                            }
+                            semaphore.signal()
+                        }
+                        semaphore.wait()
                     }
                 }
             }

--- a/SourceryTests/Generating/SwiftTemplateSpecs.swift
+++ b/SourceryTests/Generating/SwiftTemplateSpecs.swift
@@ -200,9 +200,7 @@ class SwiftTemplateTests: QuickSpec {
 
             context("with existing cache") {
                 context("and missing build dir") {
-//#if canImport(ObjectiveC)
                     expect { try Sourcery(cacheDisabled: false).processFiles(.sources(Paths(include: [Stubs.sourceDirectory])), usingTemplates: Paths(include: [templatePath]), output: output, baseIndentation: 0) }.toNot(throwError())
-//#endif
                     expect((try? (outputDir + Sourcery().generatedPath(for: templatePath)).read(.utf8))).to(equal(expectedResult))
                     guard let buildDir = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("SwiftTemplate").map({ Path($0.path) }) else {
                         fail("Could not create buildDir path")


### PR DESCRIPTION
## Context

Currently, whenever Sourcery is done with compiling `SwiftTemplate` executable binary, it tries to move this binary into a shared cache folder.

However, if Sourcery is executed concurrently, i.e. `sourcery` binary is launched multiple times with a same `.swifttemplate`, an error is thrown because one of the sourcery executions was able to move the same file from within a guarding `if` statement:

```swift
Error Domain=NSCocoaErrorDomain Code=516 "“SwiftTemplate” couldn’t be moved to “Equality.swifttemplate” because an item with the same name already exists." UserInfo={NSSourceFilePathErrorKey=/var/folders/90/8tcwdk19055d0rrgfp00h25h0000gn/T/SwiftTemplate/4F2C1EC9-D4B9-44BE-A854-1F6BAAFD5113/Major.Minor.Patch/.build/release/SwiftTemplate, NSUserStringVariant=(
    Move
), NSDestinationFilePath=/Users/art-divin/Library/Caches/Sourcery/Equality.swifttemplate/oSLR1bsrLapzaddnJtSrw7XLwIcd94jZorJD%2BX3XSxA%3D, NSFilePath=/var/folders/90/8tcwdk19055d0rrgfp00h25h0000gn/T/SwiftTemplate/4F2C1EC9-D4B9-44BE-A854-1F6BAAFD5113/Major.Minor.Patch/.build/release/SwiftTemplate, NSUnderlyingError=0x600001928030 {Error Domain=NSPOSIXErrorDomain Code=17 "File exists"}}
```

## Details

To resolve this, the move of the compiled `SwiftTemplate` binary is now `optional`, i.e. thrown error is ignored. Essentially, it is irrelevant if the binary was cached or not, since Sourcery's task is to execute SwiftTemplate and not cache SwiftTemplate.

Verification is done using a new unit test.