### PR TITLE
Ability to hide generation header

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Inside a project/package that uses this command plugin, right-click the project 
 - `--help` - Display help information
 - `--cacheBasePath` - Base path to the cache directory. Can be overriden by the config file.
 - `--buildPath` - Path to directory used when building from .swifttemplate files. This defaults to system temp directory
+- `--hideHeader` [default: false] - Stop adding the Sourcery header to the generated files.
 - `--hideVersionHeader` [default: false] - Stop adding the Sourcery version to the generated files headers.
 
 ### Configuration file

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -167,6 +167,20 @@ class SourcerySpecTests: QuickSpec {
                         }
                     }
 
+                    context("with hide header enabled") {
+                        beforeEach {
+                            expect { try Sourcery(watcherEnabled: false, cacheDisabled: true, hideHeader: true).processFiles(.sources(Paths(include: [sourcePath])), usingTemplates: Paths(include: [templatePath]), output: output, baseIndentation: 0) }.toNot(throwError())
+                        }
+                        it("removes header from within generated template") {
+                        let expectedResult = "// Line One"
+
+                        let generatedPath = outputDir + Sourcery().generatedPath(for: templatePath)
+
+                        let result = try? generatedPath.read(.utf8)
+                        expect(result?.withoutWhitespaces).to(equal(expectedResult.withoutWhitespaces))
+                        }
+                    }
+
                     it("does not remove code from within generated template when missing origin") {
                         update(code: """
                             class Foo {
@@ -1254,7 +1268,7 @@ class SourcerySpecTests: QuickSpec {
                         updateTemplate(code: "Found {{ types.all.count }} Types")
 
                         let result: () -> String? = { (try? (outputDir + Sourcery().generatedPath(for: tmpTemplate)).read(.utf8)) }
-                        expect(result()).toEventually(contain("\(sourcery.generationHeader)Found 3 Types"))
+                        expect(result()).toEventually(contain("\(sourcery.generationHeader ?? "")Found 3 Types"))
 
                         _ = watcher
                     }


### PR DESCRIPTION
This PR adds ability to disable header in generated files

**Problem**

If you use SwiftLint rule "file_name", then you will catch "File Name Violation" errors/warnings for each generated file. Even if you have "swiftlint:disable all" after header.

Also we have swiftlint rule for file header pattern "file_header" which also throws a warning :(

<img width="993" alt="Screenshot 2024-11-22 at 17 46 51" src="https://github.com/user-attachments/assets/a88c826a-9950-45b3-ae26-c7174211f07c">

**Solution**

I found a similar problem in the SwiftLint repo - https://github.com/realm/SwiftLint/issues/2277. Users suggest to add this line at the beginning of the file (at 0 line) `// swiftlint:disable:this file_name`.

But at the moment this line contains header comment `// Generated using Sourcery ...`. And I thought that if we be able to hide header and add to template `// swiftlint:disable:this file_name`, then we could solve this problem.

