### PR TITLE
Fixes issue around mutable capture of 'inout' parameter 'buffer' is not allowed in concurrently-executing code

### DIFF
--- a/SourceryRuntime/Sources/Common/Array+Parallel.swift
+++ b/SourceryRuntime/Sources/Common/Array+Parallel.swift
@@ -17,6 +17,7 @@ public extension Array {
     func parallelMap<T>(transform: (Element) -> T) -> [T] {
         var result = ContiguousArray<T?>(repeating: nil, count: count)
         return result.withUnsafeMutableBufferPointer { buffer in
+            nonisolated(unsafe) let buffer = buffer
             DispatchQueue.concurrentPerform(iterations: buffer.count) { idx in
                 buffer[idx] = transform(self[idx])
             }


### PR DESCRIPTION
## Description
This PR fixes an error thrown with Xcode 16 around mutable capture of `buffer` in `Array+Parallel`

## Related issues
* https://github.com/krzysztofzablocki/Sourcery/issues/1362