### PR TITLE
Fix AutoMockable Generation for a couple of cases with existential any

### DIFF
--- a/Templates/Templates/AutoMockable.stencil
+++ b/Templates/Templates/AutoMockable.stencil
@@ -233,9 +233,11 @@ import {{ import }}
 {% macro existentialVariableTypeName typeName isNotAllowedToBeImplicitlyUnwrappedOptional -%}
     {%- if typeName|contains:"<" and typeName|contains:">" -%}
         {{ typeName }}
+    {%- elif typeName|contains:"[" and typeName|contains:"]" -%}
+        {{ typeName }}
     {%- elif typeName|contains:"any " and typeName|contains:"!"  -%}
         {{ typeName | replace:"any","(any" | replace:"!",")!" }}
-    {%- elif typeName|contains:"any " and typeName.isOptional  -%}
+    {%- elif typeName|contains:"any " and typeName.isOptional and not typeName|contains:"(" -%}
         {{ typeName | replace:"any","(any" | replace:"?",")?" }}
     {%- elif typeName|contains:"any " and typeName.isClosure and typeName|contains:"?" -%}
         ({{ typeName | replace:"any","(any" | replace:"?",")?" }})
@@ -262,7 +264,9 @@ import {{ import }}
             {{ typeName | replace:"inout ","" }}
         {%- endif -%}
     {% endset %}
-    {%- if typeName|contains:"any " and typeName|contains:"!" -%}
+    {%- if typeName|contains:"[" and typeName|contains:"]" -%}
+        {{ name }}
+    {%- elif typeName|contains:"any " and typeName|contains:"!" -%}
         {{ name | replace:"any","(any" | replace:"!",")?" }}
     {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
         ({{ typeName.unwrappedTypeName| replace:"inout ","" | replace:"any","(any" | replace:"?",")?" }})?
@@ -295,7 +299,9 @@ import {{ import }}
             {{ typeName | replace:"inout ","" }}
         {%- endif -%}
     {% endset %}
-    {%- if typeName|contains:"any " and typeName|contains:"!" -%}
+    {%- if typeName|contains:"[" and typeName|contains:"]" -%}
+        {{ name }}
+    {%- elif typeName|contains:"any " and typeName|contains:"!" -%}
         {{ name | replace:"any","(any" | replace:"!",")?" }}
     {%- elif typeName|contains:"any " and typeName.isOptional and typeName.isClosure -%}
         ({{ typeName.unwrappedTypeName| replace:"inout ","" | replace:"any","(any" | replace:"?",")?" }})?
@@ -316,7 +322,9 @@ import {{ import }}
     {%- endif -%}
 {%- endmacro %}
 {% macro existentialParameterTypeName typeName isVariadic -%}
-    {%- if typeName|contains:"any " and typeName|contains:"?," and typeName|contains:">?" -%}
+    {%- if typeName|contains:"[" and typeName|contains:"]" -%}
+        {{ typeName }}
+    {%- elif typeName|contains:"any " and typeName|contains:"?," and typeName|contains:">?" -%}
         {{ typeName | replace:"any","(any" | replace:"?,",")?," }}
     {%- elif typeName|contains:"any " and typeName|contains:"!" -%}
         {{ typeName | replace:"any","(any" | replace:"!",")!" }}

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -219,6 +219,19 @@ protocol AnyProtocol: AutoMockable {
     func z() -> any StubProtocol & CustomStringConvertible
 }
 
+protocol AnyProtocolWithOptionals: AutoMockable {
+    var a: [any StubProtocol]? { get }
+    var b: [Result<Void, any Error>] { get }
+    var c: (Int, [(any StubProtocol)?])? { get }
+    var d: (Int, (any StubProtocol)?) { get }
+    var e: (Int, (any StubProtocol)?)? { get }
+    var f: (Int, [any StubProtocol]?)? { get }
+    func g(_ g: String, handler: @escaping ([any StubProtocol]?) -> Void) -> Bool
+    func h(_ h: String, handler: @escaping ([StubProtocol]) -> Void) -> Bool
+    func i(_ i: String, handler: @escaping ([(any StubProtocol)?]) -> Void) -> Bool
+    var j: (anyInteger: Int, anyArray: [any StubProtocol]?)? { get }
+}
+
 protocol SomeProtocol: AutoMockable {
     func a(_ x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol)
     func b(x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol) async -> String

--- a/Templates/Tests/Context_Linux/AutoMockable.swift
+++ b/Templates/Tests/Context_Linux/AutoMockable.swift
@@ -220,6 +220,19 @@ protocol AnyProtocol: AutoMockable {
     func z() -> any StubProtocol & CustomStringConvertible
 }
 
+protocol AnyProtocolWithOptionals: AutoMockable {
+    var a: [any StubProtocol]? { get }
+    var b: [Result<Void, any Error>] { get }
+    var c: (Int, [(any StubProtocol)?])? { get }
+    var d: (Int, (any StubProtocol)?) { get }
+    var e: (Int, (any StubProtocol)?)? { get }
+    var f: (Int, [any StubProtocol]?)? { get }
+    func g(_ g: String, handler: @escaping ([any StubProtocol]?) -> Void) -> Bool
+    func h(_ h: String, handler: @escaping ([StubProtocol]) -> Void) -> Bool
+    func i(_ i: String, handler: @escaping ([(any StubProtocol)?]) -> Void) -> Bool
+    var j: (anyInteger: Int, anyArray: [any StubProtocol]?)? { get }
+}
+
 protocol SomeProtocol: AutoMockable {
     func a(_ x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol)
     func b(x: (some StubProtocol)?, y: (some StubProtocol)!, z: some StubProtocol) async -> String

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -419,6 +419,90 @@ class AnyProtocolMock: AnyProtocol {
             return zAnyStubProtocolCustomStringConvertibleClosure()
         } else {
             return zAnyStubProtocolCustomStringConvertibleReturnValue
+        }
+    }
+
+
+}
+class AnyProtocolWithOptionalsMock: AnyProtocolWithOptionals {
+
+
+    var a: [any StubProtocol]?
+    var b: [Result<Void, any Error>] = []
+    var c: (Int, [(any StubProtocol)?])?
+    var d: (Int, (any StubProtocol)?) {
+        get { return underlyingD }
+        set(value) { underlyingD = value }
+    }
+    var underlyingD: ((Int, (any StubProtocol)?))!
+    var e: (Int, (any StubProtocol)?)?
+    var f: (Int, [any StubProtocol]?)?
+    var j: (anyInteger: Int, anyArray: [any StubProtocol]?)?
+
+
+    //MARK: - g
+
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount = 0
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolCalled: Bool {
+        return gGStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount > 0
+    }
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments: (g: String, handler: ([any StubProtocol]?) -> Void)?
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations: [(g: String, handler: ([any StubProtocol]?) -> Void)] = []
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue: Bool!
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure: ((String, @escaping ([any StubProtocol]?) -> Void) -> Bool)?
+
+    func g(_ g: String, handler: @escaping ([any StubProtocol]?) -> Void) -> Bool {
+        gGStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount += 1
+        gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments = (g: g, handler: handler)
+        gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations.append((g: g, handler: handler))
+        if let gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure = gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure {
+            return gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure(g, handler)
+        } else {
+            return gGStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue
+        }
+    }
+
+    //MARK: - h
+
+    var hHStringHandlerEscapingStubProtocolVoidBoolCallsCount = 0
+    var hHStringHandlerEscapingStubProtocolVoidBoolCalled: Bool {
+        return hHStringHandlerEscapingStubProtocolVoidBoolCallsCount > 0
+    }
+    var hHStringHandlerEscapingStubProtocolVoidBoolReceivedArguments: (h: String, handler: ([StubProtocol]) -> Void)?
+    var hHStringHandlerEscapingStubProtocolVoidBoolReceivedInvocations: [(h: String, handler: ([StubProtocol]) -> Void)] = []
+    var hHStringHandlerEscapingStubProtocolVoidBoolReturnValue: Bool!
+    var hHStringHandlerEscapingStubProtocolVoidBoolClosure: ((String, @escaping ([StubProtocol]) -> Void) -> Bool)?
+
+    func h(_ h: String, handler: @escaping ([StubProtocol]) -> Void) -> Bool {
+        hHStringHandlerEscapingStubProtocolVoidBoolCallsCount += 1
+        hHStringHandlerEscapingStubProtocolVoidBoolReceivedArguments = (h: h, handler: handler)
+        hHStringHandlerEscapingStubProtocolVoidBoolReceivedInvocations.append((h: h, handler: handler))
+        if let hHStringHandlerEscapingStubProtocolVoidBoolClosure = hHStringHandlerEscapingStubProtocolVoidBoolClosure {
+            return hHStringHandlerEscapingStubProtocolVoidBoolClosure(h, handler)
+        } else {
+            return hHStringHandlerEscapingStubProtocolVoidBoolReturnValue
+        }
+    }
+
+    //MARK: - i
+
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount = 0
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolCalled: Bool {
+        return iIStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount > 0
+    }
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments: (i: String, handler: ([(any StubProtocol)?]) -> Void)?
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations: [(i: String, handler: ([(any StubProtocol)?]) -> Void)] = []
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue: Bool!
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure: ((String, @escaping ([(any StubProtocol)?]) -> Void) -> Bool)?
+
+    func i(_ i: String, handler: @escaping ([(any StubProtocol)?]) -> Void) -> Bool {
+        iIStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount += 1
+        iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments = (i: i, handler: handler)
+        iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations.append((i: i, handler: handler))
+        if let iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure = iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure {
+            return iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure(i, handler)
+        } else {
+            return iIStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue
         }
     }
 
@@ -1422,10 +1506,10 @@ public class ProtocolWithOverridesMock: ProtocolWithOverrides {
     }
     public var doSomethingDataString_IntStringVoidReceivedData: (String)?
     public var doSomethingDataString_IntStringVoidReceivedInvocations: [(String)] = []
-    public var doSomethingDataString_IntStringVoidReturnValue: ((([Int], [String]) -> Void))!
-    public var doSomethingDataString_IntStringVoidClosure: ((String) -> (([Int], [String]) -> Void))?
+    public var doSomethingDataString_IntStringVoidReturnValue: (([Int], [String]) -> Void)!
+    public var doSomethingDataString_IntStringVoidClosure: ((String) -> ([Int], [String]) -> Void)?
 
-    public func doSomething(_ data: String) -> (([Int], [String]) -> Void) {
+    public func doSomething(_ data: String) -> ([Int], [String]) -> Void {
         doSomethingDataString_IntStringVoidCallsCount += 1
         doSomethingDataString_IntStringVoidReceivedData = data
         doSomethingDataString_IntStringVoidReceivedInvocations.append(data)
@@ -1445,10 +1529,10 @@ public class ProtocolWithOverridesMock: ProtocolWithOverrides {
     }
     public var doSomethingDataString_IntAnyVoidReceivedData: (String)?
     public var doSomethingDataString_IntAnyVoidReceivedInvocations: [(String)] = []
-    public var doSomethingDataString_IntAnyVoidReturnValue: ((([Int], [Any]) -> Void))!
-    public var doSomethingDataString_IntAnyVoidClosure: ((String) throws -> (([Int], [Any]) -> Void))?
+    public var doSomethingDataString_IntAnyVoidReturnValue: (([Int], [Any]) -> Void)!
+    public var doSomethingDataString_IntAnyVoidClosure: ((String) throws -> ([Int], [Any]) -> Void)?
 
-    public func doSomething(_ data: String) throws -> (([Int], [Any]) -> Void) {
+    public func doSomething(_ data: String) throws -> ([Int], [Any]) -> Void {
         doSomethingDataString_IntAnyVoidCallsCount += 1
         doSomethingDataString_IntAnyVoidReceivedData = data
         doSomethingDataString_IntAnyVoidReceivedInvocations.append(data)

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -427,17 +427,17 @@ class AnyProtocolMock: AnyProtocol {
 class AnyProtocolWithOptionalsMock: AnyProtocolWithOptionals {
 
 
-    var a: [(any StubProtocol])?
+    var a: [any StubProtocol]?
     var b: [Result<Void, any Error>] = []
-    var c: (Int, [((any StubProtocol))?]))?
+    var c: (Int, [(any StubProtocol)?])?
     var d: (Int, (any StubProtocol)?) {
         get { return underlyingD }
         set(value) { underlyingD = value }
     }
     var underlyingD: ((Int, (any StubProtocol)?))!
-    var e: (Int, ((any StubProtocol))?))?
-    var f: (Int, [(any StubProtocol])?))?
-    var j: ((anyInteger: Int, (anyArray: [(any StubProtocol])?))?
+    var e: (Int, (any StubProtocol)?)?
+    var f: (Int, [any StubProtocol]?)?
+    var j: (anyInteger: Int, anyArray: [any StubProtocol]?)?
 
 
     //MARK: - g
@@ -446,12 +446,12 @@ class AnyProtocolWithOptionalsMock: AnyProtocolWithOptionals {
     var gGStringHandlerEscapingAnyStubProtocolVoidBoolCalled: Bool {
         return gGStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount > 0
     }
-    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments: (g: String, handler: ([(any StubProtocol])?) -> Void)?
-    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations: [(g: String, handler: ([(any StubProtocol])?) -> Void)] = []
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments: (g: String, handler: ([any StubProtocol]?) -> Void)?
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations: [(g: String, handler: ([any StubProtocol]?) -> Void)] = []
     var gGStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue: Bool!
-    var gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure: ((String, @escaping ([(any StubProtocol])?) -> Void) -> Bool)?
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure: ((String, @escaping ([any StubProtocol]?) -> Void) -> Bool)?
 
-    func g(_ g: String, handler: @escaping ([(any StubProtocol])?) -> Void) -> Bool {
+    func g(_ g: String, handler: @escaping ([any StubProtocol]?) -> Void) -> Bool {
         gGStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount += 1
         gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments = (g: g, handler: handler)
         gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations.append((g: g, handler: handler))
@@ -490,12 +490,12 @@ class AnyProtocolWithOptionalsMock: AnyProtocolWithOptionals {
     var iIStringHandlerEscapingAnyStubProtocolVoidBoolCalled: Bool {
         return iIStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount > 0
     }
-    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments: (i: String, handler: ([((any StubProtocol))?]) -> Void)?
-    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations: [(i: String, handler: ([((any StubProtocol))?]) -> Void)] = []
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments: (i: String, handler: ([(any StubProtocol)?]) -> Void)?
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations: [(i: String, handler: ([(any StubProtocol)?]) -> Void)] = []
     var iIStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue: Bool!
-    var iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure: ((String, @escaping ([((any StubProtocol))?]) -> Void) -> Bool)?
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure: ((String, @escaping ([(any StubProtocol)?]) -> Void) -> Bool)?
 
-    func i(_ i: String, handler: @escaping ([((any StubProtocol))?]) -> Void) -> Bool {
+    func i(_ i: String, handler: @escaping ([(any StubProtocol)?]) -> Void) -> Bool {
         iIStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount += 1
         iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments = (i: i, handler: handler)
         iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations.append((i: i, handler: handler))
@@ -1506,10 +1506,10 @@ public class ProtocolWithOverridesMock: ProtocolWithOverrides {
     }
     public var doSomethingDataString_IntStringVoidReceivedData: (String)?
     public var doSomethingDataString_IntStringVoidReceivedInvocations: [(String)] = []
-    public var doSomethingDataString_IntStringVoidReturnValue: ((([Int], [String]) -> Void))!
-    public var doSomethingDataString_IntStringVoidClosure: ((String) -> (([Int], [String]) -> Void))?
+    public var doSomethingDataString_IntStringVoidReturnValue: (([Int], [String]) -> Void)!
+    public var doSomethingDataString_IntStringVoidClosure: ((String) -> ([Int], [String]) -> Void)?
 
-    public func doSomething(_ data: String) -> (([Int], [String]) -> Void) {
+    public func doSomething(_ data: String) -> ([Int], [String]) -> Void {
         doSomethingDataString_IntStringVoidCallsCount += 1
         doSomethingDataString_IntStringVoidReceivedData = data
         doSomethingDataString_IntStringVoidReceivedInvocations.append(data)
@@ -1529,10 +1529,10 @@ public class ProtocolWithOverridesMock: ProtocolWithOverrides {
     }
     public var doSomethingDataString_IntAnyVoidReceivedData: (String)?
     public var doSomethingDataString_IntAnyVoidReceivedInvocations: [(String)] = []
-    public var doSomethingDataString_IntAnyVoidReturnValue: ((([Int], [Any]) -> Void))!
-    public var doSomethingDataString_IntAnyVoidClosure: ((String) throws -> (([Int], [Any]) -> Void))?
+    public var doSomethingDataString_IntAnyVoidReturnValue: (([Int], [Any]) -> Void)!
+    public var doSomethingDataString_IntAnyVoidClosure: ((String) throws -> ([Int], [Any]) -> Void)?
 
-    public func doSomething(_ data: String) throws -> (([Int], [Any]) -> Void) {
+    public func doSomething(_ data: String) throws -> ([Int], [Any]) -> Void {
         doSomethingDataString_IntAnyVoidCallsCount += 1
         doSomethingDataString_IntAnyVoidReceivedData = data
         doSomethingDataString_IntAnyVoidReceivedInvocations.append(data)

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -419,6 +419,90 @@ class AnyProtocolMock: AnyProtocol {
             return zAnyStubProtocolCustomStringConvertibleClosure()
         } else {
             return zAnyStubProtocolCustomStringConvertibleReturnValue
+        }
+    }
+
+
+}
+class AnyProtocolWithOptionalsMock: AnyProtocolWithOptionals {
+
+
+    var a: [(any StubProtocol])?
+    var b: [Result<Void, any Error>] = []
+    var c: (Int, [((any StubProtocol))?]))?
+    var d: (Int, (any StubProtocol)?) {
+        get { return underlyingD }
+        set(value) { underlyingD = value }
+    }
+    var underlyingD: ((Int, (any StubProtocol)?))!
+    var e: (Int, ((any StubProtocol))?))?
+    var f: (Int, [(any StubProtocol])?))?
+    var j: ((anyInteger: Int, (anyArray: [(any StubProtocol])?))?
+
+
+    //MARK: - g
+
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount = 0
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolCalled: Bool {
+        return gGStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount > 0
+    }
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments: (g: String, handler: ([(any StubProtocol])?) -> Void)?
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations: [(g: String, handler: ([(any StubProtocol])?) -> Void)] = []
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue: Bool!
+    var gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure: ((String, @escaping ([(any StubProtocol])?) -> Void) -> Bool)?
+
+    func g(_ g: String, handler: @escaping ([(any StubProtocol])?) -> Void) -> Bool {
+        gGStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount += 1
+        gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments = (g: g, handler: handler)
+        gGStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations.append((g: g, handler: handler))
+        if let gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure = gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure {
+            return gGStringHandlerEscapingAnyStubProtocolVoidBoolClosure(g, handler)
+        } else {
+            return gGStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue
+        }
+    }
+
+    //MARK: - h
+
+    var hHStringHandlerEscapingStubProtocolVoidBoolCallsCount = 0
+    var hHStringHandlerEscapingStubProtocolVoidBoolCalled: Bool {
+        return hHStringHandlerEscapingStubProtocolVoidBoolCallsCount > 0
+    }
+    var hHStringHandlerEscapingStubProtocolVoidBoolReceivedArguments: (h: String, handler: ([StubProtocol]) -> Void)?
+    var hHStringHandlerEscapingStubProtocolVoidBoolReceivedInvocations: [(h: String, handler: ([StubProtocol]) -> Void)] = []
+    var hHStringHandlerEscapingStubProtocolVoidBoolReturnValue: Bool!
+    var hHStringHandlerEscapingStubProtocolVoidBoolClosure: ((String, @escaping ([StubProtocol]) -> Void) -> Bool)?
+
+    func h(_ h: String, handler: @escaping ([StubProtocol]) -> Void) -> Bool {
+        hHStringHandlerEscapingStubProtocolVoidBoolCallsCount += 1
+        hHStringHandlerEscapingStubProtocolVoidBoolReceivedArguments = (h: h, handler: handler)
+        hHStringHandlerEscapingStubProtocolVoidBoolReceivedInvocations.append((h: h, handler: handler))
+        if let hHStringHandlerEscapingStubProtocolVoidBoolClosure = hHStringHandlerEscapingStubProtocolVoidBoolClosure {
+            return hHStringHandlerEscapingStubProtocolVoidBoolClosure(h, handler)
+        } else {
+            return hHStringHandlerEscapingStubProtocolVoidBoolReturnValue
+        }
+    }
+
+    //MARK: - i
+
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount = 0
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolCalled: Bool {
+        return iIStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount > 0
+    }
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments: (i: String, handler: ([((any StubProtocol))?]) -> Void)?
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations: [(i: String, handler: ([((any StubProtocol))?]) -> Void)] = []
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue: Bool!
+    var iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure: ((String, @escaping ([((any StubProtocol))?]) -> Void) -> Bool)?
+
+    func i(_ i: String, handler: @escaping ([((any StubProtocol))?]) -> Void) -> Bool {
+        iIStringHandlerEscapingAnyStubProtocolVoidBoolCallsCount += 1
+        iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedArguments = (i: i, handler: handler)
+        iIStringHandlerEscapingAnyStubProtocolVoidBoolReceivedInvocations.append((i: i, handler: handler))
+        if let iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure = iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure {
+            return iIStringHandlerEscapingAnyStubProtocolVoidBoolClosure(i, handler)
+        } else {
+            return iIStringHandlerEscapingAnyStubProtocolVoidBoolReturnValue
         }
     }
 


### PR DESCRIPTION
### Problem

Let's say we have a protocol:
```swift
protocol AnyProtocolWithOptionals: AutoMockable {
    var a: [any StubProtocol]? { get }
    var b: [Result<Void, any Error>] { get }
    var c: (Int, [(any StubProtocol)?])? { get }
    var d: (Int, (any StubProtocol)?) { get }
    var e: (Int, (any StubProtocol)?)? { get }
    var f: (Int, [any StubProtocol]?)? { get }
    func g(_ g: String, handler: @escaping ([any StubProtocol]?) -> Void) -> Bool
    func h(_ h: String, handler: @escaping ([StubProtocol]) -> Void) -> Bool
    func i(_ i: String, handler: @escaping ([(any StubProtocol)?]) -> Void) -> Bool
    var j: (anyInteger: Int, anyArray: [any StubProtocol]?)? { get }
}
```

Current implementation of `AutoMockable` stencil generates broken Swift Code - too many parentheses or they are inserted in a wrong place. The full generated code can be seen in ee823f0, here is a snippet with the issues mentioned:

```swift
class AnyProtocolWithOptionalsMock: AnyProtocolWithOptionals {


    var a: [(any StubProtocol])? // <-- should  be `[any StubProtocol]?
    var b: [Result<Void, any Error>] = [] // <-- correct
    var c: (Int, [((any StubProtocol))?]))? // <--  should be (Int, [(any StubProtocol)?])?
    var d: (Int, (any StubProtocol)?) { // <-- correct
        get { return underlyingD }
        set(value) { underlyingD = value }
    }
    var underlyingD: ((Int, (any StubProtocol)?))! // <-- correct
    var e: (Int, ((any StubProtocol))?))? // <--  should be (Int, (any StubProtocol)?)?
    var f: (Int, [(any StubProtocol])?))? // <-- should be (Int, [any StubProtocol]?)?
    var j: ((anyInteger: Int, (anyArray: [(any StubProtocol])?))? // <-- should be (anyInteger: Int, anyArray: [any StubProtocol])?)?
    ...
}
```

### Solution

Pretty (maybe too) straightforward:
* skip `any` replacement when type name contains both opening and closing brackets
* in case the type is optional, proceed with `any` replacement only if the type name doesn't contain parenthesis

Looking forward to your feedback!