### PR TITLE
Fix file annotation content reuse in watch mode

### DIFF
--- a/Sourcery/Sourcery.swift
+++ b/Sourcery/Sourcery.swift
@@ -526,6 +526,7 @@ extension Sourcery {
 
         Log.info("Generating code...")
         status = ""
+        fileAnnotatedContent.removeAll()
 
         if output.isDirectory {
             try allTemplates.forEach { template in

--- a/SourceryTests/SourcerySpec.swift
+++ b/SourceryTests/SourcerySpec.swift
@@ -1183,6 +1183,27 @@ class SourcerySpecTests: QuickSpec {
                         expect(result).to(equal(expectedResult))
                     }
 
+                    it("does not reuse annotated content between generations") {
+                        let expectedResult = """
+                            // Generated using Sourcery Major.Minor.Patch — https://github.com/krzysztofzablocki/Sourcery
+                            // DO NOT EDIT
+                            extension Foo {
+                            var property = 2
+                            // Line Three
+                            }
+
+                            """
+
+                        let sourcery = Sourcery(watcherEnabled: false, cacheDisabled: true)
+                        expect { try sourcery.processFiles(.sources(Paths(include: [sourcePath])), usingTemplates: Paths(include: [templatePath]), output: output, baseIndentation: 0) }.toNot(throwError())
+                        expect { try sourcery.processFiles(.sources(Paths(include: [sourcePath])), usingTemplates: Paths(include: [templatePath]), output: output, baseIndentation: 0) }.toNot(throwError())
+
+                        let generatedPath = outputDir + Path("Generated/Foo.generated.swift")
+
+                        let result = try? generatedPath.read(.utf8)
+                        expect(result).to(equal(expectedResult))
+                    }
+
                 }
 
                 context("given a restricted file") {


### PR DESCRIPTION
Fixes #736.

## Summary
- Clear per-file annotated content at the start of each generation pass.
- Add a regression test covering repeated generation with the same `Sourcery` instance.

## Root cause
`fileAnnotatedContent` is instance state populated while processing `sourcery:file` annotations. In watch mode the same `Sourcery` instance can run generation more than once, so stale annotated content from a previous pass could be appended again.

## Validation
- `git diff --check`
- `xcrun xctest .build/arm64-apple-macosx/debug/SourceryPackageTests.xctest` (696 tests, 0 failures)