### PR TITLE
Fixed nested type resolution

### DIFF
--- a/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
@@ -27,6 +27,14 @@ internal struct ParserResultsComposed {
         associatedTypes = Self.extractAssociatedTypes(parserResult)
         parsedTypes = parserResult.types
 
+        var moduleAndTypeNameCollisions: Set<String> = []
+
+        for type in parsedTypes where !type.isExtension && type.parent == nil {
+            if let module = type.module, type.localName == module {
+                moduleAndTypeNameCollisions.insert(module)
+            }
+        }
+
         // set definedInType for all methods and variables
         parsedTypes
             .forEach { type in
@@ -36,16 +44,23 @@ internal struct ParserResultsComposed {
             }
 
         // map all known types to their names
-        parsedTypes
-            .filter { !$0.isExtension }
-            .forEach {
-                typeMap[$0.globalName] = $0
-                if let module = $0.module {
-                    var typesByModules = modules[module, default: [:]]
-                    typesByModules[$0.name] = $0
-                    modules[module] = typesByModules
-                }
+
+        for type in parsedTypes where !type.isExtension && type.parent == nil {
+            let name = type.name
+            // If a type name has the `<module>.` prefix, and the type `<module>.<module>` is undefined, we can safely remove the `<module>.` prefix
+            if let module = type.module, name.hasPrefix(module), name.dropFirst(module.count).hasPrefix("."), !moduleAndTypeNameCollisions.contains(module) {
+                type.localName.removeFirst(module.count + 1)
             }
+        }
+
+        for type in parsedTypes where !type.isExtension {
+            typeMap[type.globalName] = type
+            if let module = type.module {
+                var typesByModules = modules[module, default: [:]]
+                typesByModules[type.name] = type
+                modules[module] = typesByModules
+            }
+        }
 
         /// Resolve typealiases
         let typealiases = Array(unresolvedTypealiases.values)
@@ -66,9 +81,14 @@ internal struct ParserResultsComposed {
         types = unifyTypes()
     }
 
-    private func resolveExtensionOfNestedType(_ type: Type) {
+    mutating private func resolveExtensionOfNestedType(_ type: Type) {
         var components = type.localName.components(separatedBy: ".")
-        let rootName = type.module ?? components.removeFirst() // Module/parent name
+        let rootName: String
+        if type.parent != nil, let module = type.module {
+            rootName = module
+        } else {
+            rootName = components.removeFirst()
+        }
         if let moduleTypes = modules[rootName], let baseType = moduleTypes[components.joined(separator: ".")] ?? moduleTypes[type.localName] {
             type.localName = baseType.localName
             type.module = baseType.module
@@ -83,6 +103,14 @@ internal struct ParserResultsComposed {
                     type.parent = baseType.parent
                     return
                 }
+            }
+        }
+        // Parent extensions should always be processed before `type`, as this affects the globalName of `type`.
+        for parent in type.parentTypes where parent.isExtension && parent.localName.contains(".") {
+            let oldName = parent.globalName
+            resolveExtensionOfNestedType(parent)
+            if oldName != parent.globalName {
+                rewriteChildren(of: parent)
             }
         }
     }
@@ -103,19 +131,14 @@ internal struct ParserResultsComposed {
             .forEach { (type: Type) in
                 let oldName = type.globalName
 
-                let hasDotInLocalName = type.localName.contains(".") as Bool
-                if let _ = type.parent, hasDotInLocalName {
+                if type.localName.contains(".") {
                     resolveExtensionOfNestedType(type)
-                }
-
-                if let resolved = resolveGlobalName(for: oldName, containingType: type.parent, unique: typeMap, modules: modules, typealiases: resolvedTypealiases, associatedTypes: associatedTypes)?.name {
+                } else if let resolved = resolveGlobalName(for: oldName, containingType: type.parent, unique: typeMap, modules: modules, typealiases: resolvedTypealiases, associatedTypes: associatedTypes)?.name {
                     var moduleName: String = ""
                     if let module = type.module {
                         moduleName = "\(module)."
                     }
                     type.localName = resolved.replacingOccurrences(of: moduleName, with: "")
-                } else {
-                    return
                 }
 
                 // nothing left to do

--- a/SourceryRuntime/Sources/Generated/JSExport.generated.swift
+++ b/SourceryRuntime/Sources/Generated/JSExport.generated.swift
@@ -673,7 +673,6 @@ extension Type: TypeAutoJSExport {}
     var set: SetType? { get }
     var asSource: String { get }
     var description: String { get }
-    var hash: Int { get }
     var debugDescription: String { get }
 }
 

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -2246,6 +2246,14 @@ internal struct ParserResultsComposed {
         associatedTypes = Self.extractAssociatedTypes(parserResult)
         parsedTypes = parserResult.types
 
+        var moduleAndTypeNameCollisions: Set<String> = []
+
+        for type in parsedTypes where !type.isExtension && type.parent == nil {
+            if let module = type.module, type.localName == module {
+                moduleAndTypeNameCollisions.insert(module)
+            }
+        }
+
         // set definedInType for all methods and variables
         parsedTypes
             .forEach { type in
@@ -2255,16 +2263,23 @@ internal struct ParserResultsComposed {
             }
 
         // map all known types to their names
-        parsedTypes
-            .filter { !$0.isExtension }
-            .forEach {
-                typeMap[$0.globalName] = $0
-                if let module = $0.module {
-                    var typesByModules = modules[module, default: [:]]
-                    typesByModules[$0.name] = $0
-                    modules[module] = typesByModules
-                }
+
+        for type in parsedTypes where !type.isExtension && type.parent == nil {
+            let name = type.name
+            // If a type name has the `<module>.` prefix, and the type `<module>.<module>` is undefined, we can safely remove the `<module>.` prefix
+            if let module = type.module, name.hasPrefix(module), name.dropFirst(module.count).hasPrefix("."), !moduleAndTypeNameCollisions.contains(module) {
+                type.localName.removeFirst(module.count + 1)
             }
+        }
+
+        for type in parsedTypes where !type.isExtension {
+            typeMap[type.globalName] = type
+            if let module = type.module {
+                var typesByModules = modules[module, default: [:]]
+                typesByModules[type.name] = type
+                modules[module] = typesByModules
+            }
+        }
 
         /// Resolve typealiases
         let typealiases = Array(unresolvedTypealiases.values)
@@ -2274,15 +2289,25 @@ internal struct ParserResultsComposed {
 
         /// Map associated types
         associatedTypes.forEach {
-            typeMap[$0.key] = $0.value.type
+            if let globalName = $0.value.type?.globalName,
+               let type = typeMap[globalName] {
+                typeMap[$0.key] = type
+            } else {
+                typeMap[$0.key] = $0.value.type
+            }
         }
 
         types = unifyTypes()
     }
 
-    private func resolveExtensionOfNestedType(_ type: Type) {
+    mutating private func resolveExtensionOfNestedType(_ type: Type) {
         var components = type.localName.components(separatedBy: ".")
-        let rootName = type.module ?? components.removeFirst() // Module/parent name
+        let rootName: String
+        if type.parent != nil, let module = type.module {
+            rootName = module
+        } else {
+            rootName = components.removeFirst()
+        }
         if let moduleTypes = modules[rootName], let baseType = moduleTypes[components.joined(separator: ".")] ?? moduleTypes[type.localName] {
             type.localName = baseType.localName
             type.module = baseType.module
@@ -2297,6 +2322,14 @@ internal struct ParserResultsComposed {
                     type.parent = baseType.parent
                     return
                 }
+            }
+        }
+        // Parent extensions should always be processed before `type`, as this affects the globalName of `type`.
+        for parent in type.parentTypes where parent.isExtension && parent.localName.contains(".") {
+            let oldName = parent.globalName
+            resolveExtensionOfNestedType(parent)
+            if oldName != parent.globalName {
+                rewriteChildren(of: parent)
             }
         }
     }
@@ -2317,19 +2350,14 @@ internal struct ParserResultsComposed {
             .forEach { (type: Type) in
                 let oldName = type.globalName
 
-                let hasDotInLocalName = type.localName.contains(".") as Bool
-                if let _ = type.parent, hasDotInLocalName {
+                if type.localName.contains(".") {
                     resolveExtensionOfNestedType(type)
-                }
-
-                if let resolved = resolveGlobalName(for: oldName, containingType: type.parent, unique: typeMap, modules: modules, typealiases: resolvedTypealiases, associatedTypes: associatedTypes)?.name {
+                } else if let resolved = resolveGlobalName(for: oldName, containingType: type.parent, unique: typeMap, modules: modules, typealiases: resolvedTypealiases, associatedTypes: associatedTypes)?.name {
                     var moduleName: String = ""
                     if let module = type.module {
                         moduleName = "\\(module)."
                     }
                     type.localName = resolved.replacingOccurrences(of: moduleName, with: "")
-                } else {
-                    return
                 }
 
                 // nothing left to do
@@ -3509,7 +3537,8 @@ public final class TemplateContext: NSObject, SourceryModel, NSCoding, Diffable 
                 "based": types.based,
                 "inheriting": types.inheriting,
                 "implementing": types.implementing,
-                "protocolCompositions": types.protocolCompositions
+                "protocolCompositions": types.protocolCompositions,
+                "typealiases": types.typealiases
             ] as [String : Any],
             "functions": functions,
             "type": types.typesByName,
@@ -3547,6 +3576,9 @@ public final class Typealias: NSObject, Typed, SourceryModel, Diffable {
 
     /// module in which this typealias was declared
     public var module: String?
+    
+    /// Imports that existed in the file that contained this typealias declaration
+    public var imports: [Import] = []
 
     /// typealias annotations
     public var annotations: Annotations = [:]
@@ -3661,6 +3693,12 @@ public final class Typealias: NSObject, Typed, SourceryModel, Diffable {
              }; self.typeName = typeName
             self.type = aDecoder.decode(forKey: "type")
             self.module = aDecoder.decode(forKey: "module")
+            guard let imports: [Import] = aDecoder.decode(forKey: "imports") else { 
+                withVaList(["imports"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.imports = imports
             guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
                 withVaList(["annotations"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
@@ -3689,6 +3727,7 @@ public final class Typealias: NSObject, Typed, SourceryModel, Diffable {
             aCoder.encode(self.typeName, forKey: "typeName")
             aCoder.encode(self.type, forKey: "type")
             aCoder.encode(self.module, forKey: "module")
+            aCoder.encode(self.imports, forKey: "imports")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.parent, forKey: "parent")
@@ -8506,6 +8545,7 @@ extension TypeName: TypeNameAutoJSExport {}
     var typeName: TypeName { get }
     var type: Type? { get }
     var module: String? { get }
+    var imports: [Import] { get }
     var annotations: Annotations { get }
     var documentation: Documentation { get }
     var parent: Type? { get }

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -2246,6 +2246,14 @@ internal struct ParserResultsComposed {
         associatedTypes = Self.extractAssociatedTypes(parserResult)
         parsedTypes = parserResult.types
 
+        var moduleAndTypeNameCollisions: Set<String> = []
+
+        for type in parsedTypes where !type.isExtension && type.parent == nil {
+            if let module = type.module, type.localName == module {
+                moduleAndTypeNameCollisions.insert(module)
+            }
+        }
+
         // set definedInType for all methods and variables
         parsedTypes
             .forEach { type in
@@ -2255,16 +2263,23 @@ internal struct ParserResultsComposed {
             }
 
         // map all known types to their names
-        parsedTypes
-            .filter { !$0.isExtension }
-            .forEach {
-                typeMap[$0.globalName] = $0
-                if let module = $0.module {
-                    var typesByModules = modules[module, default: [:]]
-                    typesByModules[$0.name] = $0
-                    modules[module] = typesByModules
-                }
+
+        for type in parsedTypes where !type.isExtension && type.parent == nil {
+            let name = type.name
+            // If a type name has the `<module>.` prefix, and the type `<module>.<module>` is undefined, we can safely remove the `<module>.` prefix
+            if let module = type.module, name.hasPrefix(module), name.dropFirst(module.count).hasPrefix("."), !moduleAndTypeNameCollisions.contains(module) {
+                type.localName.removeFirst(module.count + 1)
             }
+        }
+
+        for type in parsedTypes where !type.isExtension {
+            typeMap[type.globalName] = type
+            if let module = type.module {
+                var typesByModules = modules[module, default: [:]]
+                typesByModules[type.name] = type
+                modules[module] = typesByModules
+            }
+        }
 
         /// Resolve typealiases
         let typealiases = Array(unresolvedTypealiases.values)
@@ -2274,15 +2289,25 @@ internal struct ParserResultsComposed {
 
         /// Map associated types
         associatedTypes.forEach {
-            typeMap[$0.key] = $0.value.type
+            if let globalName = $0.value.type?.globalName,
+               let type = typeMap[globalName] {
+                typeMap[$0.key] = type
+            } else {
+                typeMap[$0.key] = $0.value.type
+            }
         }
 
         types = unifyTypes()
     }
 
-    private func resolveExtensionOfNestedType(_ type: Type) {
+    mutating private func resolveExtensionOfNestedType(_ type: Type) {
         var components = type.localName.components(separatedBy: ".")
-        let rootName = type.module ?? components.removeFirst() // Module/parent name
+        let rootName: String
+        if type.parent != nil, let module = type.module {
+            rootName = module
+        } else {
+            rootName = components.removeFirst()
+        }
         if let moduleTypes = modules[rootName], let baseType = moduleTypes[components.joined(separator: ".")] ?? moduleTypes[type.localName] {
             type.localName = baseType.localName
             type.module = baseType.module
@@ -2297,6 +2322,14 @@ internal struct ParserResultsComposed {
                     type.parent = baseType.parent
                     return
                 }
+            }
+        }
+        // Parent extensions should always be processed before `type`, as this affects the globalName of `type`.
+        for parent in type.parentTypes where parent.isExtension && parent.localName.contains(".") {
+            let oldName = parent.globalName
+            resolveExtensionOfNestedType(parent)
+            if oldName != parent.globalName {
+                rewriteChildren(of: parent)
             }
         }
     }
@@ -2317,19 +2350,14 @@ internal struct ParserResultsComposed {
             .forEach { (type: Type) in
                 let oldName = type.globalName
 
-                let hasDotInLocalName = type.localName.contains(".") as Bool
-                if let _ = type.parent, hasDotInLocalName {
+                if type.localName.contains(".") {
                     resolveExtensionOfNestedType(type)
-                }
-
-                if let resolved = resolveGlobalName(for: oldName, containingType: type.parent, unique: typeMap, modules: modules, typealiases: resolvedTypealiases, associatedTypes: associatedTypes)?.name {
+                } else if let resolved = resolveGlobalName(for: oldName, containingType: type.parent, unique: typeMap, modules: modules, typealiases: resolvedTypealiases, associatedTypes: associatedTypes)?.name {
                     var moduleName: String = ""
                     if let module = type.module {
                         moduleName = "\\(module)."
                     }
                     type.localName = resolved.replacingOccurrences(of: moduleName, with: "")
-                } else {
-                    return
                 }
 
                 // nothing left to do
@@ -3509,7 +3537,8 @@ public final class TemplateContext: NSObject, SourceryModel, NSCoding, Diffable 
                 "based": types.based,
                 "inheriting": types.inheriting,
                 "implementing": types.implementing,
-                "protocolCompositions": types.protocolCompositions
+                "protocolCompositions": types.protocolCompositions,
+                "typealiases": types.typealiases
             ] as [String : Any],
             "functions": functions,
             "type": types.typesByName,
@@ -3547,6 +3576,9 @@ public final class Typealias: NSObject, Typed, SourceryModel, Diffable {
 
     /// module in which this typealias was declared
     public var module: String?
+    
+    /// Imports that existed in the file that contained this typealias declaration
+    public var imports: [Import] = []
 
     /// typealias annotations
     public var annotations: Annotations = [:]
@@ -3661,6 +3693,12 @@ public final class Typealias: NSObject, Typed, SourceryModel, Diffable {
              }; self.typeName = typeName
             self.type = aDecoder.decode(forKey: "type")
             self.module = aDecoder.decode(forKey: "module")
+            guard let imports: [Import] = aDecoder.decode(forKey: "imports") else { 
+                withVaList(["imports"]) { arguments in
+                    NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
+                }
+                fatalError()
+             }; self.imports = imports
             guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
                 withVaList(["annotations"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
@@ -3689,6 +3727,7 @@ public final class Typealias: NSObject, Typed, SourceryModel, Diffable {
             aCoder.encode(self.typeName, forKey: "typeName")
             aCoder.encode(self.type, forKey: "type")
             aCoder.encode(self.module, forKey: "module")
+            aCoder.encode(self.imports, forKey: "imports")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.parent, forKey: "parent")
@@ -9089,6 +9128,7 @@ extension TypeName: TypeNameAutoJSExport {}
     var typeName: TypeName { get }
     var type: Type? { get }
     var module: String? { get }
+    var imports: [Import] { get }
     var annotations: Annotations { get }
     var documentation: Documentation { get }
     var parent: Type? { get }


### PR DESCRIPTION
Fixed nested type resolution in an extension with a global type name in the same module.

## Example

File `Moya.xcframework/ios-arm64_x86_64-simulator/Moya.framework/Modules/Moya.swiftmodule/arm64-apple-ios-simulator.swiftinterface`

```swift
final public class NetworkActivityPlugin : Moya.PluginType {
  public typealias NetworkActivityClosure = (_ change: Moya.NetworkActivityChangeType, _ target: Moya.TargetType) -> Swift.Void
  public init(networkActivityClosure: @escaping Moya.NetworkActivityPlugin.NetworkActivityClosure)
  final public func willSend(_ request: Moya.RequestType, target: Moya.TargetType)
  final public func didReceive(_ result: Swift.Result<Moya.Response, Moya.MoyaError>, target: Moya.TargetType)
  @objc deinit
}

//...

extension Moya.NetworkLoggerPlugin {
  public struct Configuration {
    public typealias OutputType = (_ target: Moya.TargetType, _ items: [Swift.String]) -> Swift.Void
    public var formatter: Moya.NetworkLoggerPlugin.Configuration.Formatter
    public var output: Moya.NetworkLoggerPlugin.Configuration.OutputType
    public var logOptions: Moya.NetworkLoggerPlugin.Configuration.LogOptions
    public init(formatter: Moya.NetworkLoggerPlugin.Configuration.Formatter = Formatter(), output: @escaping Moya.NetworkLoggerPlugin.Configuration.OutputType = defaultOutput, logOptions: Moya.NetworkLoggerPlugin.Configuration.LogOptions = .default)
    public static func defaultOutput(target: Moya.TargetType, items: [Swift.String])
  }
}
```
Sourcery fails with error:
```
SourceryRuntime/ParserResultsComposed.swift:151: Assertion failed: Type Moya.NetworkLoggerPlugin.Configuration should be extension
```
