### PR TITLE
Fixed typealias resolution breaking resolution of real types.

### DIFF
--- a/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
@@ -533,6 +533,10 @@ internal struct ParserResultsComposed {
         // let variable: Module.ID.ID // should be resolved as MyView.ID type
         let finalLookup = typeName.actualTypeName ?? typeName
         var resolvedIdentifier = finalLookup.generic?.name ?? finalLookup.unwrappedTypeName
+        if let type = unique[resolvedIdentifier] {
+            return type
+        }
+        
         for alias in resolvedTypealiases {
             /// iteratively replace all typealiases from the resolvedIdentifier to get to the actual type name requested
             if resolvedIdentifier.contains(alias.value.name), let range = resolvedIdentifier.range(of: alias.value.name) {


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/krzysztofzablocki/Sourcery/pull/1288. If a type name contained the name of a typealias, part of the type name would be replaced with the resolved typealias, which ultimately led to the lookup of a wrong (in our case non-existent) type.

I simply added an early return, if the exact type name could be found and added a test case to make sure, that both cases work as expected now.

Please let me know, if there is anything I can do, to speed up getting this merged, as this regression has been keeping us from upgrading to the latest Sourcery version for a while (didn't get to having a closer look sooner).