### PR TITLE
Fixed wrong relative path in symbolic link

### DIFF
--- a/SourcerySwift/Sources/SwiftTemplate.swift
+++ b/SourcerySwift/Sources/SwiftTemplate.swift
@@ -225,6 +225,7 @@ open class SwiftTemplate {
                 try buildDir.mkpath()
             }
             originalBinaryPath = buildDir + hashPath
+            destinationBinaryPath = destinationBinaryPath.isRelative ? destinationBinaryPath.absolute() : destinationBinaryPath
             try FileManager.default.createSymbolicLink(atPath: originalBinaryPath.string, withDestinationPath: destinationBinaryPath.string)
         } else {
             try build()


### PR DESCRIPTION
Fixing: https://github.com/krzysztofzablocki/Sourcery/issues/1349

`destinationBinaryPath` is based on cachePath, which could be relative (related to sourcery binary) and we are creating sym link (link at `originalBinaryPath` to `destinationBinaryPath`) which will be also relative, but relative sym link resolves itself not from sourcery binary but from itself.

E.g. 
**sourcery bin**: `~/sourcery`
**destinationBinaryPath**: `/destinationBuilds`
**originalBinaryPath**: `~/sourcery/customCache`

**symlink**: originalBinaryPath-> destinationBinaryPath (`~/sourcery/customCache` will redirect to `/destinationBuilds`),
it resolves to `~/sourcery/customCache/destinationBuilds ` but should be `~/sourcery/destinationBuilds`