### PR TITLE
fix: Fixes description of Method's genericParameters

### DIFF
--- a/SourceryRuntime/Sources/Linux/AST/Method_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Method_Linux.swift
@@ -289,7 +289,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string.append("attributes = \(String(describing: self.attributes)), ")
         string.append("modifiers = \(String(describing: self.modifiers)), ")
         string.append("genericRequirements = \(String(describing: self.genericRequirements)), ")
-        string.append("genericRequirements = \(String(describing: self.genericParameters))")
+        string.append("genericParameters = \(String(describing: self.genericParameters))")
         return string
     }
 

--- a/SourceryRuntime/Sources/macOS/AST/Method.swift
+++ b/SourceryRuntime/Sources/macOS/AST/Method.swift
@@ -250,7 +250,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string.append("attributes = \(String(describing: self.attributes)), ")
         string.append("modifiers = \(String(describing: self.modifiers)), ")
         string.append("genericRequirements = \(String(describing: self.genericRequirements)), ")
-        string.append("genericRequirements = \(String(describing: self.genericParameters))")
+        string.append("genericParameters = \(String(describing: self.genericParameters))")
         return string
     }
 

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -5184,7 +5184,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string.append("attributes = \\(String(describing: self.attributes)), ")
         string.append("modifiers = \\(String(describing: self.modifiers)), ")
         string.append("genericRequirements = \\(String(describing: self.genericRequirements)), ")
-        string.append("genericRequirements = \\(String(describing: self.genericParameters))")
+        string.append("genericParameters = \\(String(describing: self.genericParameters))")
         return string
     }
 

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -5616,7 +5616,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string.append("attributes = \\(String(describing: self.attributes)), ")
         string.append("modifiers = \\(String(describing: self.modifiers)), ")
         string.append("genericRequirements = \\(String(describing: self.genericRequirements)), ")
-        string.append("genericRequirements = \\(String(describing: self.genericParameters))")
+        string.append("genericParameters = \\(String(describing: self.genericParameters))")
         return string
     }
 


### PR DESCRIPTION
This was very confusing while debugging how to implement proper Automockable with generics