### PR TITLE
Magic fix with SwiftBuild on Xcode 26 Beta 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -264,7 +264,7 @@ var dependencies: [Package.Dependency] = [
 ]
 
 #if compiler(>=6.2)
-dependencies.append(.package(url: "https://github.com/swiftlang/swift-package-manager.git", revision: "5c57a39"))
+dependencies.append(.package(url: "https://github.com/swiftlang/swift-package-manager.git", revision: "3c17da7")) // release/6.2
 #else
 dependencies.append(.package(url: "https://github.com/art-divin/swift-package-manager.git", exact: "1.0.8"))
 #endif


### PR DESCRIPTION
Switched to the commit from the main branch to release/6.2

> To be honest, I’m not sure why the Swift package version affects `ProcessInfo.processInfo.environment`, but this commit appears to work and removes the SwiftBuild dependency.