### PR TITLE
Try to fix associated types messing up types unification

### DIFF
--- a/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
@@ -55,7 +55,12 @@ internal struct ParserResultsComposed {
 
         /// Map associated types
         associatedTypes.forEach {
-            typeMap[$0.key] = $0.value.type
+            if let globalName = $0.value.type?.globalName,
+               let type = typeMap[globalName] {
+                typeMap[$0.key] = type
+            } else {
+                typeMap[$0.key] = $0.value.type
+            }
         }
 
         types = unifyTypes()


### PR DESCRIPTION
Attempt to fix https://github.com/krzysztofzablocki/Sourcery/issues/1359, which seems to be caused by associated types adding mostly empty `Type` objects to the `typeMap` of `ParserResultsComposed`.