### PR TITLE
Handle non-inout Swift type specifiers

### DIFF
--- a/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
+++ b/SourceryFramework/Sources/Parsing/SwiftSyntax/AST/TypeName+SwiftSyntax.swift
@@ -201,11 +201,7 @@ extension TypeName {
 
         var isInOut = false
         if let typeIdentifier = type.as(AttributedTypeSyntax.self), let specifier = typeIdentifier.specifier {
-            if specifier.tokenKind == .keyword(.inout) {
-                isInOut = true
-            } else {
-                assertionFailure("Unhandled specifier")
-            }
+            isInOut = specifier.tokenKind == .keyword(.inout)
         }
         
         return (isInOut, false)

--- a/SourceryTests/Parsing/FileParser_MethodsSpec.swift
+++ b/SourceryTests/Parsing/FileParser_MethodsSpec.swift
@@ -38,6 +38,23 @@ class FileParserMethodsSpec: QuickSpec {
                         MethodParameter(name: "anotherSome", index: 1, typeName: TypeName(name: "inout String"), isInout: true)
                     ], returnTypeName: TypeName(name: "Void"), definedInTypeName: TypeName(name: "Foo"))))
                 }
+
+                it("extracts methods with non-inout type specifiers") {
+                    let methods = parse("""
+                    class Foo {
+                        func fooSending(extractItem: @Sendable @escaping (String) -> sending Item?)
+                        func fooIsolated(isolation: isolated (any Actor)? = #isolation)
+                        func fooConsuming(conversation: consuming Conversation)
+                    }
+                    """)[0].methods
+
+                    expect(methods.map { $0.parameters.first?.`inout` }).to(equal([false, false, false]))
+                    expect(methods.map { $0.parameters.first?.typeName.name }).to(equal([
+                        "(@Sendable @escaping (String) -> sending Item?)",
+                        "(any Actor)?",
+                        "Conversation"
+                    ]))
+                }
                 
                 it("extracts methods with inout closure") {
                     let method = parse(


### PR DESCRIPTION
## Summary
- Stop asserting when SwiftSyntax represents non-inout type specifiers on attributed types.
- Preserve existing inout detection while allowing modern Swift specifiers such as sending, isolated, and consuming.
- Add parser coverage for those specifiers.

## Validation
- env SWIFT_DISABLE_SANDBOX=1 swift test --filter SourceryLibTests.FileParserMethodsSpec/FileParser__parseMethod__extracts_methods_with_non_inout_type_specifiers (builds; Quick filter reports 0 executed examples)
- Ran local Sourcery against ../superassistant package sources: 16,592 types across 4,741 files, both template passes completed
- Compared all five generated ../superassistant outputs against checked-in files; no diffs
- git diff --check