### PR TITLE
Add support for child configs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -165,10 +165,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "08a2f0a9a30e0f705f79c9cfaca1f68b71bdc775",
-        "version" : "510.0.0"
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     },
     {

--- a/SourceryTests/Stub/Configs/parent.yml
+++ b/SourceryTests/Stub/Configs/parent.yml
@@ -1,0 +1,2 @@
+configurations:
+    - child: valid.yml

--- a/guides/Usage.md
+++ b/guides/Usage.md
@@ -78,6 +78,16 @@ configurations:
 
 This will be equivalent to running Sourcery separately for each of the configurations. In watch mode Sourcery will observe changes in the paths from all the configurations.
 
+#### Child configurations
+
+You can specify a child configurations by using the `child` key:
+```yaml
+configurations:
+    - child: ./.child_config.yml
+    - child: Subdirectory/.another_child_config.yml
+```
+Sources will be resolved relative to the child config paths.
+
 #### Sources
 
 You can provide sources using paths to directories or specific files.


### PR DESCRIPTION
The project I work in uses sourcery and consists of quite a lot packages. Having all these configs in a single `.sourcery.yml` file is becoming quite hard to manage (350+ lines).

This PR allows for child configs, in order to break configs into smaller sub configs and also directly allow for them to be run independently.

A config with child config would look like this:
```yaml
configurations:
    - child: ./.child_config.yml
    - child: Subdirectory/.another_child_config.yml
```

Whereas the child config would be a regular sourcery config file (or have further child configs). The existing config keeps working as is, so you could have a regular config with also child configs in it.