### PR TITLE
Method/Initializer parameter types now resolve to the local type if it exists

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
@@ -9,7 +9,7 @@ extension SourceryMethod {
           parent: parent,
           identifier: node.name.text.trimmed,
           typeName: typeName,
-          signature: Signature(node.signature, annotationsParser: annotationsParser),
+          signature: Signature(node.signature, annotationsParser: annotationsParser, parent: parent),
           modifiers: node.modifiers,
           attributes: node.attributes,
           genericParameterClause: node.genericParameterClause,
@@ -30,7 +30,8 @@ extension SourceryMethod {
             output: nil,
             asyncKeyword: nil,
             throwsOrRethrowsKeyword: signature.effectSpecifiers?.throwsSpecifier?.description.trimmed,
-            annotationsParser: annotationsParser
+            annotationsParser: annotationsParser,
+            parent: parent
           ),
           modifiers: node.modifiers,
           attributes: node.attributes,
@@ -46,7 +47,7 @@ extension SourceryMethod {
           parent: parent,
           identifier: "deinit",
           typeName: typeName,
-          signature: Signature(parameters: nil, output: nil, asyncKeyword: nil, throwsOrRethrowsKeyword: nil, annotationsParser: annotationsParser),
+          signature: Signature(parameters: nil, output: nil, asyncKeyword: nil, throwsOrRethrowsKeyword: nil, annotationsParser: annotationsParser, parent: parent),
           modifiers: node.modifiers,
           attributes: node.attributes,
           genericParameterClause: nil,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/MethodParameter+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/MethodParameter+SwiftSyntax.swift
@@ -2,12 +2,24 @@ import SwiftSyntax
 import SourceryRuntime
 
 extension MethodParameter {
-    convenience init(_ node: FunctionParameterSyntax, index: Int, annotationsParser: AnnotationsParser) {
+    convenience init(_ node: FunctionParameterSyntax, index: Int, annotationsParser: AnnotationsParser, parent: Type?) {
         let firstName = node.firstName.text.trimmed.nilIfNotValidParameterName
 
-        let typeName = TypeName(node.type)
+        let isVisitingTypeSourceryProtocol = parent is SourceryProtocol
         let specifiers = TypeName.specifiers(from: node.type)
-        
+
+        // NOTE: This matches implementation in Variable+SwiftSyntax.swift
+        // TODO: Walk up the `parent` in the event that there are multiple levels of nested types
+        var typeName = TypeName(node.type)
+        if !isVisitingTypeSourceryProtocol {
+            // we are in a custom type, which may contain other types
+            // in order to assign correct type to the variable, we need to match
+            // all of the contained types against the variable type
+            if let matchingContainedType = parent?.containedTypes.first(where: { $0.localName == typeName.name }) {
+                typeName = TypeName(matchingContainedType.name)
+            }
+        }
+
         if specifiers.isInOut {
             // TODO: TBR
             typeName.name = "inout \(typeName.name)"

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
@@ -14,20 +14,28 @@ public struct Signature {
     /// The `throws` or `rethrows` keyword, if any.
     public let throwsOrRethrowsKeyword: String?
 
-    public init(_ node: FunctionSignatureSyntax, annotationsParser: AnnotationsParser) {
+    public init(_ node: FunctionSignatureSyntax, annotationsParser: AnnotationsParser, parent: Type?) {
         self.init(parameters: node.parameterClause.parameters,
                   output: node.returnClause.map { TypeName($0.type) },
                   asyncKeyword: node.effectSpecifiers?.asyncSpecifier?.text,
                   throwsOrRethrowsKeyword: node.effectSpecifiers?.throwsSpecifier?.description.trimmed,
-                  annotationsParser: annotationsParser
+                  annotationsParser: annotationsParser,
+                  parent: parent
         )
     }
 
-    public init(parameters: FunctionParameterListSyntax?, output: TypeName?, asyncKeyword: String?, throwsOrRethrowsKeyword: String?, annotationsParser: AnnotationsParser) {
+    public init(
+        parameters: FunctionParameterListSyntax?,
+        output: TypeName?,
+        asyncKeyword: String?,
+        throwsOrRethrowsKeyword: String?,
+        annotationsParser: AnnotationsParser,
+        parent: Type?
+    ) {
         var methodParameters: [MethodParameter] = []
         if let parameters {
             for (idx, param) in parameters.enumerated() {
-                methodParameters.append(MethodParameter(param, index: idx, annotationsParser: annotationsParser))
+                methodParameters.append(MethodParameter(param, index: idx, annotationsParser: annotationsParser, parent: parent))
             }
         }
         input = methodParameters

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
@@ -85,7 +85,7 @@ extension Subscript {
 
         var parameters: [MethodParameter] = []
         for (idx, param) in node.parameterClause.parameters.enumerated() {
-            parameters.append(MethodParameter(param, index: idx, annotationsParser: annotationsParser))
+            parameters.append(MethodParameter(param, index: idx, annotationsParser: annotationsParser, parent: parent))
         }
         self.init(
           parameters: parameters,

--- a/SourceryTests/Parsing/FileParser_MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_MethodsSpec.swift
@@ -293,7 +293,7 @@ class FileParserMethodsSpec: QuickSpec {
                             struct Foo {
                             }
 
-                            func doSomething(with foo: Foo) {
+                            func doSomething(with foo: Foo) -> Foo {
                             }
                         }
                         """
@@ -305,7 +305,7 @@ class FileParserMethodsSpec: QuickSpec {
                             methods: [
                                 Method(name: "doSomething(with foo: Bar.Foo)", selectorName: "doSomething(with:)", parameters: [
                                     MethodParameter(argumentLabel: "with", name: "foo", index: 0, typeName: TypeName("Bar.Foo"), type: fooStruct)
-                                ], definedInTypeName: TypeName("Bar"))
+                                ], returnTypeName: TypeName("Bar.Foo"), definedInTypeName: TypeName("Bar"))
                             ],
                             containedTypes: [
                                 fooStruct

--- a/SourceryTests/Parsing/FileParser_MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_MethodsSpec.swift
@@ -284,6 +284,38 @@ class FileParserMethodsSpec: QuickSpec {
                             ]))
                     }
 
+                    it("extracts correct typeName when a nested type shadows a global type") {
+                        let code = """
+                        protocol Foo {
+                        }
+
+                        class Bar {
+                            struct Foo {
+                            }
+
+                            func doSomething(with foo: Foo) {
+                            }
+                        }
+                        """
+
+                        let fooProtocol = Protocol(name: "Foo")
+                        let fooStruct = Struct(name: "Foo")
+                        let barClass = Class(
+                            name: "Bar",
+                            methods: [
+                                Method(name: "doSomething(with foo: Bar.Foo)", selectorName: "doSomething(with:)", parameters: [
+                                    MethodParameter(argumentLabel: "with", name: "foo", index: 0, typeName: TypeName("Bar.Foo"), type: fooStruct)
+                                ], definedInTypeName: TypeName("Bar"))
+                            ],
+                            containedTypes: [
+                                fooStruct
+                            ]
+                        )
+
+                        let result = parse(code)
+                        expect(result).to(equal([fooProtocol, barClass, fooStruct]))
+                    }
+
                     context("given parameter default value") {
                         it("extracts simple default value") {
                             expect(parse("class Foo { func foo(a: Int? = nil) {} }")).to(equal([


### PR DESCRIPTION
# Background

- https://github.com/krzysztofzablocki/Sourcery/pull/1345#discussion_r1678077591

In the latest 2.2.5 release, our templates seemed to have hit a regression where an associated type within an unrelated protocol would show up as the `type` for a `MethodParameter` of an unrelated type. This led me to discover a subtle inconsistency between how types of method parameters are resolved compared to variables.

When resolving a variable type from the syntax tree, it will be sure to check for the type name within the `containedTypes` because this type should take priority over any global type:

https://github.com/krzysztofzablocki/Sourcery/blob/070d0b1f6c839b85a5bf1330a6c3ed49362ef96c/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Variable%2BSwiftSyntax.swift#L77-L86

This handling was missing for `MethodParameter` which means that the `typeName` (and later `type`) would always be `Foo` instead of `Bar.Foo`.

# Changes

This change addresses the immediate issue of Method Parameter types not being correct by passing the parent `Type` into the `FunctionParameterSyntax` initialiser which is used when walking the syntax tree.

This however isn't quite a complete fix. While looking at the code, I spotted a few other gotchas:

1. ~Return types also aren't resolved with local nested types in mind~
    - I fixed this.. But the same consideration will need to be made for typed throws later on
2. It only works for the immediate parent type and doesn't account for multiple levels of nesting - this flaw also exists with the variable type resolution

But I think that it's a beneficial one for now until some further work can be done to align type resolution. Anyway.. Feedback is welcome 🙏 

