### PR TITLE
Add Qlty code coverage reporting

### DIFF
--- a/.github/workflows/test_macOS.yml
+++ b/.github/workflows/test_macOS.yml
@@ -23,7 +23,19 @@ jobs:
     - name: Print Current Xcode
       run: xcode-select -p
     - uses: actions/checkout@v3
-    - name: Run tests
-      run: swift test
+    - name: Run tests with coverage
+      run: swift test --enable-code-coverage
+    - name: Generate lcov coverage report
+      run: |
+        BIN_PATH="$(swift build --show-bin-path)"
+        xcrun llvm-cov export \
+          -format=lcov \
+          -instr-profile="$BIN_PATH/codecov/default.profdata" \
+          "$BIN_PATH/SourceryPackageTests.xctest/Contents/MacOS/SourceryPackageTests" \
+          > coverage.lcov
+    - name: Upload coverage to Qlty
+      uses: qltysh/qlty-action/coverage@v2
+      with:
+        token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+        files: coverage.lcov
 
- 


### PR DESCRIPTION
## Summary
- Enables code coverage data generation in the macOS CI workflow using `swift test --enable-code-coverage`
- Exports coverage data to lcov format via `xcrun llvm-cov export`
- Uploads coverage reports to Qlty Cloud using the official `qltysh/qlty-action/coverage@v2` GitHub Action

## Manual steps required
- Add a `QLTY_COVERAGE_TOKEN` repository secret with a coverage token from Qlty Cloud (Workspace Settings > Code Coverage)

## Test plan
- [ ] Verify the `QLTY_COVERAGE_TOKEN` secret is configured in the repository
- [ ] Confirm the macOS test workflow passes with coverage generation enabled
- [ ] Check Qlty Cloud dashboard to verify coverage data was published

🤖 Generated with [Claude Code](https://claude.com/claude-code)