### PR TITLE
Fix crash on trailing-comma generic arguments

### DIFF
--- a/SourceryFramework/Sources/Parsing/String+TypeInference.swift
+++ b/SourceryFramework/Sources/Parsing/String+TypeInference.swift
@@ -243,8 +243,9 @@ extension String {
         }
         
         let body = trimmed[trimmed.index(after: start)..<trimmed.index(before: trimmed.endIndex)]
-        return GenericType(name: String(trimmed[..<start]), typeParameters: String(body).commaSeparated().map({ value in
+        return GenericType(name: String(trimmed[..<start]), typeParameters: String(body).commaSeparated().compactMap({ value in
             let stripped = value.stripped()
+            guard !stripped.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
             return GenericTypeParameter(typeName: stripped.inferType ?? TypeName(stripped))
         }))
     }

--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/GenericType+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/GenericType+SwiftSyntax.swift
@@ -6,17 +6,21 @@ extension GenericType {
     convenience init(name: String, node: GenericArgumentClauseSyntax) {
         #if compiler(>=6.2)
         // TODO: ExprSyntax may need to be handled
-        let parameters = node.arguments.map { argument -> GenericTypeParameter? in
+        let parameters = node.arguments.compactMap { argument -> GenericTypeParameter? in
             switch argument.argument {
             case .type(let type):
-                return GenericTypeParameter(typeName: TypeName(type))
+                let typeName = TypeName(type)
+                guard !typeName.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+                return GenericTypeParameter(typeName: typeName)
             default: // case .expr
                 return nil
             }
-        }.compactMap({ $0 })
+        }
         #else
-        let parameters = node.arguments.map { argument in
-            GenericTypeParameter(typeName: TypeName(argument.argument))
+        let parameters = node.arguments.compactMap { argument -> GenericTypeParameter? in
+            let typeName = TypeName(argument.argument)
+            guard !typeName.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            return GenericTypeParameter(typeName: typeName)
         }
         #endif
 

--- a/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
@@ -551,10 +551,11 @@ internal struct ParserResultsComposed {
         let hasGenericRequirements = containingType?.genericRequirements.isEmpty == false
         || (method != nil && method?.genericRequirements.isEmpty == false)
 
-        if hasGenericRequirements {
+        if hasGenericRequirements,
+           let typeNameForLookup = typeName.name.split(separator: " ").first,
+           !typeNameForLookup.isEmpty {
             // we should consider if we are looking up return type of a method with generic constraints
             // where `typeName` passed would include `... where ...` suffix
-            let typeNameForLookup = typeName.name.split(separator: " ").first!
             let genericRequirements: [GenericRequirement]
             if let requirements = containingType?.genericRequirements, !requirements.isEmpty {
                 genericRequirements = requirements

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -2365,6 +2365,30 @@ class ParserComposerSpec: QuickSpec {
                             let parsedFoo = types.first(where: { $0.globalName == "Foo" })
                             expect(parsedFoo).to(equal(expectedBar))
                         }
+
+                        it("ignores empty generic arguments created by trailing commas") {
+                            let types = parse("""
+                                struct Example<A: RandomAccessCollection, B: RandomAccessCollection>
+                                  where A.Element == String,
+                                  B.Element == String
+                                {
+                                  let asyncTaskData: OrderedDictionary<
+                                    String,
+                                    (status: Result<Int, Error>, messages: [String]),
+                                  >
+                                }
+                                """)
+
+                            let example = types.first(where: { $0.globalName == "Example" })
+                            expect(example).toNot(beNil())
+
+                            let variable = example?.variables.first(where: { $0.name == "asyncTaskData" })
+                            let parameters = variable?.typeName.generic?.typeParameters
+
+                            expect(parameters).to(haveCount(2))
+                            expect(parameters?.first?.typeName.name).to(equal("String"))
+                            expect(parameters?.last?.typeName.name).to(equal("(status: Result<Int, Error>, messages: [String])"))
+                        }
                     }
                 }
 


### PR DESCRIPTION
### Root cause:
- A trailing comma inside a generic argument list can produce an empty generic argument, for example: 
```swift
OrderedDictionary<
  String, 
  (status: Result<Int, Error>, messages: [String]), // This is valid in Swift 6.2
>
```

### Repro script:
```bash
cat > /tmp/Repro.swift <<'SWIFT'
struct Example<A: RandomAccessCollection, B: RandomAccessCollection>
  where A.Element == String,
  B.Element == String
{
  let asyncTaskData: OrderedDictionary<
    String,
    (status: Result<Int, Error>, messages: [String]),
  >
}
SWIFT

cat > /tmp/inspect.stencil <<'STENCIL'
{% for type in types.structs %}
{% for variable in type.variables %}
{% if variable.name == "asyncTaskData" and variable.typeName.generic %}
GENERIC_COUNT={{ variable.typeName.generic.typeParameters.count }}
{% for p in variable.typeName.generic.typeParameters %}
PARAM={{ p.typeName.name }}
{% endfor %}
{% endif %}
{% endfor %}
{% endfor %}
STENCIL

# Before this fix: crashes with Trace/BPT trap.
# After this fix:
#   GENERIC_COUNT=2
#   PARAM=String
#   PARAM=(status: Result<Int, Error>, messages: [String])
sourcery --disableCache --sources /tmp/Repro.swift --templates /tmp/inspect.stencil --output /tmp/out.txt
cat /tmp/out.txt
```