### PR TITLE
Updated swift-syntax package's url (#1354)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -258,7 +258,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
     .package(url: "https://github.com/art-divin/StencilSwiftKit.git", exact: "2.10.4"),
     .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.16.0"),
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
     .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
     .package(url: "https://github.com/art-divin/swift-package-manager.git", exact: "1.0.8"),


### PR DESCRIPTION
## Problem

Fixed outdated link to `swift-syntax` package to be up-to-date because Apple updated the repository url

<img width="1367" alt="352982358-65e20d95-f8cd-42a6-a4ab-45c9bfea78f4" src="https://github.com/user-attachments/assets/78622a2b-f137-439a-aa89-970bf482df45">
