### PR TITLE
Fix deadlock when using EJS templates in watch mode

### DIFF
--- a/SourceryJS/Sources/EJSTemplate+Tests.swift
+++ b/SourceryJS/Sources/EJSTemplate+Tests.swift
@@ -70,12 +70,14 @@ open class EJSTemplate {
         return Path(path)
     }()
 
+    private static let jsVm = JSVirtualMachine()
+
     public let sourcePath: Path
     public let templateString: String
     let ejs: String
 
     public private(set) lazy var jsContext: JSContext = {
-        let jsContext = JSContext()!
+        let jsContext = JSContext(virtualMachine: EJSTemplate.jsVm)!
         jsContext.setObject(self.templateString, forKeyedSubscript: "template" as NSString)
         jsContext.setObject(self.sourcePath.lastComponent, forKeyedSubscript: "templateName" as NSString)
         jsContext.setObject(self.context, forKeyedSubscript: "templateContext" as NSString)

--- a/SourceryJS/Sources/EJSTemplate.swift
+++ b/SourceryJS/Sources/EJSTemplate.swift
@@ -47,12 +47,14 @@ open class EJSTemplate {
     #endif
     public static var ejsPath: Path! = bundle.path(forResource: "ejs", ofType: "js").map({ Path($0) })
 
+    private static let jsVm = JSVirtualMachine()
+
     public let sourcePath: Path
     public let templateString: String
     let ejs: String
 
     public private(set) lazy var jsContext: JSContext = {
-        let jsContext = JSContext()!
+        let jsContext = JSContext(virtualMachine: EJSTemplate.jsVm)!
         jsContext.setObject(self.templateString, forKeyedSubscript: "template" as NSString)
         jsContext.setObject(self.sourcePath.lastComponent, forKeyedSubscript: "templateName" as NSString)
         jsContext.setObject(self.context, forKeyedSubscript: "templateContext" as NSString)


### PR DESCRIPTION
On macOS 15.4.1 if you are using EJS templates in watch mode Sourcery deadlocks after a few template changes because the of work JavaScriptCore attempts to do on the main thread when cleaning up old resources.

Since JavaScriptCore is not easily debuggable its hard to say exactly what is happening but it appears that `JSContext()!` without any parameters allocates a new JSVirtualMachine each time and when the context gets deinit'd (whenever a template changes) the JSVirtualMachine also deinit's. During that deinit it takes over the main thread and deadlocks sourcery file watchers.

This change uses dedicated VMs for the entire duration of the Sourcery process. The downside is that memory usage may go up over time in watch mode, but it wont deadlock and subsequent parsing/executing of templates may speed up as it can utilise a byte code cache etc…