### PR TITLE
Ability to use custom header prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Inside a project/package that uses this command plugin, right-click the project 
 - `--cacheBasePath` - Base path to the cache directory. Can be overriden by the config file.
 - `--buildPath` - Path to directory used when building from .swifttemplate files. This defaults to system temp directory
 - `--hideVersionHeader` [default: false] - Stop adding the Sourcery version to the generated files headers.
+- `--headerPrefix` - Additional prefix for headers.
 
 ### Configuration file
 

--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -57,7 +57,8 @@ public class Sourcery {
         serialParse: Bool = false, 
         hideVersionHeader: Bool = false,
         arguments: [String: NSObject] = [:],
-        logConfiguration: Log.Configuration? = nil
+        logConfiguration: Log.Configuration? = nil,
+        headerPrefix: String? = nil
     ) {
         self.verbose = verbose
         self.arguments = arguments
@@ -76,7 +77,11 @@ public class Sourcery {
             Log.setup(using: logConfiguration)
         }
 
-        var prefix = Sourcery.generationMarker
+        var prefix = ""
+        if let headerPrefix {
+            prefix += headerPrefix + "\n"
+        }
+        prefix += Sourcery.generationMarker
         if !self.hideVersionHeader {
           prefix += " \(Sourcery.version)"
         }

--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -118,8 +118,9 @@ func runCLI() {
         Option<Path>("ejsPath", default: "", description: "Path to EJS file for JavaScript templates."),
         Option<Path>("cacheBasePath", default: "", description: "Base path to Sourcery's cache directory"),
         Option<Path>("buildPath", default: "", description: "Sets a custom build path"),
-        Flag("hideVersionHeader", description: "Do not include Sourcery version in the generated files headers.")
-    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, ejsPath, cacheBasePath, buildPath, hideVersionHeader in
+        Flag("hideVersionHeader", description: "Do not include Sourcery version in the generated files headers."),
+        Option<String?>("headerPrefix", default: nil, description: "Additional prefix for headers.")
+    ) { watcherEnabled, disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, ejsPath, cacheBasePath, buildPath, hideVersionHeader, headerPrefix in
         do {
             let logConfiguration = Log.Configuration(
                 isDryRun: isDryRun,
@@ -206,7 +207,8 @@ func runCLI() {
                                         prune: prune,
                                         serialParse: serialParse,
                                         hideVersionHeader: hideVersionHeader,
-                                        arguments: configuration.args)
+                                        arguments: configuration.args,
+                                        headerPrefix: headerPrefix)
 
                 if isDryRun, watcherEnabled {
                     throw "--dry not compatible with --watch"
@@ -301,8 +303,9 @@ func runCLI() {
         	"""),
         Option<Path>("cacheBasePath", default: "", description: "Base path to Sourcery's cache directory"),
         Option<Path>("buildPath", default: "", description: "Sets a custom build path"),
-        Flag("hideVersionHeader", description: "Do not include Sourcery version in the generated files headers.")
-    ) { disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, cacheBasePath, buildPath, hideVersionHeader in
+        Flag("hideVersionHeader", description: "Do not include Sourcery version in the generated files headers."),
+        Option<String?>("headerPrefix", default: nil, description: "Additional prefix for headers.")
+    ) { disableCache, verboseLogging, logAST, logBenchmark, parseDocumentation, quiet, prune, serialParse, sources, excludeSources, templates, excludeTemplates, output, isDryRun, configPaths, forceParse, baseIndentation, args, cacheBasePath, buildPath, hideVersionHeader, headerPrefix in
         do {
             let logConfiguration = Log.Configuration(
                 isDryRun: isDryRun,
@@ -384,7 +387,8 @@ func runCLI() {
                                         prune: prune,
                                         serialParse: serialParse,
                                         hideVersionHeader: hideVersionHeader,
-                                        arguments: configuration.args)
+                                        arguments: configuration.args,
+                                        headerPrefix: headerPrefix)
 
                 return try sourcery.processFiles(
                     configuration.source,

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -167,6 +167,26 @@ class SourcerySpecTests: QuickSpec {
                         }
                     }
 
+                    context("with custom header prefix") {
+                        beforeEach {
+                            expect { try Sourcery(watcherEnabled: false, cacheDisabled: true, hideVersionHeader: true, headerPrefix: "// swiftlint:disable all").processFiles(.sources(Paths(include: [sourcePath])), usingTemplates: Paths(include: [templatePath]), output: output, baseIndentation: 0) }.toNot(throwError())
+                        }
+                        it("removes version information from within generated template") {
+                        let expectedResult = """
+                            // swiftlint:disable all
+                            // Generated using Sourcery — https://github.com/krzysztofzablocki/Sourcery
+                            // DO NOT EDIT
+
+                            // Line One
+                            """
+
+                        let generatedPath = outputDir + Sourcery().generatedPath(for: templatePath)
+
+                        let result = try? generatedPath.read(.utf8)
+                        expect(result?.withoutWhitespaces).to(equal(expectedResult.withoutWhitespaces))
+                        }
+                    }
+
                     it("does not remove code from within generated template when missing origin") {
                         update(code: """
                             class Foo {


### PR DESCRIPTION
This PR adds ability to add additional prefix before header in generated files

**Problem**

If you use SwiftLint rule "file_name", then you will catch "File Name Violation" errors/warnings for each generated file. Even if you have "swiftlint:disable all" after header.

Also we have swiftlint rule for file header pattern "file_header" which also throws a warning :(

<img width="993" alt="Screenshot 2024-11-22 at 17 46 51" src="https://github.com/user-attachments/assets/a88c826a-9950-45b3-ae26-c7174211f07c">

**Solution**

I found a similar problem in the SwiftLint repo - https://github.com/realm/SwiftLint/issues/2277. Users suggest to add this line at the beginning of the file (at 0 line) `// swiftlint:disable:this file_name`.

But at the moment this line contains header comment `// Generated using Sourcery ...`. And I thought that if we be able to add additional custom prefix before the header with the following line `// swiftlint:disable:this file_name`, then we could solve this problem.
