### PR TITLE
chore: add unchecked Sendable conformance to AutoMockable

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -369,8 +369,12 @@ import {{ import }}
     {% endif %}
 {%- endmacro %}
 
+{% macro extractRequiredProtocolConformance type -%}
+    {% if type.based.Sendable %}, @unchecked Sendable{% endif %}
+{%- endmacro %}
+
 {% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
-{% call accessLevel type.accessLevel %}class {{ type.name }}Mock{% set generics %}{% call extractProtocolCompositionFromAssociatedTypes type %}{% endset %}{{ generics | replace:",>",">"}}: {{ type.name }} {%- set requirements -%}{% call extractProtocolRequirementsFromType type %}{%- endset -%} {{ requirements|replace:",{","{"|replace:"{"," {" }}
+{% call accessLevel type.accessLevel %}class {{ type.name }}Mock{% set generics %}{% call extractProtocolCompositionFromAssociatedTypes type %}{% endset %}{{ generics | replace:",>",">"}}: {{ type.name }}{% call extractRequiredProtocolConformance type %} {%- set requirements -%}{% call extractProtocolRequirementsFromType type %}{%- endset -%} {{ requirements|replace:",{","{"|replace:"{"," {" }}
 {% for associatedType in type.associatedTypes|sortedValuesByKeys %}
     {% if associatedType.type.kind == nil or not associatedType.type.kind|contains:"protocol" %}
     typealias {{ associatedType.name }} = {% if associatedType.type != nil %}{{ associatedType.type.name }}{% elif associatedType.typeName != nil %}{{ associatedType.typeName.name }}{% else %}Any{% endif %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -292,3 +292,15 @@ protocol TestProtocol {
 
     func getValue6() -> Value6
 }
+
+// sourcery: AutoMockable
+protocol SendableProtocol: Sendable {
+  var value: Any { get }
+}
+
+protocol NotMockedSendableProtocol: Sendable {}
+
+// sourcery: AutoMockable
+protocol SendableSendableProtocol: NotMockedSendableProtocol {
+  var value: Any { get }
+}

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -292,3 +292,15 @@ protocol TestProtocol {
 
     func getValue6() -> Value6
 }
+
+// sourcery: AutoMockable
+protocol SendableProtocol: Sendable {
+  var value: Any { get }
+}
+
+protocol NotMockedSendableProtocol: Sendable {}
+
+// sourcery: AutoMockable
+protocol SendableSendableProtocol: NotMockedSendableProtocol {
+  var value: Any { get }
+}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1457,6 +1457,30 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
 
 
 }
+class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
+
+
+    var value: Any {
+        get { return underlyingValue }
+        set(value) { underlyingValue = value }
+    }
+    var underlyingValue: (Any)!
+
+
+
+}
+class SendableSendableProtocolMock: SendableSendableProtocol, @unchecked Sendable {
+
+
+    var value: Any {
+        get { return underlyingValue }
+        set(value) { underlyingValue = value }
+    }
+    var underlyingValue: (Any)!
+
+
+
+}
 class SingleOptionalParameterFunctionMock: SingleOptionalParameterFunction {
 
 

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1457,6 +1457,30 @@ class SameShortMethodNamesProtocolMock: SameShortMethodNamesProtocol {
 
 
 }
+class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
+
+
+    var value: Any {
+        get { return underlyingValue }
+        set(value) { underlyingValue = value }
+    }
+    var underlyingValue: (Any)!
+
+
+
+}
+class SendableSendableProtocolMock: SendableSendableProtocol, @unchecked Sendable {
+
+
+    var value: Any {
+        get { return underlyingValue }
+        set(value) { underlyingValue = value }
+    }
+    var underlyingValue: (Any)!
+
+
+
+}
 class SingleOptionalParameterFunctionMock: SingleOptionalParameterFunction {
 
 


### PR DESCRIPTION
When protocol conforms to `Sendable`, Xcode generates an error for the Mock class:
```
Non-final class 'SendableProtocolMock' cannot conform to 'Sendable'; use '@unchecked Sendable'
```

This PR fixes the issue.

**UPD 1**: Updated linux sources for template tests.
**UPD 2**: Prettify templates test failures. Show actual differences line by line. Not like git diff, but much easier to navigate on failures.