### PR TITLE
AutoMockable: fix generating static reset func

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -342,9 +342,9 @@ import {{ import }}
 {% endfor %}
 
 {% if type.allMethods|static|count != 0 and type.allMethods|initializer|count != type.allMethods|static|count %}
-    static func reset()
+    {% call accessLevel type.accessLevel %}static func reset()
     {
-    {% for method in type.allMethods|static %}
+    {% for method in type.allMethods|static|!definedInExtension %}
         {% call resetMethod method %}
     {% endfor %}
     }


### PR DESCRIPTION
- don't generate invalid code (see https://github.com/krzysztofzablocki/Sourcery/issues/1335)
- use type's access level for generated reset() function

Resolves https://github.com/krzysztofzablocki/Sourcery/issues/1335