### PR TITLE
Feature/typed throws support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -258,7 +258,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/kylef/PathKit.git", exact: "1.0.1"),
     .package(url: "https://github.com/art-divin/StencilSwiftKit.git", exact: "2.10.4"),
     .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.24.6"),
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "3.0.0"),
     .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
     .package(url: "https://github.com/art-divin/swift-package-manager.git", exact: "1.0.8"),

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
@@ -158,7 +158,7 @@ extension SourceryMethod {
           parameters: signature.input,
           returnTypeName: returnTypeName,
           isAsync: signature.asyncKeyword == "async",
-          throws: signature.throwsOrRethrowsKeyword == "throws",
+          throws: signature.throwsOrRethrowsKeyword == "throws" && !(signature.throwsTypeName?.isNever ?? false),
           throwsTypeName: signature.throwsOrRethrowsKeyword == "throws" ? signature.throwsTypeName : nil,
           rethrows: signature.throwsOrRethrowsKeyword == "rethrows",
           accessLevel: baseModifiers.readAccess,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
@@ -30,6 +30,7 @@ extension SourceryMethod {
             output: nil,
             asyncKeyword: nil,
             throwsOrRethrowsKeyword: signature.effectSpecifiers?.throwsClause?.throwsSpecifier.description.trimmed,
+            throwsTypeName: signature.effectSpecifiers?.throwsClause?.type.map { TypeName($0) },
             annotationsParser: annotationsParser,
             parent: parent
           ),
@@ -47,7 +48,15 @@ extension SourceryMethod {
           parent: parent,
           identifier: "deinit",
           typeName: typeName,
-          signature: Signature(parameters: nil, output: nil, asyncKeyword: nil, throwsOrRethrowsKeyword: nil, annotationsParser: annotationsParser, parent: parent),
+          signature: Signature(
+            parameters: nil,
+            output: nil,
+            asyncKeyword: nil,
+            throwsOrRethrowsKeyword: nil,
+            throwsTypeName: nil,
+            annotationsParser: annotationsParser,
+            parent: parent
+          ),
           modifiers: node.modifiers,
           attributes: node.attributes,
           genericParameterClause: nil,
@@ -150,6 +159,7 @@ extension SourceryMethod {
           returnTypeName: returnTypeName,
           isAsync: signature.asyncKeyword == "async",
           throws: signature.throwsOrRethrowsKeyword == "throws",
+          throwsTypeName: signature.throwsOrRethrowsKeyword == "throws" ? signature.throwsTypeName : nil,
           rethrows: signature.throwsOrRethrowsKeyword == "rethrows",
           accessLevel: baseModifiers.readAccess,
           isStatic: initializerNode != nil ? true : baseModifiers.isStatic,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Method+SwiftSyntax.swift
@@ -29,7 +29,7 @@ extension SourceryMethod {
             parameters: signature.parameterClause.parameters,
             output: nil,
             asyncKeyword: nil,
-            throwsOrRethrowsKeyword: signature.effectSpecifiers?.throwsSpecifier?.description.trimmed,
+            throwsOrRethrowsKeyword: signature.effectSpecifiers?.throwsClause?.throwsSpecifier.description.trimmed,
             annotationsParser: annotationsParser,
             parent: parent
           ),

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
@@ -32,7 +32,7 @@ public struct Signature {
         self.init(parameters: node.parameterClause.parameters,
                   output: returnTypeName,
                   asyncKeyword: node.effectSpecifiers?.asyncSpecifier?.text,
-                  throwsOrRethrowsKeyword: node.effectSpecifiers?.throwsSpecifier?.description.trimmed,
+                  throwsOrRethrowsKeyword: node.effectSpecifiers?.throwsClause?.throwsSpecifier.description.trimmed,
                   annotationsParser: annotationsParser,
                   parent: parent
         )

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Signature.swift
@@ -14,6 +14,9 @@ public struct Signature {
     /// The `throws` or `rethrows` keyword, if any.
     public let throwsOrRethrowsKeyword: String?
 
+    /// The ThrownError type in `throws(ThrownError)`
+    public let throwsTypeName: TypeName?
+
     public init(_ node: FunctionSignatureSyntax, annotationsParser: AnnotationsParser, parent: Type?) {
         let isVisitingTypeSourceryProtocol = parent is SourceryProtocol
 
@@ -33,6 +36,7 @@ public struct Signature {
                   output: returnTypeName,
                   asyncKeyword: node.effectSpecifiers?.asyncSpecifier?.text,
                   throwsOrRethrowsKeyword: node.effectSpecifiers?.throwsClause?.throwsSpecifier.description.trimmed,
+                  throwsTypeName: node.effectSpecifiers?.throwsClause?.type.map { TypeName($0) },
                   annotationsParser: annotationsParser,
                   parent: parent
         )
@@ -43,6 +47,7 @@ public struct Signature {
         output: TypeName?,
         asyncKeyword: String?,
         throwsOrRethrowsKeyword: String?,
+        throwsTypeName: TypeName?,
         annotationsParser: AnnotationsParser,
         parent: Type?
     ) {
@@ -56,6 +61,7 @@ public struct Signature {
         self.output = output
         self.asyncKeyword = asyncKeyword
         self.throwsOrRethrowsKeyword = throwsOrRethrowsKeyword
+        self.throwsTypeName = throwsTypeName
     }
 
     public func definition(with name: String) -> String {

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
@@ -31,7 +31,7 @@ extension Subscript {
               computeAccessors = Set(accessors.compactMap { accessor -> Kind? in
                   let kindRaw = accessor.accessorSpecifier.text.trimmed
                   if kindRaw == "get" {
-                    return Kind.get(isAsync: accessor.effectSpecifiers?.asyncSpecifier != nil, throws: accessor.effectSpecifiers?.throwsSpecifier != nil)
+                    return Kind.get(isAsync: accessor.effectSpecifiers?.asyncSpecifier != nil, throws: accessor.effectSpecifiers?.throwsClause?.throwsSpecifier != nil)
                   }
 
                   if kindRaw == "set" {

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Subscript+SwiftSyntax.swift
@@ -98,7 +98,7 @@ extension Subscript {
           returnTypeName: TypeName(node.returnClause.type),
           accessLevel: (read: readAccess, write: isWritable ? writeAccess : .none),
           isAsync: hadAsync,
-          throws: hadThrowable,
+          throws: hadThrowable && !(hadThrowsTypeName?.isNever ?? false),
           throwsTypeName: hadThrowsTypeName,
           genericParameters: genericParameters,
           genericRequirements: genericRequirements,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -154,7 +154,8 @@ extension TypeName {
             let returnTypeName = TypeName(typeIdentifier.returnClause.type)
             let asyncKeyword = typeIdentifier.effectSpecifiers?.asyncSpecifier.map { $0.text.trimmed }
             let throwsOrRethrows = typeIdentifier.effectSpecifiers?.throwsClause?.throwsSpecifier.text.trimmed
-            let name = "\(elements.asSource)\(asyncKeyword != nil ? " \(asyncKeyword!)" : "")\(throwsOrRethrows != nil ? " \(throwsOrRethrows!)" : "") -> \(returnTypeName.asSource)"
+            let throwsTypeName = typeIdentifier.effectSpecifiers?.throwsClause?.type.map { TypeName($0) }
+            let name = "\(elements.asSource)\(asyncKeyword != nil ? " \(asyncKeyword!)" : "")\(throwsOrRethrows != nil ? " \(throwsOrRethrows!)" : "")\(throwsTypeName != nil ? "(\(throwsTypeName!.asSource))": "") -> \(returnTypeName.asSource)"
             self.init(
                 name: name,
                 closure: ClosureType(
@@ -162,7 +163,8 @@ extension TypeName {
                     parameters: elements,
                     returnTypeName: returnTypeName,
                     asyncKeyword: asyncKeyword,
-                    throwsOrRethrowsKeyword: throwsOrRethrows)
+                    throwsOrRethrowsKeyword: throwsOrRethrows,
+                    throwsTypeName: throwsOrRethrows == "throws" ? throwsTypeName : nil)
             )
         } else if let typeIdentifier = node.as(AttributedTypeSyntax.self) {
             let type = TypeName(typeIdentifier.baseType) // TODO: add test for nested type with attributes at multiple level?

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -153,7 +153,7 @@ extension TypeName {
             }
             let returnTypeName = TypeName(typeIdentifier.returnClause.type)
             let asyncKeyword = typeIdentifier.effectSpecifiers?.asyncSpecifier.map { $0.text.trimmed }
-            let throwsOrRethrows = typeIdentifier.effectSpecifiers?.throwsSpecifier.map { $0.text.trimmed }
+            let throwsOrRethrows = typeIdentifier.effectSpecifiers?.throwsClause?.throwsSpecifier.text.trimmed
             let name = "\(elements.asSource)\(asyncKeyword != nil ? " \(asyncKeyword!)" : "")\(throwsOrRethrows != nil ? " \(throwsOrRethrows!)" : "") -> \(returnTypeName.asSource)"
             self.init(
                 name: name,

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Variable+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Variable+SwiftSyntax.swift
@@ -75,8 +75,8 @@ extension Variable {
         let isVisitingTypeSourceryProtocol = visitingType is SourceryProtocol
         let isComputed = node.initializer == nil && hadGetter && !isVisitingTypeSourceryProtocol
         let isAsync = hadAsync
-        let `throws` = hadThrowable
         let throwsTypeName = hadThrowsTypeName
+        let `throws` = hadThrowable && !(throwsTypeName?.isNever ?? false)
         let isWritable = variableNode.bindingSpecifier.tokens(viewMode: .fixedUp).contains { $0.tokenKind == .keyword(.var) } && (!isComputed || hadSetter)
 
         var typeName: TypeName? = node.typeAnnotation.map { TypeName($0.type) } ??

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Variable+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/Variable+SwiftSyntax.swift
@@ -35,7 +35,7 @@ extension Variable {
               computeAccessors = Set(accessors.compactMap { accessor -> Kind? in
                   let kindRaw = accessor.accessorSpecifier.text.trimmed
                   if kindRaw == "get" {
-                    return Kind.get(isAsync: accessor.effectSpecifiers?.asyncSpecifier != nil, throws: accessor.effectSpecifiers?.throwsSpecifier != nil)
+                      return Kind.get(isAsync: accessor.effectSpecifiers?.asyncSpecifier != nil, throws: accessor.effectSpecifiers?.throwsClause?.throwsSpecifier != nil)
                   }
 
                   if kindRaw == "set" {

--- a/SourceryRuntime/Sources/Generated/JSExport.generated.swift
+++ b/SourceryRuntime/Sources/Generated/JSExport.generated.swift
@@ -185,6 +185,7 @@ extension ClosureParameter: ClosureParameterAutoJSExport {}
     var asyncKeyword: String? { get }
     var `throws`: Bool { get }
     var throwsOrRethrowsKeyword: String? { get }
+    var throwsTypeName: TypeName? { get }
     var asSource: String { get }
 }
 
@@ -318,6 +319,7 @@ extension Import: ImportAutoJSExport {}
     var parameters: [MethodParameter] { get }
     var returnTypeName: TypeName { get }
     var actualReturnTypeName: TypeName { get }
+    var isThrowsTypeGeneric: Bool { get }
     var returnType: Type? { get }
     var isOptionalReturnType: Bool { get }
     var isImplicitlyUnwrappedOptionalReturnType: Bool { get }
@@ -325,6 +327,7 @@ extension Import: ImportAutoJSExport {}
     var isAsync: Bool { get }
     var isDistributed: Bool { get }
     var `throws`: Bool { get }
+    var throwsTypeName: TypeName? { get }
     var `rethrows`: Bool { get }
     var accessLevel: String { get }
     var isStatic: Bool { get }
@@ -555,6 +558,7 @@ extension Struct: StructAutoJSExport {}
     var writeAccess: String { get }
     var isAsync: Bool { get }
     var `throws`: Bool { get }
+    var throwsTypeName: TypeName? { get }
     var isMutable: Bool { get }
     var annotations: Annotations { get }
     var documentation: Documentation { get }
@@ -671,6 +675,7 @@ extension Type: TypeAutoJSExport {}
     var closure: ClosureType? { get }
     var isSet: Bool { get }
     var set: SetType? { get }
+    var isNever: Bool { get }
     var asSource: String { get }
     var description: String { get }
     var debugDescription: String { get }
@@ -710,6 +715,7 @@ extension TypesCollection: TypesCollectionAutoJSExport {}
     var isComputed: Bool { get }
     var isAsync: Bool { get }
     var `throws`: Bool { get }
+    var throwsTypeName: TypeName? { get }
     var isStatic: Bool { get }
     var readAccess: String { get }
     var writeAccess: String { get }

--- a/SourceryRuntime/Sources/Linux/AST/Method_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Method_Linux.swift
@@ -80,6 +80,12 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     }
 
     // sourcery: skipEquality, skipDescription
+    /// Return if the throwsType is generic
+    public var isThrowsTypeGeneric: Bool {
+        return genericParameters.contains { $0.name == throwsTypeName?.name }
+    }
+
+    // sourcery: skipEquality, skipDescription
     /// Actual return value type, if known
     public var returnType: Type?
 

--- a/SourceryRuntime/Sources/Linux/AST/Method_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Method_Linux.swift
@@ -22,6 +22,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 return parameters
             case "throws":
                 return `throws`
+            case "throwsTypeName":
+                return throwsTypeName
             case "isInitializer":
                 return isInitializer
             case "accessLevel":
@@ -109,6 +111,9 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
 
     /// Whether method throws
     public let `throws`: Bool
+
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
 
     /// Whether method rethrows
     public let `rethrows`: Bool
@@ -236,6 +241,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 returnTypeName: TypeName = TypeName(name: "Void"),
                 isAsync: Bool = false,
                 throws: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 rethrows: Bool = false,
                 accessLevel: AccessLevel = .internal,
                 isStatic: Bool = false,
@@ -254,6 +260,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         self.returnTypeName = returnTypeName
         self.isAsync = isAsync
         self.throws = `throws`
+        self.throwsTypeName = throwsTypeName
         self.rethrows = `rethrows`
         self.accessLevel = accessLevel.rawValue
         self.isStatic = isStatic
@@ -278,6 +285,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string.append("returnTypeName = \(String(describing: self.returnTypeName)), ")
         string.append("isAsync = \(String(describing: self.isAsync)), ")
         string.append("`throws` = \(String(describing: self.`throws`)), ")
+        string.append("throwsTypeName = \(String(describing: self.throwsTypeName)), ")
         string.append("`rethrows` = \(String(describing: self.`rethrows`)), ")
         string.append("accessLevel = \(String(describing: self.accessLevel)), ")
         string.append("isStatic = \(String(describing: self.isStatic)), ")
@@ -305,6 +313,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "`rethrows`").trackDifference(actual: self.`rethrows`, expected: castObject.`rethrows`))
         results.append(contentsOf: DiffableResult(identifier: "accessLevel").trackDifference(actual: self.accessLevel, expected: castObject.accessLevel))
         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: castObject.isStatic))
@@ -330,6 +339,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         hasher.combine(self.returnTypeName)
         hasher.combine(self.isAsync)
         hasher.combine(self.`throws`)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.`rethrows`)
         hasher.combine(self.accessLevel)
         hasher.combine(self.isStatic)
@@ -355,6 +365,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         if self.isAsync != rhs.isAsync { return false }
         if self.isDistributed != rhs.isDistributed { return false }
         if self.`throws` != rhs.`throws` { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.`rethrows` != rhs.`rethrows` { return false }
         if self.accessLevel != rhs.accessLevel { return false }
         if self.isStatic != rhs.isStatic { return false }
@@ -401,6 +412,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             self.returnType = aDecoder.decode(forKey: "returnType")
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
             self.`rethrows` = aDecoder.decode(forKey: "`rethrows`")
             guard let accessLevel: String = aDecoder.decode(forKey: "accessLevel") else { 
                 withVaList(["accessLevel"]) { arguments in
@@ -460,6 +472,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             aCoder.encode(self.returnType, forKey: "returnType")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.`rethrows`, forKey: "`rethrows`")
             aCoder.encode(self.accessLevel, forKey: "accessLevel")
             aCoder.encode(self.isStatic, forKey: "isStatic")

--- a/SourceryRuntime/Sources/Linux/AST/Method_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Method_Linux.swift
@@ -40,6 +40,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 return isOptionalReturnType
             case "actualReturnTypeName":
                 return actualReturnTypeName
+            case "isThrowsTypeGeneric":
+                return isThrowsTypeGeneric
             case "isDynamic":
                 return isDynamic
             case "genericRequirements":

--- a/SourceryRuntime/Sources/Linux/AST/Subscript_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Subscript_Linux.swift
@@ -30,6 +30,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
                 return isAsync
             case "throws":
                 return `throws`
+            case "throwsTypeName":
+                return throwsTypeName
             case "isMutable":
                 return isMutable
             case "annotations":
@@ -106,6 +108,9 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     /// Whether subscript throws
     public let `throws`: Bool
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// Whether variable is mutable or not
     public var isMutable: Bool {
         return writeAccess != AccessLevel.none.rawValue
@@ -158,6 +163,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
                 accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
                 isAsync: Bool = false,
                 `throws`: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 genericParameters: [GenericParameter] = [],
                 genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
@@ -172,6 +178,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         self.writeAccess = accessLevel.write.rawValue
         self.isAsync = isAsync
         self.throws = `throws`
+        self.throwsTypeName = throwsTypeName
         self.genericParameters = genericParameters
         self.genericRequirements = genericRequirements
         self.attributes = attributes
@@ -193,6 +200,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         string.append("writeAccess = \(String(describing: self.writeAccess)), ")
         string.append("isAsync = \(String(describing: self.isAsync)), ")
         string.append("`throws` = \(String(describing: self.throws)), ")
+        string.append("throwsTypeName = \(String(describing: self.throwsTypeName)), ")
         string.append("isMutable = \(String(describing: self.isMutable)), ")
         string.append("annotations = \(String(describing: self.annotations)), ")
         string.append("documentation = \(String(describing: self.documentation)), ")
@@ -218,6 +226,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.throws, expected: castObject.throws))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "documentation").trackDifference(actual: self.documentation, expected: castObject.documentation))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
@@ -238,6 +247,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         hasher.combine(self.writeAccess)
         hasher.combine(self.isAsync)
         hasher.combine(self.throws)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.annotations)
         hasher.combine(self.documentation)
         hasher.combine(self.definedInTypeName)
@@ -257,6 +267,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         if self.writeAccess != rhs.writeAccess { return false }
         if self.isAsync != rhs.isAsync { return false }
         if self.throws != rhs.throws { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.annotations != rhs.annotations { return false }
         if self.documentation != rhs.documentation { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
@@ -298,7 +309,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
              }; self.writeAccess = writeAccess
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
-            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
+            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else {
                 withVaList(["annotations"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
@@ -347,6 +359,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.definedInTypeName, forKey: "definedInTypeName")

--- a/SourceryRuntime/Sources/Linux/AST/TypeName/Closure_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/TypeName/Closure_Linux.swift
@@ -95,7 +95,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
         self.asyncKeyword = asyncKeyword
         self.isAsync = asyncKeyword != nil
         self.throwsOrRethrowsKeyword = throwsOrRethrowsKeyword
-        self.`throws` = throwsOrRethrowsKeyword != nil
+        self.`throws` = throwsOrRethrowsKeyword != nil && !(throwsTypeName?.isNever ?? false)
         self.throwsTypeName = throwsTypeName
     }
 

--- a/SourceryRuntime/Sources/Linux/AST/TypeName/Closure_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/TypeName/Closure_Linux.swift
@@ -29,6 +29,8 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
                 return `throws`
             case "throwsOrRethrowsKeyword":
                 return throwsOrRethrowsKeyword
+            case "throwsTypeName":
+                return throwsTypeName
             default:
                 fatalError("unable to lookup: \(member) in \(self)")
         }
@@ -81,8 +83,11 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
     /// throws or rethrows keyword
     public let throwsOrRethrowsKeyword: String?
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// :nodoc:
-    public init(name: String, parameters: [ClosureParameter], returnTypeName: TypeName, returnType: Type? = nil, asyncKeyword: String? = nil, throwsOrRethrowsKeyword: String? = nil) {
+    public init(name: String, parameters: [ClosureParameter], returnTypeName: TypeName, returnType: Type? = nil, asyncKeyword: String? = nil, throwsOrRethrowsKeyword: String? = nil, throwsTypeName: TypeName? = nil) {
         self.name = name
         self.parameters = parameters
         self.returnTypeName = returnTypeName
@@ -91,10 +96,11 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
         self.isAsync = asyncKeyword != nil
         self.throwsOrRethrowsKeyword = throwsOrRethrowsKeyword
         self.`throws` = throwsOrRethrowsKeyword != nil
+        self.throwsTypeName = throwsTypeName
     }
 
     public var asSource: String {
-        "\(parameters.asSource)\(asyncKeyword != nil ? " \(asyncKeyword!)" : "")\(throwsOrRethrowsKeyword != nil ? " \(throwsOrRethrowsKeyword!)" : "") -> \(returnTypeName.asSource)"
+        "\(parameters.asSource)\(asyncKeyword != nil ? " \(asyncKeyword!)" : "")\(throwsOrRethrowsKeyword != nil ? " \(throwsOrRethrowsKeyword!)\(throwsTypeName != nil ? "(\(throwsTypeName!.asSource))" : "")" : "") -> \(returnTypeName.asSource)"
     }
 
     /// :nodoc:
@@ -109,6 +115,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
         string.append("asyncKeyword = \(String(describing: self.asyncKeyword)), ")
         string.append("`throws` = \(String(describing: self.`throws`)), ")
         string.append("throwsOrRethrowsKeyword = \(String(describing: self.throwsOrRethrowsKeyword)), ")
+        string.append("throwsTypeName = \(String(describing: self.throwsTypeName)), ")
         string.append("asSource = \(String(describing: self.asSource))")
         return string
     }
@@ -126,6 +133,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
         results.append(contentsOf: DiffableResult(identifier: "asyncKeyword").trackDifference(actual: self.asyncKeyword, expected: castObject.asyncKeyword))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
         results.append(contentsOf: DiffableResult(identifier: "throwsOrRethrowsKeyword").trackDifference(actual: self.throwsOrRethrowsKeyword, expected: castObject.throwsOrRethrowsKeyword))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         return results
     }
 
@@ -140,6 +148,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
         hasher.combine(self.asyncKeyword)
         hasher.combine(self.`throws`)
         hasher.combine(self.throwsOrRethrowsKeyword)
+        hasher.combine(self.throwsTypeName)
         return hasher.finalize()
     }
 
@@ -153,6 +162,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
         if self.asyncKeyword != rhs.asyncKeyword { return false }
         if self.`throws` != rhs.`throws` { return false }
         if self.throwsOrRethrowsKeyword != rhs.throwsOrRethrowsKeyword { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         return true
     }
 
@@ -183,6 +193,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
             self.asyncKeyword = aDecoder.decode(forKey: "asyncKeyword")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.throwsOrRethrowsKeyword = aDecoder.decode(forKey: "throwsOrRethrowsKeyword")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
         }
 
         /// :nodoc:
@@ -195,6 +206,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable, SourceryDynam
             aCoder.encode(self.asyncKeyword, forKey: "asyncKeyword")
             aCoder.encode(self.`throws`, forKey: "`throws`")
             aCoder.encode(self.throwsOrRethrowsKeyword, forKey: "throwsOrRethrowsKeyword")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
         }
 // sourcery:end
 

--- a/SourceryRuntime/Sources/Linux/AST/TypeName/TypeName_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/TypeName/TypeName_Linux.swift
@@ -162,6 +162,11 @@ public final class TypeName: NSObject, SourceryModelWithoutDescription, Lossless
     /// Set type data
     public var set: SetType?
 
+    /// Whether type is `Never`
+    public var isNever: Bool {
+        return name == "Never"
+    }
+
     /// Prints typename as it would appear on definition
     public var asSource: String {
         // TODO: TBR special treatment

--- a/SourceryRuntime/Sources/Linux/AST/TypeName/TypeName_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/TypeName/TypeName_Linux.swift
@@ -13,6 +13,8 @@ public final class TypeName: NSObject, SourceryModelWithoutDescription, Lossless
                 return tuple
             case "name":
                 return name
+            case "actualTypeName":
+                return actualTypeName
             case "isOptional":
                 return isOptional
             case "unwrappedTypeName":

--- a/SourceryRuntime/Sources/Linux/AST/Variable_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Variable_Linux.swift
@@ -32,6 +32,8 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             return isAsync
         case "throws":
             return `throws`
+        case "throwsTypeName":
+            return throwsTypeName
         case "isArray":
             return isArray
         case "isDictionary":
@@ -62,6 +64,9 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
     
     /// Whether variable throws
     public let `throws`: Bool
+
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
 
     /// Whether variable is static
     public let isStatic: Bool
@@ -135,6 +140,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
                 isComputed: Bool = false,
                 isAsync: Bool = false,
                 `throws`: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 isStatic: Bool = false,
                 defaultValue: String? = nil,
                 attributes: AttributeList = [:],
@@ -149,6 +155,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         self.isComputed = isComputed
         self.isAsync = isAsync
         self.`throws` = `throws`
+        self.throwsTypeName = throwsTypeName
         self.isStatic = isStatic
         self.defaultValue = defaultValue
         self.readAccess = accessLevel.read.rawValue
@@ -169,6 +176,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         string.append("isComputed = \(String(describing: self.isComputed)), ")
         string.append("isAsync = \(String(describing: self.isAsync)), ")
         string.append("`throws` = \(String(describing: self.`throws`)), ")
+        string.append("throwsTypeName = \(String(describing: self.throwsTypeName)), ")
         string.append("isStatic = \(String(describing: self.isStatic)), ")
         string.append("readAccess = \(String(describing: self.readAccess)), ")
         string.append("writeAccess = \(String(describing: self.writeAccess)), ")
@@ -198,6 +206,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         results.append(contentsOf: DiffableResult(identifier: "isComputed").trackDifference(actual: self.isComputed, expected: castObject.isComputed))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: castObject.isStatic))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
@@ -219,6 +228,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         hasher.combine(self.isComputed)
         hasher.combine(self.isAsync)
         hasher.combine(self.`throws`)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.isStatic)
         hasher.combine(self.readAccess)
         hasher.combine(self.writeAccess)
@@ -239,6 +249,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         if self.isComputed != rhs.isComputed { return false }
         if self.isAsync != rhs.isAsync { return false }
         if self.`throws` != rhs.`throws` { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.isStatic != rhs.isStatic { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
@@ -271,6 +282,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             self.isComputed = aDecoder.decode(forKey: "isComputed")
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
             self.isStatic = aDecoder.decode(forKey: "isStatic")
             guard let readAccess: String = aDecoder.decode(forKey: "readAccess") else { 
                 withVaList(["readAccess"]) { arguments in
@@ -321,6 +333,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             aCoder.encode(self.isComputed, forKey: "isComputed")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.isStatic, forKey: "isStatic")
             aCoder.encode(self.readAccess, forKey: "readAccess")
             aCoder.encode(self.writeAccess, forKey: "writeAccess")

--- a/SourceryRuntime/Sources/macOS/AST/Method.swift
+++ b/SourceryRuntime/Sources/macOS/AST/Method.swift
@@ -71,6 +71,9 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     /// Whether method throws
     public let `throws`: Bool
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// Whether method rethrows
     public let `rethrows`: Bool
 
@@ -197,6 +200,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 returnTypeName: TypeName = TypeName(name: "Void"),
                 isAsync: Bool = false,
                 throws: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 rethrows: Bool = false,
                 accessLevel: AccessLevel = .internal,
                 isStatic: Bool = false,
@@ -215,6 +219,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         self.returnTypeName = returnTypeName
         self.isAsync = isAsync
         self.throws = `throws`
+        self.throwsTypeName = throwsTypeName
         self.rethrows = `rethrows`
         self.accessLevel = accessLevel.rawValue
         self.isStatic = isStatic
@@ -239,6 +244,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string.append("returnTypeName = \(String(describing: self.returnTypeName)), ")
         string.append("isAsync = \(String(describing: self.isAsync)), ")
         string.append("`throws` = \(String(describing: self.`throws`)), ")
+        string.append("throwsTypeName = \(String(describing: self.throwsTypeName)), ")
         string.append("`rethrows` = \(String(describing: self.`rethrows`)), ")
         string.append("accessLevel = \(String(describing: self.accessLevel)), ")
         string.append("isStatic = \(String(describing: self.isStatic)), ")
@@ -266,6 +272,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "`rethrows`").trackDifference(actual: self.`rethrows`, expected: castObject.`rethrows`))
         results.append(contentsOf: DiffableResult(identifier: "accessLevel").trackDifference(actual: self.accessLevel, expected: castObject.accessLevel))
         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: castObject.isStatic))
@@ -291,6 +298,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         hasher.combine(self.returnTypeName)
         hasher.combine(self.isAsync)
         hasher.combine(self.`throws`)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.`rethrows`)
         hasher.combine(self.accessLevel)
         hasher.combine(self.isStatic)
@@ -316,6 +324,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         if self.isAsync != rhs.isAsync { return false }
         if self.isDistributed != rhs.isDistributed { return false }
         if self.`throws` != rhs.`throws` { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.`rethrows` != rhs.`rethrows` { return false }
         if self.accessLevel != rhs.accessLevel { return false }
         if self.isStatic != rhs.isStatic { return false }
@@ -362,6 +371,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             self.returnType = aDecoder.decode(forKey: "returnType")
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
             self.`rethrows` = aDecoder.decode(forKey: "`rethrows`")
             guard let accessLevel: String = aDecoder.decode(forKey: "accessLevel") else { 
                 withVaList(["accessLevel"]) { arguments in
@@ -421,6 +431,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             aCoder.encode(self.returnType, forKey: "returnType")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.`rethrows`, forKey: "`rethrows`")
             aCoder.encode(self.accessLevel, forKey: "accessLevel")
             aCoder.encode(self.isStatic, forKey: "isStatic")

--- a/SourceryRuntime/Sources/macOS/AST/Method.swift
+++ b/SourceryRuntime/Sources/macOS/AST/Method.swift
@@ -74,6 +74,12 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     /// Type of thrown error if specified
     public let throwsTypeName: TypeName?
 
+    // sourcery: skipEquality, skipDescription
+    /// Return if the throwsType is generic
+    public var isThrowsTypeGeneric: Bool {
+        return genericParameters.contains { $0.name == throwsTypeName?.name }
+    }
+
     /// Whether method rethrows
     public let `rethrows`: Bool
 

--- a/SourceryRuntime/Sources/macOS/AST/Subscript.swift
+++ b/SourceryRuntime/Sources/macOS/AST/Subscript.swift
@@ -56,6 +56,9 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     /// Whether subscript throws
     public let `throws`: Bool
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// Whether variable is mutable or not
     public var isMutable: Bool {
         return writeAccess != AccessLevel.none.rawValue
@@ -107,6 +110,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
                 accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
                 isAsync: Bool = false,
                 `throws`: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 genericParameters: [GenericParameter] = [],
                 genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
@@ -121,6 +125,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         self.writeAccess = accessLevel.write.rawValue
         self.isAsync = isAsync
         self.throws = `throws`
+        self.throwsTypeName = throwsTypeName
         self.genericParameters = genericParameters
         self.genericRequirements = genericRequirements
         self.attributes = attributes
@@ -142,6 +147,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         string.append("writeAccess = \(String(describing: self.writeAccess)), ")
         string.append("isAsync = \(String(describing: self.isAsync)), ")
         string.append("`throws` = \(String(describing: self.throws)), ")
+        string.append("throwsTypeName = \(String(describing: self.throwsTypeName)), ")
         string.append("isMutable = \(String(describing: self.isMutable)), ")
         string.append("annotations = \(String(describing: self.annotations)), ")
         string.append("documentation = \(String(describing: self.documentation)), ")
@@ -167,6 +173,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.throws, expected: castObject.throws))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "documentation").trackDifference(actual: self.documentation, expected: castObject.documentation))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
@@ -187,6 +194,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         hasher.combine(self.writeAccess)
         hasher.combine(self.isAsync)
         hasher.combine(self.throws)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.annotations)
         hasher.combine(self.documentation)
         hasher.combine(self.definedInTypeName)
@@ -206,6 +214,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         if self.writeAccess != rhs.writeAccess { return false }
         if self.isAsync != rhs.isAsync { return false }
         if self.throws != rhs.throws { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.annotations != rhs.annotations { return false }
         if self.documentation != rhs.documentation { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
@@ -247,7 +256,8 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
              }; self.writeAccess = writeAccess
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
-            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
+            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else {
                 withVaList(["annotations"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }
@@ -296,6 +306,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.definedInTypeName, forKey: "definedInTypeName")

--- a/SourceryRuntime/Sources/macOS/AST/TypeName/Closure.swift
+++ b/SourceryRuntime/Sources/macOS/AST/TypeName/Closure.swift
@@ -53,8 +53,11 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
     /// throws or rethrows keyword
     public let throwsOrRethrowsKeyword: String?
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// :nodoc:
-    public init(name: String, parameters: [ClosureParameter], returnTypeName: TypeName, returnType: Type? = nil, asyncKeyword: String? = nil, throwsOrRethrowsKeyword: String? = nil) {
+    public init(name: String, parameters: [ClosureParameter], returnTypeName: TypeName, returnType: Type? = nil, asyncKeyword: String? = nil, throwsOrRethrowsKeyword: String? = nil, throwsTypeName: TypeName? = nil) {
         self.name = name
         self.parameters = parameters
         self.returnTypeName = returnTypeName
@@ -63,6 +66,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         self.isAsync = asyncKeyword != nil
         self.throwsOrRethrowsKeyword = throwsOrRethrowsKeyword
         self.`throws` = throwsOrRethrowsKeyword != nil
+        self.throwsTypeName = throwsTypeName
     }
 
     public var asSource: String {
@@ -81,6 +85,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         string.append("asyncKeyword = \(String(describing: self.asyncKeyword)), ")
         string.append("`throws` = \(String(describing: self.`throws`)), ")
         string.append("throwsOrRethrowsKeyword = \(String(describing: self.throwsOrRethrowsKeyword)), ")
+        string.append("throwsTypeName = \(String(describing: self.throwsTypeName)), ")
         string.append("asSource = \(String(describing: self.asSource))")
         return string
     }
@@ -98,6 +103,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         results.append(contentsOf: DiffableResult(identifier: "asyncKeyword").trackDifference(actual: self.asyncKeyword, expected: castObject.asyncKeyword))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
         results.append(contentsOf: DiffableResult(identifier: "throwsOrRethrowsKeyword").trackDifference(actual: self.throwsOrRethrowsKeyword, expected: castObject.throwsOrRethrowsKeyword))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         return results
     }
 
@@ -112,6 +118,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         hasher.combine(self.asyncKeyword)
         hasher.combine(self.`throws`)
         hasher.combine(self.throwsOrRethrowsKeyword)
+        hasher.combine(self.throwsTypeName)
         return hasher.finalize()
     }
 
@@ -125,6 +132,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         if self.asyncKeyword != rhs.asyncKeyword { return false }
         if self.`throws` != rhs.`throws` { return false }
         if self.throwsOrRethrowsKeyword != rhs.throwsOrRethrowsKeyword { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         return true
     }
 
@@ -155,6 +163,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
             self.asyncKeyword = aDecoder.decode(forKey: "asyncKeyword")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.throwsOrRethrowsKeyword = aDecoder.decode(forKey: "throwsOrRethrowsKeyword")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
         }
 
         /// :nodoc:
@@ -167,6 +176,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
             aCoder.encode(self.asyncKeyword, forKey: "asyncKeyword")
             aCoder.encode(self.`throws`, forKey: "`throws`")
             aCoder.encode(self.throwsOrRethrowsKeyword, forKey: "throwsOrRethrowsKeyword")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
         }
 // sourcery:end
 

--- a/SourceryRuntime/Sources/macOS/AST/TypeName/Closure.swift
+++ b/SourceryRuntime/Sources/macOS/AST/TypeName/Closure.swift
@@ -65,7 +65,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         self.asyncKeyword = asyncKeyword
         self.isAsync = asyncKeyword != nil
         self.throwsOrRethrowsKeyword = throwsOrRethrowsKeyword
-        self.`throws` = throwsOrRethrowsKeyword != nil
+        self.`throws` = throwsOrRethrowsKeyword != nil && !(throwsTypeName?.isNever ?? false)
         self.throwsTypeName = throwsTypeName
     }
 

--- a/SourceryRuntime/Sources/macOS/AST/TypeName/TypeName.swift
+++ b/SourceryRuntime/Sources/macOS/AST/TypeName/TypeName.swift
@@ -138,6 +138,11 @@ public final class TypeName: NSObject, SourceryModelWithoutDescription, Lossless
     /// Set type data
     public var set: SetType?
 
+    /// Whether type is `Never`
+    public var isNever: Bool {
+        return name == "Never"
+    }
+
     /// Prints typename as it would appear on definition
     public var asSource: String {
         // TODO: TBR special treatment

--- a/SourceryRuntime/Sources/macOS/AST/Variable.swift
+++ b/SourceryRuntime/Sources/macOS/AST/Variable.swift
@@ -32,6 +32,9 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
     /// Whether variable throws
     public let `throws`: Bool
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// Whether variable is static
     public let isStatic: Bool
 
@@ -104,6 +107,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
                 isComputed: Bool = false,
                 isAsync: Bool = false,
                 `throws`: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 isStatic: Bool = false,
                 defaultValue: String? = nil,
                 attributes: AttributeList = [:],
@@ -118,6 +122,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         self.isComputed = isComputed
         self.isAsync = isAsync
         self.`throws` = `throws`
+        self.throwsTypeName = throwsTypeName
         self.isStatic = isStatic
         self.defaultValue = defaultValue
         self.readAccess = accessLevel.read.rawValue
@@ -138,6 +143,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         string.append("isComputed = \(String(describing: self.isComputed)), ")
         string.append("isAsync = \(String(describing: self.isAsync)), ")
         string.append("`throws` = \(String(describing: self.`throws`)), ")
+        string.append("throwsTypeName = \(String(describing: self.throwsTypeName)), ")
         string.append("isStatic = \(String(describing: self.isStatic)), ")
         string.append("readAccess = \(String(describing: self.readAccess)), ")
         string.append("writeAccess = \(String(describing: self.writeAccess)), ")
@@ -168,6 +174,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         results.append(contentsOf: DiffableResult(identifier: "isComputed").trackDifference(actual: self.isComputed, expected: castObject.isComputed))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: castObject.isStatic))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
@@ -189,6 +196,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         hasher.combine(self.isComputed)
         hasher.combine(self.isAsync)
         hasher.combine(self.`throws`)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.isStatic)
         hasher.combine(self.readAccess)
         hasher.combine(self.writeAccess)
@@ -209,6 +217,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         if self.isComputed != rhs.isComputed { return false }
         if self.isAsync != rhs.isAsync { return false }
         if self.`throws` != rhs.`throws` { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.isStatic != rhs.isStatic { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
@@ -241,6 +250,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             self.isComputed = aDecoder.decode(forKey: "isComputed")
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
             self.isStatic = aDecoder.decode(forKey: "isStatic")
             guard let readAccess: String = aDecoder.decode(forKey: "readAccess") else { 
                 withVaList(["readAccess"]) { arguments in
@@ -291,6 +301,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             aCoder.encode(self.isComputed, forKey: "isComputed")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.isStatic, forKey: "isStatic")
             aCoder.encode(self.readAccess, forKey: "readAccess")
             aCoder.encode(self.writeAccess, forKey: "writeAccess")

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -4045,8 +4045,11 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
     /// throws or rethrows keyword
     public let throwsOrRethrowsKeyword: String?
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// :nodoc:
-    public init(name: String, parameters: [ClosureParameter], returnTypeName: TypeName, returnType: Type? = nil, asyncKeyword: String? = nil, throwsOrRethrowsKeyword: String? = nil) {
+    public init(name: String, parameters: [ClosureParameter], returnTypeName: TypeName, returnType: Type? = nil, asyncKeyword: String? = nil, throwsOrRethrowsKeyword: String? = nil, throwsTypeName: TypeName? = nil) {
         self.name = name
         self.parameters = parameters
         self.returnTypeName = returnTypeName
@@ -4054,7 +4057,8 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         self.asyncKeyword = asyncKeyword
         self.isAsync = asyncKeyword != nil
         self.throwsOrRethrowsKeyword = throwsOrRethrowsKeyword
-        self.`throws` = throwsOrRethrowsKeyword != nil
+        self.`throws` = throwsOrRethrowsKeyword != nil && !(throwsTypeName?.isNever ?? false)
+        self.throwsTypeName = throwsTypeName
     }
 
     public var asSource: String {
@@ -4073,6 +4077,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         string.append("asyncKeyword = \\(String(describing: self.asyncKeyword)), ")
         string.append("`throws` = \\(String(describing: self.`throws`)), ")
         string.append("throwsOrRethrowsKeyword = \\(String(describing: self.throwsOrRethrowsKeyword)), ")
+        string.append("throwsTypeName = \\(String(describing: self.throwsTypeName)), ")
         string.append("asSource = \\(String(describing: self.asSource))")
         return string
     }
@@ -4090,6 +4095,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         results.append(contentsOf: DiffableResult(identifier: "asyncKeyword").trackDifference(actual: self.asyncKeyword, expected: castObject.asyncKeyword))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
         results.append(contentsOf: DiffableResult(identifier: "throwsOrRethrowsKeyword").trackDifference(actual: self.throwsOrRethrowsKeyword, expected: castObject.throwsOrRethrowsKeyword))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         return results
     }
 
@@ -4104,6 +4110,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         hasher.combine(self.asyncKeyword)
         hasher.combine(self.`throws`)
         hasher.combine(self.throwsOrRethrowsKeyword)
+        hasher.combine(self.throwsTypeName)
         return hasher.finalize()
     }
 
@@ -4117,6 +4124,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
         if self.asyncKeyword != rhs.asyncKeyword { return false }
         if self.`throws` != rhs.`throws` { return false }
         if self.throwsOrRethrowsKeyword != rhs.throwsOrRethrowsKeyword { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         return true
     }
 
@@ -4147,6 +4155,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
             self.asyncKeyword = aDecoder.decode(forKey: "asyncKeyword")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.throwsOrRethrowsKeyword = aDecoder.decode(forKey: "throwsOrRethrowsKeyword")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
         }
 
         /// :nodoc:
@@ -4159,6 +4168,7 @@ public final class ClosureType: NSObject, SourceryModel, Diffable {
             aCoder.encode(self.asyncKeyword, forKey: "asyncKeyword")
             aCoder.encode(self.`throws`, forKey: "`throws`")
             aCoder.encode(self.throwsOrRethrowsKeyword, forKey: "throwsOrRethrowsKeyword")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
         }
 // sourcery:end
 
@@ -5005,6 +5015,15 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
     /// Whether method throws
     public let `throws`: Bool
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
+    // sourcery: skipEquality, skipDescription
+    /// Return if the throwsType is generic
+    public var isThrowsTypeGeneric: Bool {
+        return genericParameters.contains { $0.name == throwsTypeName?.name }
+    }
+
     /// Whether method rethrows
     public let `rethrows`: Bool
 
@@ -5131,6 +5150,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 returnTypeName: TypeName = TypeName(name: "Void"),
                 isAsync: Bool = false,
                 throws: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 rethrows: Bool = false,
                 accessLevel: AccessLevel = .internal,
                 isStatic: Bool = false,
@@ -5149,6 +5169,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         self.returnTypeName = returnTypeName
         self.isAsync = isAsync
         self.throws = `throws`
+        self.throwsTypeName = throwsTypeName
         self.rethrows = `rethrows`
         self.accessLevel = accessLevel.rawValue
         self.isStatic = isStatic
@@ -5173,6 +5194,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         string.append("returnTypeName = \\(String(describing: self.returnTypeName)), ")
         string.append("isAsync = \\(String(describing: self.isAsync)), ")
         string.append("`throws` = \\(String(describing: self.`throws`)), ")
+        string.append("throwsTypeName = \\(String(describing: self.throwsTypeName)), ")
         string.append("`rethrows` = \\(String(describing: self.`rethrows`)), ")
         string.append("accessLevel = \\(String(describing: self.accessLevel)), ")
         string.append("isStatic = \\(String(describing: self.isStatic)), ")
@@ -5200,6 +5222,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         results.append(contentsOf: DiffableResult(identifier: "returnTypeName").trackDifference(actual: self.returnTypeName, expected: castObject.returnTypeName))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "`rethrows`").trackDifference(actual: self.`rethrows`, expected: castObject.`rethrows`))
         results.append(contentsOf: DiffableResult(identifier: "accessLevel").trackDifference(actual: self.accessLevel, expected: castObject.accessLevel))
         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: castObject.isStatic))
@@ -5225,6 +5248,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         hasher.combine(self.returnTypeName)
         hasher.combine(self.isAsync)
         hasher.combine(self.`throws`)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.`rethrows`)
         hasher.combine(self.accessLevel)
         hasher.combine(self.isStatic)
@@ -5250,6 +5274,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
         if self.isAsync != rhs.isAsync { return false }
         if self.isDistributed != rhs.isDistributed { return false }
         if self.`throws` != rhs.`throws` { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.`rethrows` != rhs.`rethrows` { return false }
         if self.accessLevel != rhs.accessLevel { return false }
         if self.isStatic != rhs.isStatic { return false }
@@ -5296,6 +5321,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             self.returnType = aDecoder.decode(forKey: "returnType")
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
             self.`rethrows` = aDecoder.decode(forKey: "`rethrows`")
             guard let accessLevel: String = aDecoder.decode(forKey: "accessLevel") else { 
                 withVaList(["accessLevel"]) { arguments in
@@ -5355,6 +5381,7 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
             aCoder.encode(self.returnType, forKey: "returnType")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.`rethrows`, forKey: "`rethrows`")
             aCoder.encode(self.accessLevel, forKey: "accessLevel")
             aCoder.encode(self.isStatic, forKey: "isStatic")
@@ -5633,6 +5660,9 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
     /// Whether subscript throws
     public let `throws`: Bool
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// Whether variable is mutable or not
     public var isMutable: Bool {
         return writeAccess != AccessLevel.none.rawValue
@@ -5684,6 +5714,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
                 accessLevel: (read: AccessLevel, write: AccessLevel) = (.internal, .internal),
                 isAsync: Bool = false,
                 `throws`: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 genericParameters: [GenericParameter] = [],
                 genericRequirements: [GenericRequirement] = [],
                 attributes: AttributeList = [:],
@@ -5698,6 +5729,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         self.writeAccess = accessLevel.write.rawValue
         self.isAsync = isAsync
         self.throws = `throws`
+        self.throwsTypeName = throwsTypeName
         self.genericParameters = genericParameters
         self.genericRequirements = genericRequirements
         self.attributes = attributes
@@ -5719,6 +5751,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         string.append("writeAccess = \\(String(describing: self.writeAccess)), ")
         string.append("isAsync = \\(String(describing: self.isAsync)), ")
         string.append("`throws` = \\(String(describing: self.throws)), ")
+        string.append("throwsTypeName = \\(String(describing: self.throwsTypeName)), ")
         string.append("isMutable = \\(String(describing: self.isMutable)), ")
         string.append("annotations = \\(String(describing: self.annotations)), ")
         string.append("documentation = \\(String(describing: self.documentation)), ")
@@ -5744,6 +5777,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.throws, expected: castObject.throws))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "annotations").trackDifference(actual: self.annotations, expected: castObject.annotations))
         results.append(contentsOf: DiffableResult(identifier: "documentation").trackDifference(actual: self.documentation, expected: castObject.documentation))
         results.append(contentsOf: DiffableResult(identifier: "definedInTypeName").trackDifference(actual: self.definedInTypeName, expected: castObject.definedInTypeName))
@@ -5764,6 +5798,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         hasher.combine(self.writeAccess)
         hasher.combine(self.isAsync)
         hasher.combine(self.throws)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.annotations)
         hasher.combine(self.documentation)
         hasher.combine(self.definedInTypeName)
@@ -5783,6 +5818,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
         if self.writeAccess != rhs.writeAccess { return false }
         if self.isAsync != rhs.isAsync { return false }
         if self.throws != rhs.throws { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.annotations != rhs.annotations { return false }
         if self.documentation != rhs.documentation { return false }
         if self.definedInTypeName != rhs.definedInTypeName { return false }
@@ -5824,6 +5860,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
              }; self.writeAccess = writeAccess
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
             guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
                 withVaList(["annotations"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
@@ -5873,6 +5910,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.annotations, forKey: "annotations")
             aCoder.encode(self.documentation, forKey: "documentation")
             aCoder.encode(self.definedInTypeName, forKey: "definedInTypeName")
@@ -6979,6 +7017,11 @@ public final class TypeName: NSObject, SourceryModelWithoutDescription, Lossless
     /// Set type data
     public var set: SetType?
 
+    /// Whether type is `Never`
+    public var isNever: Bool {
+        return name == "Never"
+    }
+
     /// Prints typename as it would appear on definition
     public var asSource: String {
         // TODO: TBR special treatment
@@ -7465,6 +7508,9 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
     /// Whether variable throws
     public let `throws`: Bool
 
+    /// Type of thrown error if specified
+    public let throwsTypeName: TypeName?
+
     /// Whether variable is static
     public let isStatic: Bool
 
@@ -7537,6 +7583,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
                 isComputed: Bool = false,
                 isAsync: Bool = false,
                 `throws`: Bool = false,
+                throwsTypeName: TypeName? = nil,
                 isStatic: Bool = false,
                 defaultValue: String? = nil,
                 attributes: AttributeList = [:],
@@ -7551,6 +7598,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         self.isComputed = isComputed
         self.isAsync = isAsync
         self.`throws` = `throws`
+        self.throwsTypeName = throwsTypeName
         self.isStatic = isStatic
         self.defaultValue = defaultValue
         self.readAccess = accessLevel.read.rawValue
@@ -7571,6 +7619,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         string.append("isComputed = \\(String(describing: self.isComputed)), ")
         string.append("isAsync = \\(String(describing: self.isAsync)), ")
         string.append("`throws` = \\(String(describing: self.`throws`)), ")
+        string.append("throwsTypeName = \\(String(describing: self.throwsTypeName)), ")
         string.append("isStatic = \\(String(describing: self.isStatic)), ")
         string.append("readAccess = \\(String(describing: self.readAccess)), ")
         string.append("writeAccess = \\(String(describing: self.writeAccess)), ")
@@ -7601,6 +7650,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         results.append(contentsOf: DiffableResult(identifier: "isComputed").trackDifference(actual: self.isComputed, expected: castObject.isComputed))
         results.append(contentsOf: DiffableResult(identifier: "isAsync").trackDifference(actual: self.isAsync, expected: castObject.isAsync))
         results.append(contentsOf: DiffableResult(identifier: "`throws`").trackDifference(actual: self.`throws`, expected: castObject.`throws`))
+        results.append(contentsOf: DiffableResult(identifier: "throwsTypeName").trackDifference(actual: self.throwsTypeName, expected: castObject.throwsTypeName))
         results.append(contentsOf: DiffableResult(identifier: "isStatic").trackDifference(actual: self.isStatic, expected: castObject.isStatic))
         results.append(contentsOf: DiffableResult(identifier: "readAccess").trackDifference(actual: self.readAccess, expected: castObject.readAccess))
         results.append(contentsOf: DiffableResult(identifier: "writeAccess").trackDifference(actual: self.writeAccess, expected: castObject.writeAccess))
@@ -7622,6 +7672,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         hasher.combine(self.isComputed)
         hasher.combine(self.isAsync)
         hasher.combine(self.`throws`)
+        hasher.combine(self.throwsTypeName)
         hasher.combine(self.isStatic)
         hasher.combine(self.readAccess)
         hasher.combine(self.writeAccess)
@@ -7642,6 +7693,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
         if self.isComputed != rhs.isComputed { return false }
         if self.isAsync != rhs.isAsync { return false }
         if self.`throws` != rhs.`throws` { return false }
+        if self.throwsTypeName != rhs.throwsTypeName { return false }
         if self.isStatic != rhs.isStatic { return false }
         if self.readAccess != rhs.readAccess { return false }
         if self.writeAccess != rhs.writeAccess { return false }
@@ -7674,6 +7726,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             self.isComputed = aDecoder.decode(forKey: "isComputed")
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
+            self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
             self.isStatic = aDecoder.decode(forKey: "isStatic")
             guard let readAccess: String = aDecoder.decode(forKey: "readAccess") else { 
                 withVaList(["readAccess"]) { arguments in
@@ -7724,6 +7777,7 @@ public final class Variable: NSObject, SourceryModel, Typed, Annotated, Document
             aCoder.encode(self.isComputed, forKey: "isComputed")
             aCoder.encode(self.isAsync, forKey: "isAsync")
             aCoder.encode(self.`throws`, forKey: "`throws`")
+            aCoder.encode(self.throwsTypeName, forKey: "throwsTypeName")
             aCoder.encode(self.isStatic, forKey: "isStatic")
             aCoder.encode(self.readAccess, forKey: "readAccess")
             aCoder.encode(self.writeAccess, forKey: "writeAccess")
@@ -8047,6 +8101,7 @@ extension ClosureParameter: ClosureParameterAutoJSExport {}
     var asyncKeyword: String? { get }
     var `throws`: Bool { get }
     var throwsOrRethrowsKeyword: String? { get }
+    var throwsTypeName: TypeName? { get }
     var asSource: String { get }
 }
 
@@ -8180,6 +8235,7 @@ extension Import: ImportAutoJSExport {}
     var parameters: [MethodParameter] { get }
     var returnTypeName: TypeName { get }
     var actualReturnTypeName: TypeName { get }
+    var isThrowsTypeGeneric: Bool { get }
     var returnType: Type? { get }
     var isOptionalReturnType: Bool { get }
     var isImplicitlyUnwrappedOptionalReturnType: Bool { get }
@@ -8187,6 +8243,7 @@ extension Import: ImportAutoJSExport {}
     var isAsync: Bool { get }
     var isDistributed: Bool { get }
     var `throws`: Bool { get }
+    var throwsTypeName: TypeName? { get }
     var `rethrows`: Bool { get }
     var accessLevel: String { get }
     var isStatic: Bool { get }
@@ -8417,6 +8474,7 @@ extension Struct: StructAutoJSExport {}
     var writeAccess: String { get }
     var isAsync: Bool { get }
     var `throws`: Bool { get }
+    var throwsTypeName: TypeName? { get }
     var isMutable: Bool { get }
     var annotations: Annotations { get }
     var documentation: Documentation { get }
@@ -8533,6 +8591,7 @@ extension Type: TypeAutoJSExport {}
     var closure: ClosureType? { get }
     var isSet: Bool { get }
     var set: SetType? { get }
+    var isNever: Bool { get }
     var asSource: String { get }
     var description: String { get }
     var debugDescription: String { get }
@@ -8572,6 +8631,7 @@ extension TypesCollection: TypesCollectionAutoJSExport {}
     var isComputed: Bool { get }
     var isAsync: Bool { get }
     var `throws`: Bool { get }
+    var throwsTypeName: TypeName? { get }
     var isStatic: Bool { get }
     var readAccess: String { get }
     var writeAccess: String { get }

--- a/SourceryTests/Models/MethodSpec.swift
+++ b/SourceryTests/Models/MethodSpec.swift
@@ -60,6 +60,12 @@ class MethodSpec: QuickSpec {
                 expect(Method(name: "foo()").isGeneric).to(beFalse())
             }
 
+            it("reports throws error generic type") {
+                expect(Method(name: "foo<E: Error>() throws(E)", throws: true, throwsTypeName: TypeName("E"), genericRequirements: [], genericParameters: [GenericParameter(name: "E", inheritedTypeName: TypeName("Error"))]).isThrowsTypeGeneric).to(beTrue())
+                expect(Method(name: "foo<E>() throws(E) where E: Error", throws: true, throwsTypeName: TypeName("E"), genericRequirements: [GenericRequirement(leftType: AssociatedType(name: "E", typeName: TypeName("E"), type: nil), rightType: GenericTypeParameter(typeName: TypeName("Error"), type: nil), relationship: .conformsTo)], genericParameters: [GenericParameter(name: "E")]).isThrowsTypeGeneric).to(beTrue())
+                expect(Method(name: "foo()").isThrowsTypeGeneric).to(beFalse())
+            }
+
             it("reports distributed method") {
                 expect(Method(name: "foo()", modifiers: [.init(name: "distributed")]).isDistributed).to(beTrue())
             }

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -980,6 +980,15 @@ class ParserComposerSpec: QuickSpec {
                         ))
                     }
 
+                    it("extracts typed throws return type") {
+                        let types = parse("struct Foo { var closure: () throws(CustomError) -> Int }")
+                        let variables = types.first?.variables
+
+                        expect(variables?[0].typeName.closure).to(equal(
+                            ClosureType(name: "() throws(CustomError) -> Int", parameters: [], returnTypeName: TypeName(name: "Int"), throwsOrRethrowsKeyword: "throws", throwsTypeName: TypeName("CustomError"))
+                        ))
+                    }
+
                     it("extracts void return type") {
                         let types = parse("struct Foo { var closure: () -> Void }")
                         let variables = types.first?.variables
@@ -999,13 +1008,13 @@ class ParserComposerSpec: QuickSpec {
                     }
 
                     it("extracts complex closure type") {
-                        let types = parse("struct Foo { var closure: () -> (Int) throws -> Int }")
+                        let types = parse("struct Foo { var closure: () -> (Int) throws(CustomError) -> Int }")
                         let variables = types.first?.variables
 
                         expect(variables?[0].typeName.closure).to(equal(
-                            ClosureType(name: "() -> (Int) throws -> Int", parameters: [], returnTypeName: TypeName(name: "(Int) throws -> Int", closure: ClosureType(name: "(Int) throws -> Int", parameters: [
+                            ClosureType(name: "() -> (Int) throws(CustomError) -> Int", parameters: [], returnTypeName: TypeName(name: "(Int) throws(CustomError) -> Int", closure: ClosureType(name: "(Int) throws(CustomError) -> Int", parameters: [
                                 ClosureParameter(typeName: TypeName(name: "Int"))
-                                ], returnTypeName: TypeName(name: "Int"), throwsOrRethrowsKeyword: "throws"
+                                ], returnTypeName: TypeName(name: "Int"), throwsOrRethrowsKeyword: "throws", throwsTypeName: TypeName("CustomError")
                             )))
                         ))
                     }

--- a/SourceryTests/Parsing/FileParser_MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_MethodsSpec.swift
@@ -107,7 +107,8 @@ class FileParserMethodsSpec: QuickSpec {
                                                     Foo
                         func fooBar() rethrows ; func fooVoid();
                         func fooAsync() async; func barAsync() async throws;
-                        func fooInOut(some: Int, anotherSome: inout String) }
+                        func fooInOut(some: Int, anotherSome: inout String)
+                        func fooTypedThrows() throws(CustomError); func fooTypedThrowsAsync() async throws(CustomError) }
                     """)[0].methods
                     expect(methods[0]).to(equal(Method(name: "init()", selectorName: "init", parameters: [], returnTypeName: TypeName(name: "Foo"), throws: true, isStatic: true, definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[1]).to(equal(Method(name: "bar(some: Int)", selectorName: "bar(some:)", parameters: [
@@ -122,6 +123,8 @@ class FileParserMethodsSpec: QuickSpec {
                         MethodParameter(name: "some", index: 0, typeName: TypeName(name: "Int")),
                         MethodParameter(name: "anotherSome", index: 1, typeName: TypeName(name: "inout String"), isInout: true)
                         ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))))
+                    expect(methods[8]).to(equal(Method(name: "fooTypedThrows()", selectorName: "fooTypedThrows", returnTypeName: TypeName(name: "Void"), throws: true, throwsTypeName: TypeName(name: "CustomError"), rethrows: false, definedInTypeName: TypeName(name: "Foo"))))
+                    expect(methods[9]).to(equal(Method(name: "fooTypedThrowsAsync()", selectorName: "fooTypedThrowsAsync", returnTypeName: TypeName(name: "Void"), isAsync: true, throws: true, throwsTypeName: TypeName(name: "CustomError"), rethrows: false, definedInTypeName: TypeName(name: "Foo"))))
                 }
 
                 it("extracts class method properly") {

--- a/SourceryTests/Parsing/FileParser_MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_MethodsSpec.swift
@@ -108,7 +108,9 @@ class FileParserMethodsSpec: QuickSpec {
                         func fooBar() rethrows ; func fooVoid();
                         func fooAsync() async; func barAsync() async throws;
                         func fooInOut(some: Int, anotherSome: inout String)
-                        func fooTypedThrows() throws(CustomError); func fooTypedThrowsAsync() async throws(CustomError) }
+                        func fooTypedThrows() throws(CustomError); func fooTypedThrowsAsync() async throws(CustomError) 
+                        func rethrowing<E>(block: () throws(E) -> Int) throws(E) -> Int where E: Error
+                    }
                     """)[0].methods
                     expect(methods[0]).to(equal(Method(name: "init()", selectorName: "init", parameters: [], returnTypeName: TypeName(name: "Foo"), throws: true, isStatic: true, definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[1]).to(equal(Method(name: "bar(some: Int)", selectorName: "bar(some:)", parameters: [
@@ -125,6 +127,16 @@ class FileParserMethodsSpec: QuickSpec {
                         ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[8]).to(equal(Method(name: "fooTypedThrows()", selectorName: "fooTypedThrows", returnTypeName: TypeName(name: "Void"), throws: true, throwsTypeName: TypeName(name: "CustomError"), rethrows: false, definedInTypeName: TypeName(name: "Foo"))))
                     expect(methods[9]).to(equal(Method(name: "fooTypedThrowsAsync()", selectorName: "fooTypedThrowsAsync", returnTypeName: TypeName(name: "Void"), isAsync: true, throws: true, throwsTypeName: TypeName(name: "CustomError"), rethrows: false, definedInTypeName: TypeName(name: "Foo"))))
+                    expect(methods[9].isThrowsTypeGeneric).to(beFalse())
+                    expect(methods[10]).to(equal(Method(name: "rethrowing<E>(block: () throws(E) -> Int)", selectorName: "rethrowing(block:)", parameters: [
+                        MethodParameter(name: "block", index: 0, typeName: TypeName(name: "() throws(E) -> Int", closure: ClosureType(name: "() throws(E) -> Int", parameters: [], returnTypeName: TypeName(name: "Int"), returnType: nil, asyncKeyword: nil, throwsOrRethrowsKeyword: "throws", throwsTypeName: TypeName(name: "E")))),
+                    ], returnTypeName: TypeName(name: "Int where E: Error"), isAsync: false, throws: true, throwsTypeName: TypeName(name: "E"), rethrows: false, definedInTypeName: TypeName(name: "Foo"), genericRequirements: [
+                        GenericRequirement.init(leftType: AssociatedType(name: "E", typeName: nil, type: nil), rightType: GenericTypeParameter(typeName: TypeName("Error"), type: nil), relationship: .conformsTo)
+                    ], genericParameters: [
+                        GenericParameter(name: "E", inheritedTypeName: TypeName("Error"))
+                    ])))
+                    expect(methods[10].isThrowsTypeGeneric).to(beTrue())
+
                 }
 
                 it("extracts class method properly") {

--- a/SourceryTests/Parsing/FileParser_SubscriptsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_SubscriptsSpec.swift
@@ -123,17 +123,29 @@ class FileParserSubscriptsSpec: QuickSpec {
                                            protocol Subscript: AnyObject {
                                              subscript(arg1: Int) -> Int? { get async }
                                              subscript(arg2: Int) -> Int? { get throws }
-                                             subscript(arg3: Int) -> Int? { get async throws }
+                                             subscript(arg3: Int) -> Int? { get throws(CustomError) }
+                                             subscript(arg4: Int) -> Int? { get async throws }
+                                             subscript(arg5: Int) -> Int? { get async throws(CustomError) }
                                            }
                                            """).first?.subscripts
 
                     expect(subscripts?[0].isAsync).to(beTrue())
                     expect(subscripts?[1].isAsync).to(beFalse())
-                    expect(subscripts?[2].isAsync).to(beTrue())
+                    expect(subscripts?[2].isAsync).to(beFalse())
+                    expect(subscripts?[3].isAsync).to(beTrue())
+                    expect(subscripts?[4].isAsync).to(beTrue())
 
                     expect(subscripts?[0].throws).to(beFalse())
                     expect(subscripts?[1].throws).to(beTrue())
                     expect(subscripts?[2].throws).to(beTrue())
+                    expect(subscripts?[3].throws).to(beTrue())
+                    expect(subscripts?[4].throws).to(beTrue())
+
+                    expect(subscripts?[0].throwsTypeName).to(beNil())
+                    expect(subscripts?[1].throwsTypeName).to(beNil())
+                    expect(subscripts?[2].throwsTypeName).to(equal(TypeName("CustomError")))
+                    expect(subscripts?[3].throwsTypeName).to(beNil())
+                    expect(subscripts?[4].throwsTypeName).to(equal(TypeName("CustomError")))
                 }
                 
                 it("extracts optional return type") {

--- a/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
+++ b/SourceryTests/Parsing/FileParser_TypeNameSpec.swift
@@ -213,6 +213,12 @@ class TypeNameSpec: QuickSpec {
                     expect(variableTypeName("(@MainActor @Sendable (Int) -> Void)!").name).to(equal("(@MainActor @Sendable (Int) -> Void)!"))
                 }
             }
+
+            context("given Never type") {
+                it("reports Never correctly") {
+                    expect(variableTypeName("Never").isNever).to(beTrue())
+                }
+            }
         }
     }
 }

--- a/SourceryTests/Parsing/FileParser_VariableSpec.swift
+++ b/SourceryTests/Parsing/FileParser_VariableSpec.swift
@@ -160,6 +160,8 @@ class FileParserVariableSpec: QuickSpec {
                     it("reports variable throwability") {
                         expect(variable("var name: String { get } ")?.throws).to(beFalse())
                         expect(variable("var name: String { get throws }")?.throws).to(beTrue())
+                        expect(variable("var name: String { get throws(CustomError) }")?.throws).to(beTrue())
+                        expect(variable("var name: String { get throws(CustomError) }")?.throwsTypeName).to(equal(TypeName("CustomError")))
                     }
                 }
 

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -71,6 +71,7 @@ import {{ import }}
 {% macro mockMethod method %}
     //MARK: - {{ method.shortName }}
 
+    {% if not method.isThrowsTypeGeneric %}
     {% if method.throws %}
         {% call methodThrowableErrorDeclaration method %}
     {% endif %}
@@ -96,6 +97,7 @@ import {{ import }}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName false %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
     {% endif %}
     {% call methodClosureDeclaration method %}
+    {% endif %}
 
 {% if method.isInitializer %}
     {% call accessLevel method.accessLevel %}required {{ method.name }} {
@@ -109,6 +111,9 @@ import {{ import }}
     {% endfor %}
     {% endfor %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' ' if method.throws }}{% call throwsSpecifier method %}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName false %}{% endif %} {
+        {% if method.isThrowsTypeGeneric %}
+        fatalError("Generic typed throws are not fully supported yet")
+        {% else %}
         {% call swiftifyMethodName method %}CallsCount += 1
         {% call methodReceivedParameters method %}
         {% if method.throws %}
@@ -122,6 +127,7 @@ import {{ import }}
         } else {
             return {% call swiftifyMethodName method %}ReturnValue
         }
+        {% endif %}
         {% endif %}
     }
 

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -28,7 +28,7 @@ import {{ import }}
 {% macro staticSpecifier method %}{% if method.isStatic and not method.isInitializer %}static {% endif %}{% endmacro %}
 
 {% macro methodThrowableErrorDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ThrowableError: (any Error)?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ThrowableError: {% if method.throwsTypeName %}({% call getTypeName method.throwsTypeName %})?{% else %}(any Error)?{% endif %}
 {% endmacro %}
 
 {% macro methodThrowableErrorUsage method %}
@@ -58,8 +58,12 @@ import {{ import }}
 
 {% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
 
+{% macro getTypeName type %}{% if type.actualTypeName %}{{ type.actualTypeName }}{% else %}{{ type.name }}{% endif %}{% endmacro -%}
+
+{% macro throwsSpecifier throwable %}{% if throwable.throws %}throws{% if throwable.throwsTypeName %}({% call getTypeName throwable.throwsTypeName %}){% endif %}{% endif %}{% endmacro -%}
+
 {% macro methodClosureDeclaration method %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic true %}{% if not forloop.last %}, {% elif param.typeName.isClosure and param.typeName.closure.returnTypeName.name|contains:"any " %}{% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName true %}{% endif %})?
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call existentialClosureVariableTypeName param.typeName param.isVariadic true %}{% if not forloop.last %}, {% elif param.typeName.isClosure and param.typeName.closure.returnTypeName.name|contains:"any " %}{% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% call throwsSpecifier method %}{{ ' ' if method.throws }}-> {% if method.isInitializer %}Void{% else %}{% call existentialVariableTypeName method.returnTypeName true %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ '&' if param.typeName.name | hasPrefix:"inout " }}{% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -104,7 +108,7 @@ import {{ import }}
     {{ value }}
     {% endfor %}
     {% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName false %}{% endif %} {
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}{% call methodName method %}{{ ' async' if method.isAsync }}{{ ' ' if method.throws }}{% call throwsSpecifier method %}{% if not method.returnTypeName.isVoid %} -> {% call existentialVariableTypeName method.returnTypeName false %}{% endif %} {
         {% call swiftifyMethodName method %}CallsCount += 1
         {% call methodReceivedParameters method %}
         {% if method.throws %}
@@ -127,7 +131,7 @@ import {{ import }}
 {% macro mockSubscript subscript index %}
     //MARK: - Subscript #{{ index }}
     {% call accessLevel subscript.readAccess %}subscript{% if subscript.isGeneric %}<{% for genericParameter in subscript.genericParameters %}{{ genericParameter.name }}{% if genericParameter.inheritedTypeName %}: {{ genericParameter.inheritedTypeName.name }}{% endif %}{{ ', ' if not forloop.last }}{% endfor %}>{% endif %}({% for parameter in subscript.parameters %}{{ parameter.asSource }}{{ ', ' if not forloop.last }}{% endfor %}) -> {{ subscript.returnTypeName.name }}{% if subscript.genericRequirements|count != 0 %} where {% for requirement in subscript.genericRequirements %}{{ requirement.leftType.name }} {{ requirement.relationshipSyntax }} {{ requirement.rightType.typeName.name }}{{ ', ' if not forloop.last }}{% endfor %}{% endif %} {
-        {% if subscript.readAccess %}get{% if subscript.isAsync %} async{% endif %}{% if subscript.throws %} throws{% endif %} { fatalError("Subscripts are not fully supported yet") }{% endif %}
+        {% if subscript.readAccess %}get{% if subscript.isAsync %} async{% endif %}{% if subscript.throws %} {% call throwsSpecifier subscript %}{% endif %} { fatalError("Subscripts are not fully supported yet") }{% endif %}
         {% if subscript.writeAccess %}set { fatalError("Subscripts are not fully supported yet") }{% endif %}
     }
 {% endmacro %}
@@ -172,7 +176,7 @@ import {{ import }}
 {% endmacro %}
 
 {% macro variableThrowableErrorDeclaration variable %}
-    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}ThrowableError: Error?
+    {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}ThrowableError: {% if variable.throwsTypeName %}({% call getTypeName variable.throwsTypeName %})?{% else %}Error?{% endif %}
 {% endmacro %}
 
 {% macro variableThrowableErrorUsage variable %}
@@ -182,7 +186,7 @@ import {{ import }}
 {% endmacro %}
 
 {% macro variableClosureDeclaration variable %}
-    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}-> {% call existentialVariableTypeName variable.typeName true %})?
+    {% call accessLevel variable.readAccess %}var {% call variableClosureName variable %}: (() {% if variable.isAsync %}async {% endif %}{% if variable.throws %}{% call throwsSpecifier variable %} {% endif %}-> {% call existentialVariableTypeName variable.typeName true %})?
 {% endmacro %}
 
 {% macro variableClosureName variable %}{% call mockedVariableName variable %}Closure{% endmacro %}
@@ -194,7 +198,7 @@ import {{ import }}
     }
 
     {% call accessLevel variable.readAccess %}var {% call mockedVariableName variable %}: {% call existentialVariableTypeName variable.typeName false %} {
-        get {% if variable.isAsync %}async {% endif %}{% if variable.throws %}throws {% endif %}{
+        get {% if variable.isAsync %}async {% endif %}{% if variable.throws %}{% call throwsSpecifier variable %} {% endif %}{
             {% call mockedVariableName variable %}CallsCount += 1
             {% if variable.throws %}
             {% call variableThrowableErrorUsage variable %}

--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -101,8 +101,12 @@ import {{ import }}
 
 {% if method.isInitializer %}
     {% call accessLevel method.accessLevel %}required {{ method.name }} {
+        {% if method.isThrowsTypeGeneric %}
+        fatalError("Generic typed throws in inits are not fully supported yet")
+        {% else %}
         {% call methodReceivedParameters method %}
         {% call methodClosureName method %}?({% call methodClosureCallParameters method %})
+        {% endif %}
     }
 {% else %}
     {% for name, attribute in method.attributes %}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -67,6 +67,7 @@ protocol TypedThrowableProtocol: AutoMockable {
     func doOrThrowVoid() throws(CustomErrorNameSpace.Error)
     func doOrThrowAnyError() throws(any Error)
     func doOrThrowNever() throws(Never)
+    func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error
 }
 
 struct CustomError: Error {}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -66,16 +66,17 @@ protocol TypedThrowableProtocol: AutoMockable {
     var valueAnyError: Int { get throws(any Error) }
     var valueThrowsNever: Int { get throws(Never) }
     func doOrThrow() throws(CustomError) -> String
-    func doOrThrowVoid() throws(CustomErrorNameSpace.Error)
+//    func doOrThrowVoid() throws(CustomErrorNameSpace.Error)
     func doOrThrowAnyError() throws(any Error)
     func doOrThrowNever() throws(Never)
     func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error
 }
 
 struct CustomError: Error {}
-enum CustomErrorNameSpace {
-    struct Error: Swift.Error {}
-}
+// Nested types does not work on Linux, but works on macOS so this cannot be used in this test
+//enum CustomErrorNameSpace {
+//    struct Error: Swift.Error {}
+//}
 
 protocol CurrencyPresenter: AutoMockable {
     func showSourceCurrency(_ currency: String)

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -62,9 +62,11 @@ protocol ThrowableProtocol: AutoMockable {
 protocol TypedThrowableProtocol: AutoMockable {
     var value: Int { get throws(CustomError) }
     var valueAnyError: Int { get throws(any Error) }
+    var valueThrowsNever: Int { get throws(Never) }
     func doOrThrow() throws(CustomError) -> String
     func doOrThrowVoid() throws(CustomErrorNameSpace.Error)
     func doOrThrowAnyError() throws(any Error)
+    func doOrThrowNever() throws(Never)
 }
 
 struct CustomError: Error {}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -59,6 +59,19 @@ protocol ThrowableProtocol: AutoMockable {
     func doOrThrowVoid() throws
 }
 
+protocol TypedThrowableProtocol: AutoMockable {
+    var value: Int { get throws(CustomError) }
+    var valueAnyError: Int { get throws(any Error) }
+    func doOrThrow() throws(CustomError) -> String
+    func doOrThrowVoid() throws(CustomErrorNameSpace.Error)
+    func doOrThrowAnyError() throws(any Error)
+}
+
+struct CustomError: Error {}
+enum CustomErrorNameSpace {
+    struct Error: Swift.Error {}
+}
+
 protocol CurrencyPresenter: AutoMockable {
     func showSourceCurrency(_ currency: String)
 }
@@ -270,6 +283,7 @@ protocol SubscriptProtocol {
     subscript<T>(arg: T) -> String { get async }
     subscript<T: Hashable>(arg: T) -> T? { get set }
     subscript<T>(arg: String) -> T? where T: Cancellable { get throws }
+    subscript<T>(arg2: String) -> T { get throws(CustomError) }
 }
 
 // sourcery: AutoMockable

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -60,6 +60,8 @@ protocol ThrowableProtocol: AutoMockable {
 }
 
 protocol TypedThrowableProtocol: AutoMockable {
+    init() throws(CustomError)
+    init<E>(init2: Void) throws(E) where E: Error
     var value: Int { get throws(CustomError) }
     var valueAnyError: Int { get throws(any Error) }
     var valueThrowsNever: Int { get throws(Never) }

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -66,16 +66,17 @@ protocol TypedThrowableProtocol: AutoMockable {
     var valueAnyError: Int { get throws(any Error) }
     var valueThrowsNever: Int { get throws(Never) }
     func doOrThrow() throws(CustomError) -> String
-    func doOrThrowVoid() throws(CustomErrorNameSpace.Error)
+    // func doOrThrowVoid() throws(CustomErrorNameSpace.Error)
     func doOrThrowAnyError() throws(any Error)
     func doOrThrowNever() throws(Never)
     func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error
 }
 
 struct CustomError: Error {}
-enum CustomErrorNameSpace {
-    struct Error: Swift.Error {}
-}
+// This seems to not be supported on linux, as it cause a crash when running sourcery
+// enum CustomErrorNameSpace {
+//     struct Error: Swift.Error {}
+// }
 
 protocol CurrencyPresenter: AutoMockable {
     func showSourceCurrency(_ currency: String)

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -73,7 +73,8 @@ protocol TypedThrowableProtocol: AutoMockable {
 }
 
 struct CustomError: Error {}
-// This seems to not be supported on linux, as it cause a crash when running sourcery
+// This seems to not be supported on linux, as it cause a crash when running Sourcery
+// because of the cycle in Type (with Type and Typealias), causing a crash during NSArchive decoding
 // enum CustomErrorNameSpace {
 //     struct Error: Swift.Error {}
 // }

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -59,6 +59,24 @@ protocol ThrowableProtocol: AutoMockable {
     func doOrThrowVoid() throws
 }
 
+protocol TypedThrowableProtocol: AutoMockable {
+    init() throws(CustomError)
+    init<E>(init2: Void) throws(E) where E: Error
+    var value: Int { get throws(CustomError) }
+    var valueAnyError: Int { get throws(any Error) }
+    var valueThrowsNever: Int { get throws(Never) }
+    func doOrThrow() throws(CustomError) -> String
+    func doOrThrowVoid() throws(CustomErrorNameSpace.Error)
+    func doOrThrowAnyError() throws(any Error)
+    func doOrThrowNever() throws(Never)
+    func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error
+}
+
+struct CustomError: Error {}
+enum CustomErrorNameSpace {
+    struct Error: Swift.Error {}
+}
+
 protocol CurrencyPresenter: AutoMockable {
     func showSourceCurrency(_ currency: String)
 }
@@ -270,6 +288,7 @@ protocol SubscriptProtocol {
     subscript<T>(arg: T) -> String { get async }
     subscript<T: Hashable>(arg: T) -> T? { get set }
     subscript<T>(arg: String) -> T? where T: Cancellable { get throws }
+    subscript<T>(arg2: String) -> T { get throws(CustomError) }
 }
 
 // sourcery: AutoMockable

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -2070,6 +2070,13 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
         doOrThrowNeverVoidClosure?()
     }
 
+    //MARK: - doOrRethrows<E>
+
+
+    func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error {
+        fatalError("Generic typed throws are not fully supported yet")
+    }
+
 
 }
 class VariablesProtocolMock: VariablesProtocol {

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -2001,6 +2001,20 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
     var underlyingValueThrowsNever: (Int)!
 
 
+    //MARK: - init
+
+    var initTypedThrowableProtocolThrowableError: (CustomError)?
+    var initTypedThrowableProtocolClosure: (() throws(CustomError) -> Void)?
+
+    required init() {
+        initTypedThrowableProtocolClosure?()
+    }
+    //MARK: - init<E>
+
+
+    required init<E>(init2: Void) {
+        fatalError("Generic typed throws in inits are not fully supported yet")
+    }
     //MARK: - doOrThrow
 
     var doOrThrowStringThrowableError: (CustomError)?

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.5 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -1746,6 +1746,10 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript<T>(arg: String) -> T? where T : Cancellable {
         get throws { fatalError("Subscripts are not fully supported yet") }
     }
+    //MARK: - Subscript #6
+    subscript<T>(arg2: String) -> T {
+        get throws(CustomError) { fatalError("Subscripts are not fully supported yet") }
+    }
 }
 class TestProtocolMock<
     Value: Sequence,
@@ -1942,6 +1946,111 @@ class ThrowingVariablesProtocolMock: ThrowingVariablesProtocol {
     var firstNameThrowableError: Error?
     var firstNameClosure: (() throws -> String)?
 
+
+
+}
+class TypedThrowableProtocolMock: TypedThrowableProtocol {
+
+
+    var valueCallsCount = 0
+    var valueCalled: Bool {
+        return valueCallsCount > 0
+    }
+
+    var value: Int {
+        get throws(CustomError) {
+            valueCallsCount += 1
+            if let error = valueThrowableError {
+                throw error
+            }
+            if let valueClosure = valueClosure {
+                return try valueClosure()
+            } else {
+                return underlyingValue
+            }
+        }
+    }
+    var underlyingValue: Int!
+    var valueThrowableError: (CustomError)?
+    var valueClosure: (() throws(CustomError) -> Int)?
+    var valueAnyErrorCallsCount = 0
+    var valueAnyErrorCalled: Bool {
+        return valueAnyErrorCallsCount > 0
+    }
+
+    var valueAnyError: Int {
+        get throws(any Error) {
+            valueAnyErrorCallsCount += 1
+            if let error = valueAnyErrorThrowableError {
+                throw error
+            }
+            if let valueAnyErrorClosure = valueAnyErrorClosure {
+                return try valueAnyErrorClosure()
+            } else {
+                return underlyingValueAnyError
+            }
+        }
+    }
+    var underlyingValueAnyError: Int!
+    var valueAnyErrorThrowableError: (any Error)?
+    var valueAnyErrorClosure: (() throws(any Error) -> Int)?
+
+
+    //MARK: - doOrThrow
+
+    var doOrThrowStringThrowableError: (CustomError)?
+    var doOrThrowStringCallsCount = 0
+    var doOrThrowStringCalled: Bool {
+        return doOrThrowStringCallsCount > 0
+    }
+    var doOrThrowStringReturnValue: String!
+    var doOrThrowStringClosure: (() throws(CustomError) -> String)?
+
+    func doOrThrow() throws(CustomError) -> String {
+        doOrThrowStringCallsCount += 1
+        if let error = doOrThrowStringThrowableError {
+            throw error
+        }
+        if let doOrThrowStringClosure = doOrThrowStringClosure {
+            return try doOrThrowStringClosure()
+        } else {
+            return doOrThrowStringReturnValue
+        }
+    }
+
+    //MARK: - doOrThrowVoid
+
+    var doOrThrowVoidVoidThrowableError: (CustomErrorNameSpace.Error)?
+    var doOrThrowVoidVoidCallsCount = 0
+    var doOrThrowVoidVoidCalled: Bool {
+        return doOrThrowVoidVoidCallsCount > 0
+    }
+    var doOrThrowVoidVoidClosure: (() throws(CustomErrorNameSpace.Error) -> Void)?
+
+    func doOrThrowVoid() throws(CustomErrorNameSpace.Error) {
+        doOrThrowVoidVoidCallsCount += 1
+        if let error = doOrThrowVoidVoidThrowableError {
+            throw error
+        }
+        try doOrThrowVoidVoidClosure?()
+    }
+
+    //MARK: - doOrThrowAnyError
+
+    var doOrThrowAnyErrorVoidThrowableError: (any Error)?
+    var doOrThrowAnyErrorVoidCallsCount = 0
+    var doOrThrowAnyErrorVoidCalled: Bool {
+        return doOrThrowAnyErrorVoidCallsCount > 0
+    }
+    var doOrThrowAnyErrorVoidClosure: (() throws(any Error) -> Void)?
+
+    func doOrThrowAnyError() throws(any Error) {
+        doOrThrowAnyErrorVoidCallsCount += 1
+        if let error = doOrThrowAnyErrorVoidThrowableError {
+            throw error
+        }
+        try doOrThrowAnyErrorVoidClosure?()
+    }
 
 
 }

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -2037,23 +2037,6 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
         }
     }
 
-    //MARK: - doOrThrowVoid
-
-    var doOrThrowVoidVoidThrowableError: (CustomErrorNameSpace.Error)?
-    var doOrThrowVoidVoidCallsCount = 0
-    var doOrThrowVoidVoidCalled: Bool {
-        return doOrThrowVoidVoidCallsCount > 0
-    }
-    var doOrThrowVoidVoidClosure: (() throws(CustomErrorNameSpace.Error) -> Void)?
-
-    func doOrThrowVoid() throws(CustomErrorNameSpace.Error) {
-        doOrThrowVoidVoidCallsCount += 1
-        if let error = doOrThrowVoidVoidThrowableError {
-            throw error
-        }
-        try doOrThrowVoidVoidClosure?()
-    }
-
     //MARK: - doOrThrowAnyError
 
     var doOrThrowAnyErrorVoidThrowableError: (any Error)?

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1994,6 +1994,11 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
     var underlyingValueAnyError: Int!
     var valueAnyErrorThrowableError: (any Error)?
     var valueAnyErrorClosure: (() throws(any Error) -> Int)?
+    var valueThrowsNever: Int {
+        get { return underlyingValueThrowsNever }
+        set(value) { underlyingValueThrowsNever = value }
+    }
+    var underlyingValueThrowsNever: (Int)!
 
 
     //MARK: - doOrThrow
@@ -2050,6 +2055,19 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
             throw error
         }
         try doOrThrowAnyErrorVoidClosure?()
+    }
+
+    //MARK: - doOrThrowNever
+
+    var doOrThrowNeverVoidCallsCount = 0
+    var doOrThrowNeverVoidCalled: Bool {
+        return doOrThrowNeverVoidCallsCount > 0
+    }
+    var doOrThrowNeverVoidClosure: (() -> Void)?
+
+    func doOrThrowNever() {
+        doOrThrowNeverVoidCallsCount += 1
+        doOrThrowNeverVoidClosure?()
     }
 
 

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -2070,6 +2070,13 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
         doOrThrowNeverVoidClosure?()
     }
 
+    //MARK: - doOrRethrows<E>
+
+
+    func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error {
+        fatalError("Generic typed throws are not fully supported yet")
+    }
+
 
 }
 class VariablesProtocolMock: VariablesProtocol {

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -2001,6 +2001,20 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
     var underlyingValueThrowsNever: (Int)!
 
 
+    //MARK: - init
+
+    var initTypedThrowableProtocolThrowableError: (CustomError)?
+    var initTypedThrowableProtocolClosure: (() throws(CustomError) -> Void)?
+
+    required init() {
+        initTypedThrowableProtocolClosure?()
+    }
+    //MARK: - init<E>
+
+
+    required init<E>(init2: Void) {
+        fatalError("Generic typed throws in inits are not fully supported yet")
+    }
     //MARK: - doOrThrow
 
     var doOrThrowStringThrowableError: (CustomError)?

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.5 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -1746,6 +1746,10 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript<T>(arg: String) -> T? where T : Cancellable {
         get throws { fatalError("Subscripts are not fully supported yet") }
     }
+    //MARK: - Subscript #6
+    subscript<T>(arg2: String) -> T {
+        get throws(CustomError) { fatalError("Subscripts are not fully supported yet") }
+    }
 }
 class TestProtocolMock<
     Value: Sequence,
@@ -1942,6 +1946,111 @@ class ThrowingVariablesProtocolMock: ThrowingVariablesProtocol {
     var firstNameThrowableError: Error?
     var firstNameClosure: (() throws -> String)?
 
+
+
+}
+class TypedThrowableProtocolMock: TypedThrowableProtocol {
+
+
+    var valueCallsCount = 0
+    var valueCalled: Bool {
+        return valueCallsCount > 0
+    }
+
+    var value: Int {
+        get throws(CustomError) {
+            valueCallsCount += 1
+            if let error = valueThrowableError {
+                throw error
+            }
+            if let valueClosure = valueClosure {
+                return try valueClosure()
+            } else {
+                return underlyingValue
+            }
+        }
+    }
+    var underlyingValue: Int!
+    var valueThrowableError: (CustomError)?
+    var valueClosure: (() throws(CustomError) -> Int)?
+    var valueAnyErrorCallsCount = 0
+    var valueAnyErrorCalled: Bool {
+        return valueAnyErrorCallsCount > 0
+    }
+
+    var valueAnyError: Int {
+        get throws(any Error) {
+            valueAnyErrorCallsCount += 1
+            if let error = valueAnyErrorThrowableError {
+                throw error
+            }
+            if let valueAnyErrorClosure = valueAnyErrorClosure {
+                return try valueAnyErrorClosure()
+            } else {
+                return underlyingValueAnyError
+            }
+        }
+    }
+    var underlyingValueAnyError: Int!
+    var valueAnyErrorThrowableError: (any Error)?
+    var valueAnyErrorClosure: (() throws(any Error) -> Int)?
+
+
+    //MARK: - doOrThrow
+
+    var doOrThrowStringThrowableError: (CustomError)?
+    var doOrThrowStringCallsCount = 0
+    var doOrThrowStringCalled: Bool {
+        return doOrThrowStringCallsCount > 0
+    }
+    var doOrThrowStringReturnValue: String!
+    var doOrThrowStringClosure: (() throws(CustomError) -> String)?
+
+    func doOrThrow() throws(CustomError) -> String {
+        doOrThrowStringCallsCount += 1
+        if let error = doOrThrowStringThrowableError {
+            throw error
+        }
+        if let doOrThrowStringClosure = doOrThrowStringClosure {
+            return try doOrThrowStringClosure()
+        } else {
+            return doOrThrowStringReturnValue
+        }
+    }
+
+    //MARK: - doOrThrowVoid
+
+    var doOrThrowVoidVoidThrowableError: (CustomErrorNameSpace.Error)?
+    var doOrThrowVoidVoidCallsCount = 0
+    var doOrThrowVoidVoidCalled: Bool {
+        return doOrThrowVoidVoidCallsCount > 0
+    }
+    var doOrThrowVoidVoidClosure: (() throws(CustomErrorNameSpace.Error) -> Void)?
+
+    func doOrThrowVoid() throws(CustomErrorNameSpace.Error) {
+        doOrThrowVoidVoidCallsCount += 1
+        if let error = doOrThrowVoidVoidThrowableError {
+            throw error
+        }
+        try doOrThrowVoidVoidClosure?()
+    }
+
+    //MARK: - doOrThrowAnyError
+
+    var doOrThrowAnyErrorVoidThrowableError: (any Error)?
+    var doOrThrowAnyErrorVoidCallsCount = 0
+    var doOrThrowAnyErrorVoidCalled: Bool {
+        return doOrThrowAnyErrorVoidCallsCount > 0
+    }
+    var doOrThrowAnyErrorVoidClosure: (() throws(any Error) -> Void)?
+
+    func doOrThrowAnyError() throws(any Error) {
+        doOrThrowAnyErrorVoidCallsCount += 1
+        if let error = doOrThrowAnyErrorVoidThrowableError {
+            throw error
+        }
+        try doOrThrowAnyErrorVoidClosure?()
+    }
 
 
 }

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -2037,23 +2037,6 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
         }
     }
 
-    //MARK: - doOrThrowVoid
-
-    var doOrThrowVoidVoidThrowableError: (CustomErrorNameSpace.Error)?
-    var doOrThrowVoidVoidCallsCount = 0
-    var doOrThrowVoidVoidCalled: Bool {
-        return doOrThrowVoidVoidCallsCount > 0
-    }
-    var doOrThrowVoidVoidClosure: (() throws(CustomErrorNameSpace.Error) -> Void)?
-
-    func doOrThrowVoid() throws(CustomErrorNameSpace.Error) {
-        doOrThrowVoidVoidCallsCount += 1
-        if let error = doOrThrowVoidVoidThrowableError {
-            throw error
-        }
-        try doOrThrowVoidVoidClosure?()
-    }
-
     //MARK: - doOrThrowAnyError
 
     var doOrThrowAnyErrorVoidThrowableError: (any Error)?

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1994,6 +1994,11 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
     var underlyingValueAnyError: Int!
     var valueAnyErrorThrowableError: (any Error)?
     var valueAnyErrorClosure: (() throws(any Error) -> Int)?
+    var valueThrowsNever: Int {
+        get { return underlyingValueThrowsNever }
+        set(value) { underlyingValueThrowsNever = value }
+    }
+    var underlyingValueThrowsNever: (Int)!
 
 
     //MARK: - doOrThrow
@@ -2050,6 +2055,19 @@ class TypedThrowableProtocolMock: TypedThrowableProtocol {
             throw error
         }
         try doOrThrowAnyErrorVoidClosure?()
+    }
+
+    //MARK: - doOrThrowNever
+
+    var doOrThrowNeverVoidCallsCount = 0
+    var doOrThrowNeverVoidCalled: Bool {
+        return doOrThrowNeverVoidCallsCount > 0
+    }
+    var doOrThrowNeverVoidClosure: (() -> Void)?
+
+    func doOrThrowNever() {
+        doOrThrowNeverVoidCallsCount += 1
+        doOrThrowNeverVoidClosure?()
     }
 
 


### PR DESCRIPTION
This PR solves #1371 by adding basic support for Typed Throws ([SE-0413](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md)) introduced with Swift 6 and usable without Swift 6 language mode.

Here a recap of what has been added to support typed throws:
- Updating swift-syntax to 600.0.1 (from 510.0.3) for the new syntax
- Adding `throwsTypeName` to `Method`, `Variable`, `Subscript` and `Closure` to expose the optional throws type
- Adding `isThrowsTypeGeneric` to `Method`, to tell if the thrown type error is a generic parameter
- Adding `isNever` on `TypeName` to facilitate the handling of `throws(Never)`
- Updating AutoMockable.stencil to add support for typed throws. Typed throws in subscript and generic constrained typed throws are not supported, but the generated mocks correctly conforms to the protocol

## Usage example

Protocol we want to mock
```swift
protocol AutoMockable {}
struct CustomError: Error {}

protocol TypedThrowableProtocol: AutoMockable {
    var value: Int { get throws(CustomError) }
    func doOrThrow() throws(CustomError) -> String
    func doOrThrowAnyError() throws(any Error)
    func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error
}
```

<details>
<summary>Generated code from AutoMockable</summary>

```swift
class TypedThrowableProtocolMock: TypedThrowableProtocol {


    var valueCallsCount = 0
    var valueCalled: Bool {
        return valueCallsCount > 0
    }

    var value: Int {
        get throws(CustomError) {
            valueCallsCount += 1
            if let error = valueThrowableError {
                throw error
            }
            if let valueClosure = valueClosure {
                return try valueClosure()
            } else {
                return underlyingValue
            }
        }
    }
    var underlyingValue: Int!
    var valueThrowableError: (CustomError)?
    var valueClosure: (() throws(CustomError) -> Int)?


    //MARK: - doOrThrow

    var doOrThrowStringThrowableError: (CustomError)?
    var doOrThrowStringCallsCount = 0
    var doOrThrowStringCalled: Bool {
        return doOrThrowStringCallsCount > 0
    }
    var doOrThrowStringReturnValue: String!
    var doOrThrowStringClosure: (() throws(CustomError) -> String)?

    func doOrThrow() throws(CustomError) -> String {
        doOrThrowStringCallsCount += 1
        if let error = doOrThrowStringThrowableError {
            throw error
        }
        if let doOrThrowStringClosure = doOrThrowStringClosure {
            return try doOrThrowStringClosure()
        } else {
            return doOrThrowStringReturnValue
        }
    }

    //MARK: - doOrThrowAnyError

    var doOrThrowAnyErrorVoidThrowableError: (any Error)?
    var doOrThrowAnyErrorVoidCallsCount = 0
    var doOrThrowAnyErrorVoidCalled: Bool {
        return doOrThrowAnyErrorVoidCallsCount > 0
    }
    var doOrThrowAnyErrorVoidClosure: (() throws(any Error) -> Void)?

    func doOrThrowAnyError() throws(any Error) {
        doOrThrowAnyErrorVoidCallsCount += 1
        if let error = doOrThrowAnyErrorVoidThrowableError {
            throw error
        }
        try doOrThrowAnyErrorVoidClosure?()
    }

    //MARK: - doOrRethrows<E>


    func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error {
        fatalError("Generic typed throws are not fully supported yet")
    }


}
```

</details>

Mock usage example:
```swift
let mock = TypedThrowableProtocolMock()
let sut = mock as TypedThrowableProtocol

// Typed Throws variable getter

print("Test value getter")
do {
    mock.underlyingValue = 42
    print(try sut.value)
    mock.valueThrowableError = CustomError()
    print(try sut.value)
} catch {
    print("Expected thrown error", error)
}
print("value call count", mock.valueCallsCount)

// Typed Throws method

print("Test method doOrThrows")

do {
    mock.doOrThrowStringThrowableError = CustomError()
    print(try sut.doOrThrow())
} catch {
    print("Expected thrown error", error)
}
mock.doOrThrowStringThrowableError = nil

mock.doOrThrowStringClosure = { () throws(CustomError) in
    return "String return value"
}
print(try! sut.doOrThrow())

do {
    mock.doOrThrowStringClosure = { () throws(CustomError) in
        throw CustomError()
    }
    print(try sut.doOrThrow())
} catch {
    print("Expected thrown error", error)
}

// Output:
// Test value getter
// 42
// Expected thrown error CustomError()
// value call count 2
// Test method doOrThrows
// Expected thrown error CustomError()
// String return value
// Expected thrown error CustomError()
```


## Limitations
1. Methods using generics to define thrown error, like `func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error` are not supported as handling those error types are not easy. Also The where clause was causing me an issue because it was included in the return type, this causing issues with generated variables used to control mock behavior.
2. Inits using generics to define thrown error, like `init<E>() throws(E) where E: Error`, for the same reason as Methods
3. Typed throws in subscript, because subscript are not supported right now in AutoMockable

Even if those limitation does not allow complete configuration of mocked methods, this makes possible the generation of a mock class that still allow compilation. Those limitations can be managed manually by subclassing the generated mock for now, and it should be possible to handle that in AutoMockable but right now it is too much work for me.

If in the future we want to support those generic types, an approach could be to attempt the generation of this code:

<details>
<summary>This is NOT what is proposed in this Pull Request, but may be useful for a future evolution</summary>

```swift
protocol TypedThrowableNotYetSupportedProtocol: AutoMockable {
    func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error
}

class TypedThrowableNotYetSupportedProtocolMock: TypedThrowableNotYetSupportedProtocol {

    //MARK: - doOrRethrows<E>

    var doOrRethrowsEBlockThrowsEVoidIntWhereEErrorThrowableError: (any Error)?
    var doOrRethrowsEBlockThrowsEVoidIntWhereEErrorCallsCount = 0
    var doOrRethrowsEBlockThrowsEVoidIntWhereEErrorCalled: Bool {
        return doOrRethrowsEBlockThrowsEVoidIntWhereEErrorCallsCount > 0
    }
    var doOrRethrowsEBlockThrowsEVoidIntWhereEErrorReturnValue: Int!
    var doOrRethrowsEBlockThrowsEVoidIntWhereEErrorClosure: ((() throws(any Error) -> Void) throws(any Error) -> Int)?

    func doOrRethrows<E>(_ block: () throws(E) -> Void) throws(E) -> Int where E: Error {
        doOrRethrowsEBlockThrowsEVoidIntWhereEErrorCallsCount += 1
        if let error = doOrRethrowsEBlockThrowsEVoidIntWhereEErrorThrowableError {
            throw error as! E
        }
        if let doOrRethrowsEBlockThrowsEVoidIntWhereEErrorClosure = doOrRethrowsEBlockThrowsEVoidIntWhereEErrorClosure {
            do {
            	return try doOrRethrowsEBlockThrowsEVoidIntWhereEErrorClosure(block)
        	} catch {
        		throw error as! E
        	}
        } else {
            return doOrRethrowsEBlockThrowsEVoidIntWhereEErrorReturnValue
        }
    }
}

let mockNotYetSupported = TypedThrowableNotYetSupportedProtocolMock()

mockNotYetSupported.doOrRethrowsEBlockThrowsEVoidIntWhereEErrorThrowableError = CustomError()
mockNotYetSupported.doOrRethrowsEBlockThrowsEVoidIntWhereEErrorClosure = { (block) throws(any Error) -> Int in
	throw CustomError()
}
do {
	_ = try mockNotYetSupported.doOrRethrows { () throws(CustomError) in
		throw CustomError()
	}
} catch {
	print("Expected throws", error)
}
```
</details>