### PR TITLE
Fix AutoMockable mock when associated type name collides with a concrete type

### DIFF
--- a/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
+++ b/SourceryRuntime/Sources/Common/Composer/ParserResultsComposed.swift
@@ -70,6 +70,7 @@ internal struct ParserResultsComposed {
 
         /// Map associated types
         associatedTypes.forEach {
+            guard typeMap[$0.key] == nil else { return }
             if let globalName = $0.value.type?.globalName,
                let type = typeMap[globalName] {
                 typeMap[$0.key] = type

--- a/Templates/Tests/Context/AutoMockable.swift
+++ b/Templates/Tests/Context/AutoMockable.swift
@@ -349,3 +349,16 @@ protocol NotMockedSendableProtocol: Sendable {}
 protocol SendableSendableProtocol: NotMockedSendableProtocol {
   var value: Any { get }
 }
+
+// Reproduces bug: associated type name collides with a concrete struct,
+// causing the constraint protocol's variable list to be polluted via Type.extend.
+protocol CollisionHandlerProtocol {
+    associatedtype CollisionAssocType: Sendable
+}
+
+struct CollisionAssocType {
+    var collisionProp: String
+}
+
+// sourcery: AutoMockable
+protocol ProtocolWithAssociatedTypeCollision: Sendable {}

--- a/Templates/Tests/Expected/AutoMockable.expected
+++ b/Templates/Tests/Expected/AutoMockable.expected
@@ -1306,6 +1306,11 @@ class NullableClosureProtocolMock: NullableClosureProtocol {
 
 
 }
+class ProtocolWithAssociatedTypeCollisionMock: ProtocolWithAssociatedTypeCollision, @unchecked Sendable {
+
+
+
+}
 public class ProtocolWithMethodWithGenericParametersMock: ProtocolWithMethodWithGenericParameters {
 
     public init() {}

--- a/Templates/Tests/Generated/AutoMockable.generated.swift
+++ b/Templates/Tests/Generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.7 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -1303,6 +1303,13 @@ class NullableClosureProtocolMock: NullableClosureProtocol {
         setClosureClosureVoidVoidReceivedInvocations.append(closure)
         setClosureClosureVoidVoidClosure?(closure)
     }
+
+
+}
+class ProtocolWithAssociatedTypeCollisionMock: ProtocolWithAssociatedTypeCollision, @unchecked Sendable {
+
+
+
 
 
 }


### PR DESCRIPTION
Fixes #1458 

When a protocol declares a primary associated type whose name matches a concrete type in the same module, mocks for unrelated protocols could incorrectly inherit the concrete type's properties.

```
protocol Handler {
    associatedtype State: Sendable
}

struct State {
    let name: String
}

// sourcery: AutoMockable
protocol SampleProtocol: Sendable {}

// Generated (incorrectly):
class SampleProtocolMock: SampleProtocol, @unchecked Sendable {
    var name: String {
        get { return underlyingName }
        set(value) { underlyingName = value }
    }
    var underlyingName: (String)!
}
```

**Root cause**

In `ParserResultsComposed.init`, after building `typeMap` from parsed types, a second loop registers associated type names into the same map. For `associatedtype State: Sendable`, this loop unconditionally overwrote `typeMap["State"]` (which held struct `State`) with a placeholder `SourceryProtocol(name: "Sendable")`.

In `unifyTypes`, `struct State` was then found in `parsedTypes` and its "canonical" type was looked up as `typeMap["State"]` — now the placeholder. `Type.extend` was called on the placeholder with `struct State` as the argument, copying `name: String` into the placeholder's `rawVariables`. The placeholder was then stored in `typeMap` under `"Sendable"`, so any protocol conforming to `Sendable` found it via `updateTypeRelationships` and inherited those variables.

**Fix**

Skip the registration when a concrete type already occupies that key in `typeMap`:

```
associatedTypes.forEach {
    guard typeMap[$0.key] == nil else { return }
    if let globalName = $0.value.type?.globalName,
       let type = typeMap[globalName] {
        typeMap[$0.key] = type
    } else {
        typeMap[$0.key] = $0.value.type
    }
}

```

Associated type resolution in `resolveType` uses the `associatedTypes` dictionary (checked before `typeMap`), so skipping the `typeMap` registration for collision cases has no effect on the primary resolution path.