### PR TITLE
Enabled lookup for generic type information in arrays

### DIFF
--- a/SourceryRuntime/Sources/Common/AST/TypeName/Array.swift
+++ b/SourceryRuntime/Sources/Common/AST/TypeName/Array.swift
@@ -25,7 +25,7 @@ public final class ArrayType: NSObject, SourceryModel, Diffable {
     /// Returns array as generic type
     public var asGeneric: GenericType {
         GenericType(name: "Array", typeParameters: [
-            .init(typeName: elementTypeName)
+            .init(typeName: elementTypeName, type: elementType)
         ])
     }
 

--- a/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
@@ -392,7 +392,7 @@ internal struct ParserResultsComposed {
         if let array = lookupName.array {
             array.elementType = resolveTypeWithName(array.elementTypeName)
 
-            if array.elementTypeName.actualTypeName != nil || retrievedName != nil {
+            if array.elementTypeName.actualTypeName != nil || retrievedName != nil || array.elementType != nil {
                 let array = ArrayType(name: array.name, elementTypeName: array.elementTypeName, elementType: array.elementType)
                 array.elementTypeName = array.elementTypeName.actualTypeName ?? array.elementTypeName
                 array.elementTypeName.actualTypeName = nil

--- a/SourceryTests/Models/ArrayTypeSpec.swift
+++ b/SourceryTests/Models/ArrayTypeSpec.swift
@@ -1,0 +1,28 @@
+import Quick
+import Nimble
+#if SWIFT_PACKAGE
+@testable import SourceryLib
+#else
+@testable import Sourcery
+#endif
+@testable import SourceryRuntime
+
+class ArrayTypeSpec: QuickSpec {
+    override func spec() {
+        describe("Array") {
+            var sut: ArrayType?
+
+            beforeEach {
+                sut = ArrayType(name: "Foo", elementTypeName: TypeName(name: "Foo"), elementType: Type(name: "Bar"))
+            }
+
+            afterEach {
+                sut = nil
+            }
+
+            it("preserves element type for generic") {
+                expect(sut?.asGeneric.typeParameters.first?.type).toNot(beNil())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #1177

## Context

This PR persists information about generic type's element types. Previously, this information was getting lost and/or not used after parsing.