### PR TITLE
Release 2.2.7 🚧 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Sourcery CHANGELOG
-## 2.2.6
+
+## 2.2.7
+* Feature/typed throws support by @alexandre-pod in https://github.com/krzysztofzablocki/Sourcery/pull/1401
+* Add missing `isGeneric` dynamic member by @tayloraswift in https://github.com/krzysztofzablocki/Sourcery/pull/1408
+
+## 2.2.6 
 * Method/Initializer parameter types now resolve to the local type if it exists by @liamnichols in https://github.com/krzysztofzablocki/Sourcery/pull/1347
 * Fixed wrong relative path in symbolic link by @pavel-trafimuk in https://github.com/krzysztofzablocki/Sourcery/pull/1350
 * chore: add unchecked Sendable conformance to AutoMockable by @nekrich in https://github.com/krzysztofzablocki/Sourcery/pull/1355

--- a/Sourcery.podspec
+++ b/Sourcery.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Sourcery"
-  s.version      = "2.2.6"
+  s.version      = "2.2.7"
   s.summary      = "A tool that brings meta-programming to Swift, allowing you to code generate Swift code."
   s.ios.deployment_target = '12'
   s.osx.deployment_target = '10.15'

--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -224,12 +224,12 @@ func runCLI() {
                     baseIndentation: configuration.baseIndentation
                 ) ?? []
             }
-            defer { keepAlive.removeAll() }
 
             if keepAlive.isEmpty {
                 Log.info(String(format: "Processing time %.2f seconds", currentTimestamp() - start))
             } else {
                 RunLoop.current.run()
+                _ = keepAlive
             }
         } catch {
             if isDryRun {

--- a/SourceryFramework.podspec
+++ b/SourceryFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SourceryFramework"
-  s.version      = "2.2.6"
+  s.version      = "2.2.7"
   s.summary      = "A tool that brings meta-programming to Swift, allowing you to code generate Swift code."
   s.platform     = :osx, '10.15'
 

--- a/SourceryRuntime.podspec
+++ b/SourceryRuntime.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SourceryRuntime"
-  s.version      = "2.2.6"
+  s.version      = "2.2.7"
   s.summary      = "A tool that brings meta-programming to Swift, allowing you to code generate Swift code."
   s.platform     = :osx, '10.15'
 

--- a/SourceryRuntime/Sources/Linux/AST/Subscript_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Subscript_Linux.swift
@@ -310,7 +310,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
-            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else {
+            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
                 withVaList(["annotations"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }

--- a/SourceryRuntime/Sources/macOS/AST/Subscript.swift
+++ b/SourceryRuntime/Sources/macOS/AST/Subscript.swift
@@ -257,7 +257,7 @@ public final class Subscript: NSObject, SourceryModel, Annotated, Documented, De
             self.isAsync = aDecoder.decode(forKey: "isAsync")
             self.`throws` = aDecoder.decode(forKey: "`throws`")
             self.throwsTypeName = aDecoder.decode(forKey: "throwsTypeName")
-            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else {
+            guard let annotations: Annotations = aDecoder.decode(forKey: "annotations") else { 
                 withVaList(["annotations"]) { arguments in
                     NSException.raise(NSExceptionName.parseErrorException, format: "Key '%@' not found.", arguments: arguments)
                 }

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -3891,6 +3891,20 @@ public final class AssociatedValue: NSObject, SourceryModel, AutoDescription, Ty
                 return defaultValue
             case "annotations":
                 return annotations
+            case "isArray":
+                return isArray
+            case "isClosure":
+                return isClosure
+            case "isDictionary":
+                return isDictionary
+            case "isTuple":
+                return isTuple
+            case "isOptional":
+                return isOptional
+            case "isImplicitlyUnwrappedOptional":
+                return isImplicitlyUnwrappedOptional
+            case "isGeneric":
+                return typeName.isGeneric
             default:
                 fatalError("unable to lookup: \\(member) in \\(self)")
         }
@@ -5381,6 +5395,8 @@ public final class Method: NSObject, SourceryModel, Annotated, Documented, Defin
                 return isOptionalReturnType
             case "actualReturnTypeName":
                 return actualReturnTypeName
+            case "isThrowsTypeGeneric":
+                return isThrowsTypeGeneric
             case "isDynamic":
                 return isDynamic
             case "genericRequirements":
@@ -6609,6 +6625,16 @@ import Foundation
 public final class TypeName: NSObject, SourceryModelWithoutDescription, LosslessStringConvertible, Diffable, SourceryDynamicMemberLookup {
     public subscript(dynamicMember member: String) -> Any? {
         switch member {
+            case "array":
+                return array
+            case "closure":
+                return closure
+            case "dictionary":
+                return dictionary
+            case "generic":
+                return generic
+            case "set":
+                return set
             case "tuple":
                 return tuple
             case "name":
@@ -6623,12 +6649,14 @@ public final class TypeName: NSObject, SourceryModelWithoutDescription, Lossless
                 return isProtocolComposition
             case "isVoid":
                 return isVoid
+            case "isArray":
+                return isArray
             case "isClosure":
                 return isClosure
-            case "closure":
-                return closure
-            case "set":
-                return set
+            case "isDictionary":
+                return isDictionary
+            case "isGeneric":
+                return isGeneric
             case "isSet":
                 return isSet
             default:

--- a/SourceryUtils.podspec
+++ b/SourceryUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SourceryUtils"
-  s.version      = "2.2.6"
+  s.version      = "2.2.7"
   s.summary      = "A tool that brings meta-programming to Swift, allowing you to code generate Swift code."
   s.platform     = :osx, '10.15'
 

--- a/SourceryUtils/Sources/Version.swift
+++ b/SourceryUtils/Sources/Version.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct SourceryVersion {
     public let value: String
-    public static let current = SourceryVersion(value: inUnitTests ? "Major.Minor.Patch" : "2.2.6")
+    public static let current = SourceryVersion(value: inUnitTests ? "Major.Minor.Patch" : "2.2.7")
 }
 
 #if canImport(ObjectiveC)


### PR DESCRIPTION
- Work in progress, will go live on the 14/15th of May 
- Releases Sourcery `2.2.7`.
- Reverts https://github.com/krzysztofzablocki/Sourcery/pull/1413 which caused `rake generate_internal_boilerplate_code` to fail with errors. See the PR for the details.
- Solves https://github.com/krzysztofzablocki/Sourcery/issues/1411
