### PR TITLE
Added hideVersionHeader to configuration arguments

### DIFF
--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -33,7 +33,7 @@ public class Sourcery {
     fileprivate let buildPath: Path?
     fileprivate let prune: Bool
     fileprivate let serialParse: Bool
-    fileprivate var hideVersionHeader: Bool
+    fileprivate let hideVersionHeader: Bool
 
     fileprivate var status = ""
     fileprivate var templatesPaths = Paths(include: [])
@@ -67,13 +67,17 @@ public class Sourcery {
         self.buildPath = buildPath
         self.prune = prune
         self.serialParse = serialParse
-        self.hideVersionHeader = hideVersionHeader
+        if let hideVersionHeader = arguments["hideVersionHeader"] {
+            self.hideVersionHeader = (hideVersionHeader as? NSNumber)?.boolValue == true
+        } else {
+            self.hideVersionHeader = hideVersionHeader
+        }
         if let logConfiguration {
             Log.setup(using: logConfiguration)
         }
 
         var prefix = Sourcery.generationMarker
-        if !hideVersionHeader {
+        if !self.hideVersionHeader {
           prefix += " \(Sourcery.version)"
         }
         self.generationHeader = "\(prefix) — https://github.com/krzysztofzablocki/Sourcery\n"


### PR DESCRIPTION
This PR adds support for hideVersionHeader argument in `.yaml` configuration.

## Example

```yaml
      sources:
        - ./S20.swift
      templates:
        - ./template26.stencil
      output: 
        ./Generated/
      parseDocumentation: true
      disableCache: true
      serialParse: true
      args: 
        hideVersionHeader: true
```

