### PR TITLE
Fix PBXGroup duplication while linking

### DIFF
--- a/Sourcery/Utils/Xcode+Extensions.swift
+++ b/Sourcery/Utils/Xcode+Extensions.swift
@@ -71,7 +71,7 @@ extension XcodeProj {
         // Find existing group to reuse
         // Having `ProjectRoot/Data/` exists and given group to create `ProjectRoot/Data/Generated`
         // will create `Generated` group under ProjectRoot/Data to link files to
-        let existingGroup = findGroup(in: fileGroup, components: components)
+        let existingGroup = findGroup(in: fileGroup, components: components, validate: { $0?.path == $1 || $0?.name == $1 })
 
         var groupName: String?
 
@@ -103,21 +103,11 @@ extension XcodeProj {
         }
         return fileGroup
     }
-    
+
 }
 
 private extension XcodeProj {
-    
-    func findGroup(in group: PBXGroup, components: [String]) -> (group: PBXGroup?, components: [String]) {
-        let existingGroup = findGroup(in: group, components: components, validate: { $0?.path == $1 })
-        
-        if existingGroup.group?.path != nil {
-            return existingGroup
-        }
-        
-        return findGroup(in: group, components: components, validate: { $0?.name == $1 })
-    }
-    
+
     func findGroup(in group: PBXGroup, components: [String], validate: (PBXFileElement?, String?) -> Bool) -> (group: PBXGroup?, components: [String]) {
         return components.reduce((group: group as PBXGroup?, components: components)) { current, name in
             let first = current.group?.children.first { validate($0, name) } as? PBXGroup
@@ -125,5 +115,4 @@ private extension XcodeProj {
             return (result, current.components.filter { !validate(result, $0) })
         }
     }
-    
 }


### PR DESCRIPTION
The issue was previously addressed [here](https://github.com/krzysztofzablocki/Sourcery/pull/1017). However, there we check for either the path property or name property in each individual traversal (there are two of them). This means that if we traverse only looking for the path property in a PBXGroup's child, we would inevitably create duplicate child group if that child only has the name property.

I don't see any need to traverse twice, so in this implementation, I check for both path and name in a single pass.