### PR TITLE
Expose implemented types for protocol compositions

### DIFF
--- a/SourceryRuntime/Sources/Generated/JSExport.generated.swift
+++ b/SourceryRuntime/Sources/Generated/JSExport.generated.swift
@@ -43,6 +43,7 @@ import JavaScriptCore
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -141,6 +142,7 @@ extension BytesRange: BytesRangeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -244,6 +246,7 @@ extension DictionaryType: DictionaryTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -421,6 +424,7 @@ extension Modifier: ModifierAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -471,6 +475,7 @@ extension Protocol: ProtocolAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -532,6 +537,7 @@ extension SetType: SetTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -640,6 +646,7 @@ extension TupleType: TupleTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }

--- a/SourceryRuntime/Sources/Linux/AST/Type_Linux.swift
+++ b/SourceryRuntime/Sources/Linux/AST/Type_Linux.swift
@@ -336,6 +336,12 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Sou
     /// Protocols this type implements. Does not contain classes in case where composition (`&`) is used in the declaration
     public var implements = [String: Type]()
 
+    // sourcery: skipEquality, skipDescription
+    /// Protocols this type implements, sorted by name.
+    public var implementedTypes: [Type] {
+        return implements.values.sorted { $0.name < $1.name }
+    }
+
     /// Contained types
     public var containedTypes: [Type] {
         didSet {

--- a/SourceryRuntime/Sources/macOS/AST/Type.swift
+++ b/SourceryRuntime/Sources/macOS/AST/Type.swift
@@ -292,6 +292,12 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
     /// Protocols this type implements. Does not contain classes in case where composition (`&`) is used in the declaration
     public var implements: [String: Type] = [:]
 
+    // sourcery: skipEquality, skipDescription
+    /// Protocols this type implements, sorted by name.
+    public var implementedTypes: [Type] {
+        return implements.values.sorted { $0.name < $1.name }
+    }
+
     /// Contained types
     public var containedTypes: [Type] {
         didSet {

--- a/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime.content.generated.swift
@@ -2289,6 +2289,7 @@ internal struct ParserResultsComposed {
 
         /// Map associated types
         associatedTypes.forEach {
+            guard typeMap[$0.key] == nil else { return }
             if let globalName = $0.value.type?.globalName,
                let type = typeMap[globalName] {
                 typeMap[$0.key] = type
@@ -2456,8 +2457,15 @@ internal struct ParserResultsComposed {
         typealiasesByNames.forEach { _, alias in
             var aliasNamesToReplace = [alias.name]
             var finalAlias = alias
+            var visitedAliasNames = Set<String>()
+            visitedAliasNames.insert(alias.name)
             while let targetAlias = typealiasesByNames[finalAlias.typeName.name] {
+                if visitedAliasNames.contains(targetAlias.name) {
+                    Log.astWarning("Detected typealias cycle while resolving '\\(alias.name)' -> '\\(targetAlias.name)' (type name: \\(finalAlias.typeName.name)).")
+                    break
+                }
                 aliasNamesToReplace.append(targetAlias.name)
+                visitedAliasNames.insert(targetAlias.name)
                 finalAlias = targetAlias
             }
 
@@ -2763,10 +2771,11 @@ internal struct ParserResultsComposed {
         let hasGenericRequirements = containingType?.genericRequirements.isEmpty == false
         || (method != nil && method?.genericRequirements.isEmpty == false)
 
-        if hasGenericRequirements {
+        if hasGenericRequirements,
+           let typeNameForLookup = typeName.name.split(separator: " ").first,
+           !typeNameForLookup.isEmpty {
             // we should consider if we are looking up return type of a method with generic constraints
             // where `typeName` passed would include `... where ...` suffix
-            let typeNameForLookup = typeName.name.split(separator: " ").first!
             let genericRequirements: [GenericRequirement]
             if let requirements = containingType?.genericRequirements, !requirements.isEmpty {
                 genericRequirements = requirements
@@ -6411,6 +6420,12 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable {
     /// Protocols this type implements. Does not contain classes in case where composition (`&`) is used in the declaration
     public var implements: [String: Type] = [:]
 
+    // sourcery: skipEquality, skipDescription
+    /// Protocols this type implements, sorted by name.
+    public var implementedTypes: [Type] {
+        return implements.values.sorted { $0.name < $1.name }
+    }
+
     /// Contained types
     public var containedTypes: [Type] {
         didSet {
@@ -7959,6 +7974,7 @@ import JavaScriptCore
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8057,6 +8073,7 @@ extension BytesRange: BytesRangeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8160,6 +8177,7 @@ extension DictionaryType: DictionaryTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8337,6 +8355,7 @@ extension Modifier: ModifierAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8387,6 +8406,7 @@ extension Protocol: ProtocolAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8448,6 +8468,7 @@ extension SetType: SetTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8556,6 +8577,7 @@ extension TupleType: TupleTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8656,6 +8678,7 @@ extension Variable: VariableAutoJSExport {}
 
 
 #endif
+
 """),
     .init(name: "Typed.generated.swift", content:
 """

--- a/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
+++ b/SourcerySwift/Sources/SourceryRuntime_Linux.content.generated.swift
@@ -2289,6 +2289,7 @@ internal struct ParserResultsComposed {
 
         /// Map associated types
         associatedTypes.forEach {
+            guard typeMap[$0.key] == nil else { return }
             if let globalName = $0.value.type?.globalName,
                let type = typeMap[globalName] {
                 typeMap[$0.key] = type
@@ -2456,8 +2457,15 @@ internal struct ParserResultsComposed {
         typealiasesByNames.forEach { _, alias in
             var aliasNamesToReplace = [alias.name]
             var finalAlias = alias
+            var visitedAliasNames = Set<String>()
+            visitedAliasNames.insert(alias.name)
             while let targetAlias = typealiasesByNames[finalAlias.typeName.name] {
+                if visitedAliasNames.contains(targetAlias.name) {
+                    Log.astWarning("Detected typealias cycle while resolving '\\(alias.name)' -> '\\(targetAlias.name)' (type name: \\(finalAlias.typeName.name)).")
+                    break
+                }
                 aliasNamesToReplace.append(targetAlias.name)
+                visitedAliasNames.insert(targetAlias.name)
                 finalAlias = targetAlias
             }
 
@@ -2763,10 +2771,11 @@ internal struct ParserResultsComposed {
         let hasGenericRequirements = containingType?.genericRequirements.isEmpty == false
         || (method != nil && method?.genericRequirements.isEmpty == false)
 
-        if hasGenericRequirements {
+        if hasGenericRequirements,
+           let typeNameForLookup = typeName.name.split(separator: " ").first,
+           !typeNameForLookup.isEmpty {
             // we should consider if we are looking up return type of a method with generic constraints
             // where `typeName` passed would include `... where ...` suffix
-            let typeNameForLookup = typeName.name.split(separator: " ").first!
             let genericRequirements: [GenericRequirement]
             if let requirements = containingType?.genericRequirements, !requirements.isEmpty {
                 genericRequirements = requirements
@@ -7312,6 +7321,12 @@ public class Type: NSObject, SourceryModel, Annotated, Documented, Diffable, Sou
     /// Protocols this type implements. Does not contain classes in case where composition (`&`) is used in the declaration
     public var implements = [String: Type]()
 
+    // sourcery: skipEquality, skipDescription
+    /// Protocols this type implements, sorted by name.
+    public var implementedTypes: [Type] {
+        return implements.values.sorted { $0.name < $1.name }
+    }
+
     /// Contained types
     public var containedTypes: [Type] {
         didSet {
@@ -8582,6 +8597,7 @@ import JavaScriptCore
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8680,6 +8696,7 @@ extension BytesRange: BytesRangeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8783,6 +8800,7 @@ extension DictionaryType: DictionaryTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -8960,6 +8978,7 @@ extension Modifier: ModifierAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -9010,6 +9029,7 @@ extension Protocol: ProtocolAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -9071,6 +9091,7 @@ extension SetType: SetTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -9179,6 +9200,7 @@ extension TupleType: TupleTypeAutoJSExport {}
     var basedTypes: [String: Type] { get }
     var inherits: [String: Type] { get }
     var implements: [String: Type] { get }
+    var implementedTypes: [Type] { get }
     var containedTypes: [Type] { get }
     var containedType: [String: Type] { get }
     var parentName: String? { get }
@@ -9279,6 +9301,7 @@ extension Variable: VariableAutoJSExport {}
 
 
 #endif
+
 """),
     .init(name: "Typed.generated.swift", content:
 """

--- a/SourceryTests/Parsing/ComposerSpec.swift
+++ b/SourceryTests/Parsing/ComposerSpec.swift
@@ -1600,6 +1600,37 @@ class ParserComposerSpec: QuickSpec {
                             expect(type?.composedTypes?.last).to(equal(expectedProtocol2))
                         }
 
+                        it("exposes protocol composition conformances as iterable types") {
+                            let type = parse("""
+                                             struct API {}
+                                             struct Store {}
+                                             protocol APIProviding { var api: API { get } }
+                                             protocol StoreProviding { var store: Store { get } }
+                                             typealias Dependencies = APIProviding & StoreProviding
+                                             """).compactMap { $0 as? ProtocolComposition }.first
+
+                            expect(type?.implementedTypes.map(\.name)).to(equal(["APIProviding", "StoreProviding"]))
+                            expect(type?.allVariables.map(\.name)).to(equal(["api", "store"]))
+                            expect(type?.implementedTypes.first?.variables.first?.name).to(equal("api"))
+                        }
+
+                        it("exposes nested protocol composition conformances as iterable types") {
+                            let type = parse("""
+                                             struct API {}
+                                             struct Logger {}
+                                             struct Store {}
+                                             protocol APIProviding { var api: API { get } }
+                                             protocol LoggerProviding { var logger: Logger { get } }
+                                             protocol StoreProviding { var store: Store { get } }
+                                             typealias BaseDependencies = APIProviding & StoreProviding
+                                             typealias Dependencies = BaseDependencies & LoggerProviding
+                                             """).compactMap { $0 as? ProtocolComposition }.first { $0.name == "Dependencies" }
+
+                            let protocolNames = type?.implementedTypes.compactMap { $0 as? SourceryProtocol }.map(\.name)
+                            expect(protocolNames).to(equal(["APIProviding", "LoggerProviding", "StoreProviding"]))
+                            expect(type?.allVariables.map(\.name).sorted()).to(equal(["api", "logger", "store"]))
+                        }
+
                         it("should deconstruct compositions of protocols for implements") {
                             let expectedProtocol1 = Protocol(name: "Foo")
                             let expectedProtocol2 = Protocol(name: "Bar")


### PR DESCRIPTION
## Summary
- Add Type.implementedTypes as a deterministic array view over implements.
- Expose implementedTypes to JavaScript templates and refresh embedded runtime content.
- Add composer coverage showing protocol composition aliases can be iterated and inspected through their conformances.

## Validation
- env SWIFT_DISABLE_SANDBOX=1 swift test --filter SourceryLibTests.ParserComposerSpec/ParserComposer__uniqueTypesAndFunctions__given_typealiases__given_global_protocol_composition__exposes_protocol_composition_conformances_as_iterable_types (builds; Quick filter reports 0 executed examples)
- git diff --check