### PR TITLE
Use withExtendedLifetime

### DIFF
--- a/SourceryExecutable/main.swift
+++ b/SourceryExecutable/main.swift
@@ -229,7 +229,9 @@ func runCLI() {
                 Log.info(String(format: "Processing time %.2f seconds", currentTimestamp() - start))
             } else {
                 RunLoop.current.run()
-                _ = keepAlive
+                withExtendedLifetime(keepAlive) {
+                    _ = keepAlive
+                }
             }
         } catch {
             if isDryRun {


### PR DESCRIPTION
When using Sourcery via Mint, file change watching doesn't work in my environment.  
Tested with Xcode 16.2 and Swift 6.0.3.

At least since Swift 6.0.3, it seems that "FolderWatcher.Local" is being deallocated due to optimizations in release builds.